### PR TITLE
taskwarrior: add support

### DIFF
--- a/modules/taskwarrior/hm.nix
+++ b/modules/taskwarrior/hm.nix
@@ -9,7 +9,30 @@
   in lib.mkIf config.stylix.targets.taskwarrior.enable {
     programs.taskwarrior.colorTheme = "${config.xdg.configHome}/${themeDir}/${themeName}";
 
-    xdg.configFile."${themeDir}/${themeFile}".source = config.lib.stylix.colors {
+    xdg.configFile."${themeDir}/${themeFile}".source = with config.lib.stylix.colors; let
+      base00 = "rgb${scale base00-rgb-r}${scale base00-rgb-g}${scale base00-rgb-b}";
+      base01 = "rgb${scale base01-rgb-r}${scale base01-rgb-g}${scale base01-rgb-b}";
+      base02 = "rgb${scale base02-rgb-r}${scale base02-rgb-g}${scale base02-rgb-b}";
+      base03 = "rgb${scale base03-rgb-r}${scale base03-rgb-g}${scale base03-rgb-b}";
+      base04 = "rgb${scale base04-rgb-r}${scale base04-rgb-g}${scale base04-rgb-b}";
+      base05 = "rgb${scale base05-rgb-r}${scale base05-rgb-g}${scale base05-rgb-b}";
+      base06 = "rgb${scale base06-rgb-r}${scale base06-rgb-g}${scale base06-rgb-b}";
+      base07 = "rgb${scale base07-rgb-r}${scale base07-rgb-g}${scale base07-rgb-b}";
+      base08 = "rgb${scale base08-rgb-r}${scale base08-rgb-g}${scale base08-rgb-b}";
+      base09 = "rgb${scale base09-rgb-r}${scale base09-rgb-g}${scale base09-rgb-b}";
+      base0A = "rgb${scale base0A-rgb-r}${scale base0A-rgb-g}${scale base0A-rgb-b}";
+      base0B = "rgb${scale base0B-rgb-r}${scale base0B-rgb-g}${scale base0B-rgb-b}";
+      base0C = "rgb${scale base0C-rgb-r}${scale base0C-rgb-g}${scale base0C-rgb-b}";
+      base0D = "rgb${scale base0D-rgb-r}${scale base0D-rgb-g}${scale base0D-rgb-b}";
+      base0E = "rgb${scale base0E-rgb-r}${scale base0E-rgb-g}${scale base0E-rgb-b}";
+      base0F = "rgb${scale base0F-rgb-r}${scale base0F-rgb-g}${scale base0F-rgb-b}";
+
+      # Map the traditional RGB range (0--255) to Taskwarrior's RGB range
+      # (0--5).
+      scale = let
+        factor = 6.0 / 255.0;
+      in rgb: toString (builtins.floor (lib.toInt rgb * factor + 0.5));
+    in config.lib.stylix.colors {
       extension = "theme";
       template = ./template.theme.mustache;
     };

--- a/modules/taskwarrior/hm.nix
+++ b/modules/taskwarrior/hm.nix
@@ -30,13 +30,14 @@
       # Map the traditional RGB range (0--255) to Taskwarrior's RGB range
       # (0--5).
       taskwarriorRgb = let
-        convert = rgb: builtins.floor (lib.toInt rgb * factor + 0.5);
+        convert = component: toString (scale component);
         factor = 6.0 / 255.0;
+        scale = rgb: builtins.floor (lib.toInt rgb * factor + 0.5);
       in red: green: blue: let
         taskwarrior = {
-          blue = toString (convert blue);
-          green = toString (convert green);
-          red = toString (convert red);
+          blue = convert blue;
+          green = convert green;
+          red = convert red;
         };
       in "rgb${taskwarrior.red}${taskwarrior.green}${taskwarrior.blue}";
     in config.lib.stylix.colors {

--- a/modules/taskwarrior/hm.nix
+++ b/modules/taskwarrior/hm.nix
@@ -33,13 +33,7 @@
         convert = component: toString (scale component);
         factor = 6.0 / 255.0;
         scale = component: builtins.floor (lib.toInt component * factor + 0.5);
-      in red: green: blue: let
-        taskwarrior = {
-          blue = convert blue;
-          green = convert green;
-          red = convert red;
-        };
-      in "rgb${taskwarrior.red}${taskwarrior.green}${taskwarrior.blue}";
+      in red: green: blue: "rgb${convert red}${convert green}${convert blue}";
     in config.lib.stylix.colors {
       extension = "theme";
       template = ./template.theme.mustache;

--- a/modules/taskwarrior/hm.nix
+++ b/modules/taskwarrior/hm.nix
@@ -33,10 +33,12 @@
         convert = rgb: builtins.floor (lib.toInt rgb * factor + 0.5);
         factor = 6.0 / 255.0;
       in red: green: blue: let
-        taskwarriorBlue = toString (convert blue);
-        taskwarriorGreen = toString (convert green);
-        taskwarriorRed = toString (convert red);
-      in "rgb${taskwarriorRed}${taskwarriorGreen}${taskwarriorBlue}";
+        taskwarrior = {
+          blue = toString (convert blue);
+          green = toString (convert green);
+          red = toString (convert red);
+        };
+      in "rgb${taskwarrior.red}${taskwarrior.green}${taskwarrior.blue}";
     in config.lib.stylix.colors {
       extension = "theme";
       template = ./template.theme.mustache;

--- a/modules/taskwarrior/hm.nix
+++ b/modules/taskwarrior/hm.nix
@@ -10,28 +10,33 @@
     programs.taskwarrior.colorTheme = "${config.xdg.configHome}/${themeDir}/${themeName}";
 
     xdg.configFile."${themeDir}/${themeFile}".source = with config.lib.stylix.colors; let
-      base00 = "rgb${scale base00-rgb-r}${scale base00-rgb-g}${scale base00-rgb-b}";
-      base01 = "rgb${scale base01-rgb-r}${scale base01-rgb-g}${scale base01-rgb-b}";
-      base02 = "rgb${scale base02-rgb-r}${scale base02-rgb-g}${scale base02-rgb-b}";
-      base03 = "rgb${scale base03-rgb-r}${scale base03-rgb-g}${scale base03-rgb-b}";
-      base04 = "rgb${scale base04-rgb-r}${scale base04-rgb-g}${scale base04-rgb-b}";
-      base05 = "rgb${scale base05-rgb-r}${scale base05-rgb-g}${scale base05-rgb-b}";
-      base06 = "rgb${scale base06-rgb-r}${scale base06-rgb-g}${scale base06-rgb-b}";
-      base07 = "rgb${scale base07-rgb-r}${scale base07-rgb-g}${scale base07-rgb-b}";
-      base08 = "rgb${scale base08-rgb-r}${scale base08-rgb-g}${scale base08-rgb-b}";
-      base09 = "rgb${scale base09-rgb-r}${scale base09-rgb-g}${scale base09-rgb-b}";
-      base0A = "rgb${scale base0A-rgb-r}${scale base0A-rgb-g}${scale base0A-rgb-b}";
-      base0B = "rgb${scale base0B-rgb-r}${scale base0B-rgb-g}${scale base0B-rgb-b}";
-      base0C = "rgb${scale base0C-rgb-r}${scale base0C-rgb-g}${scale base0C-rgb-b}";
-      base0D = "rgb${scale base0D-rgb-r}${scale base0D-rgb-g}${scale base0D-rgb-b}";
-      base0E = "rgb${scale base0E-rgb-r}${scale base0E-rgb-g}${scale base0E-rgb-b}";
-      base0F = "rgb${scale base0F-rgb-r}${scale base0F-rgb-g}${scale base0F-rgb-b}";
+      base00 = taskwarriorRgb base00-rgb-r base00-rgb-g base00-rgb-b;
+      base01 = taskwarriorRgb base01-rgb-r base01-rgb-g base01-rgb-b;
+      base02 = taskwarriorRgb base02-rgb-r base02-rgb-g base02-rgb-b;
+      base03 = taskwarriorRgb base03-rgb-r base03-rgb-g base03-rgb-b;
+      base04 = taskwarriorRgb base04-rgb-r base04-rgb-g base04-rgb-b;
+      base05 = taskwarriorRgb base05-rgb-r base05-rgb-g base05-rgb-b;
+      base06 = taskwarriorRgb base06-rgb-r base06-rgb-g base06-rgb-b;
+      base07 = taskwarriorRgb base07-rgb-r base07-rgb-g base07-rgb-b;
+      base08 = taskwarriorRgb base08-rgb-r base08-rgb-g base08-rgb-b;
+      base09 = taskwarriorRgb base09-rgb-r base09-rgb-g base09-rgb-b;
+      base0A = taskwarriorRgb base0A-rgb-r base0A-rgb-g base0A-rgb-b;
+      base0B = taskwarriorRgb base0B-rgb-r base0B-rgb-g base0B-rgb-b;
+      base0C = taskwarriorRgb base0C-rgb-r base0C-rgb-g base0C-rgb-b;
+      base0D = taskwarriorRgb base0D-rgb-r base0D-rgb-g base0D-rgb-b;
+      base0E = taskwarriorRgb base0E-rgb-r base0E-rgb-g base0E-rgb-b;
+      base0F = taskwarriorRgb base0F-rgb-r base0F-rgb-g base0F-rgb-b;
 
       # Map the traditional RGB range (0--255) to Taskwarrior's RGB range
       # (0--5).
-      scale = let
+      taskwarriorRgb = let
+        convert = rgb: builtins.floor (lib.toInt rgb * factor + 0.5);
         factor = 6.0 / 255.0;
-      in rgb: toString (builtins.floor (lib.toInt rgb * factor + 0.5));
+      in red: green: blue: let
+        taskwarriorBlue = toString (convert blue);
+        taskwarriorGreen = toString (convert green);
+        taskwarriorRed = toString (convert red);
+      in "rgb${taskwarriorRed}${taskwarriorGreen}${taskwarriorBlue}";
     in config.lib.stylix.colors {
       extension = "theme";
       template = ./template.theme.mustache;

--- a/modules/taskwarrior/hm.nix
+++ b/modules/taskwarrior/hm.nix
@@ -32,7 +32,7 @@
       taskwarriorRgb = let
         convert = component: toString (scale component);
         factor = 6.0 / 255.0;
-        scale = rgb: builtins.floor (lib.toInt rgb * factor + 0.5);
+        scale = component: builtins.floor (lib.toInt component * factor + 0.5);
       in red: green: blue: let
         taskwarrior = {
           blue = convert blue;

--- a/modules/taskwarrior/hm.nix
+++ b/modules/taskwarrior/hm.nix
@@ -1,0 +1,17 @@
+{config, lib, ...}: {
+  options.stylix.targets.taskwarrior.enable =
+    config.lib.stylix.mkEnableTarget "Taskwarrior" true;
+
+  config = let
+    themeDir = "task";
+    themeFile = "${themeName}.theme";
+    themeName = "base16";
+  in lib.mkIf config.stylix.targets.taskwarrior.enable {
+    programs.taskwarrior.colorTheme = "${config.xdg.configHome}/${themeDir}/${themeName}";
+
+    xdg.configFile."${themeDir}/${themeFile}".source = config.lib.stylix.colors {
+      extension = "theme";
+      template = ./template.theme.mustache;
+    };
+  };
+}

--- a/modules/taskwarrior/template.theme.mustache
+++ b/modules/taskwarrior/template.theme.mustache
@@ -1,0 +1,71 @@
+rule.precedence.color=deleted,completed,active,keyword.,tag.,project.,overdue,scheduled,due.today,due,blocked,blocking,recurring,tagged,uda.
+
+# General decoration
+color.label=
+color.label.sort=
+color.alternate=on gray2
+color.header=rgb031
+color.footnote=rgb031
+color.warning=black on yellow
+color.error=white on red
+color.debug=blue
+
+# Task state
+color.completed=
+color.deleted=
+color.active=rgb451 on rgb320
+color.recurring=rgb343
+color.scheduled=black on rgb441
+color.until=
+color.blocked=white on rgb110
+color.blocking=white on rgb220
+
+# Project
+color.project.none=
+
+# Priority
+color.uda.priority.H=rgb450
+color.uda.priority.M=rgb030
+color.uda.priority.L=rgb010
+
+# Tags
+color.tag.next=
+color.tag.none=
+color.tagged=
+
+# Due
+color.due=rgb440
+color.due.today=rgb430
+color.overdue=rgb420
+
+# Report: burndown
+color.burndown.pending=on rgb110
+color.burndown.started=on rgb430
+color.burndown.done=on gray4
+
+# Report: history
+color.history.add=color0 on rgb110
+color.history.done=color0 on rgb430
+color.history.delete=white on gray4
+
+# Report: summary
+color.summary.bar=white on rgb330
+color.summary.background=white on rgb110
+
+# Command: calendar
+color.calendar.due=color0 on rgb440
+color.calendar.due.today=color0 on rgb430
+color.calendar.holiday=rgb151 on rgb020
+color.calendar.overdue=color0 on rgb420
+color.calendar.today=color15 on rgb110
+color.calendar.weekend=on color235
+color.calendar.weeknumber=rgb110
+
+# Command: sync
+color.sync.added=gray4
+color.sync.changed=rgb430
+color.sync.rejected=rgb110
+
+# Command: undo
+color.undo.before=rgb021
+color.undo.after=rgb042


### PR DESCRIPTION
This module themes the [Taskwarrior](https://taskwarrior.org) ([`programs.taskwarrior.enable`](https://nix-community.github.io/home-manager/options.xhtml#opt-programs.taskwarrior.enable)) Home Manager package.

However, I am unsure how to properly interpolate the Stylix colors into the current draft theme at `modules/taskwarrior/template.theme.mustache`. I am unsure whether `{{base00-hex}}` or `{{base00-rgb-r}}` are appropriate in this case: https://www.systutorials.com/docs/linux/man/5-task-color.

Once this PR merges, we could try to patch the theme upstream, and then remove it from this repo in a follow up PR.

Note that the current state properly applies the (non-Stylix) colors in my Home Manager setup.
