### PR TITLE
treewide: swatch proposal

### DIFF
--- a/stylix/darwin/default.nix
+++ b/stylix/darwin/default.nix
@@ -11,6 +11,7 @@ in {
     ../target.nix
     ./fonts.nix
     (import ./palette.nix { inherit palette-generator base16; })
+    (import ../swatches.nix { inherit base16; })
     (import ../templates.nix inputs)
   ] ++ autoload;
 

--- a/stylix/hm/default.nix
+++ b/stylix/hm/default.nix
@@ -12,6 +12,7 @@ in {
     ./cursor.nix
     ./fonts.nix
     (import ./palette.nix { inherit palette-generator base16; })
+    (import ../swatches.nix { inherit base16; })
     (import ../templates.nix inputs)
   ] ++ autoload;
 }

--- a/stylix/nixos/default.nix
+++ b/stylix/nixos/default.nix
@@ -10,6 +10,7 @@ in {
     ../pixel.nix
     ../target.nix
     ../opacity.nix
+    ../swatches.nix
     ./cursor.nix
     ./fonts.nix
     (import ./palette.nix { inherit palette-generator base16; })

--- a/stylix/nixos/default.nix
+++ b/stylix/nixos/default.nix
@@ -10,10 +10,10 @@ in {
     ../pixel.nix
     ../target.nix
     ../opacity.nix
-    ../swatches.nix
     ./cursor.nix
     ./fonts.nix
     (import ./palette.nix { inherit palette-generator base16; })
+    (import ../swatches.nix { inherit base16; })
     (import ../templates.nix inputs)
   ] ++ autoload;
 

--- a/stylix/swatches.nix
+++ b/stylix/swatches.nix
@@ -191,7 +191,7 @@ let
       override.${name} args
     else
       import genFile args
-  ) swatchGenerators) // colors;
+  ) swatchGenerators) // { inherit colors; };
 
 in {
   config = {

--- a/stylix/swatches.nix
+++ b/stylix/swatches.nix
@@ -1,0 +1,206 @@
+{ config, lib, ... }:
+
+let
+  inherit (lib) findFirst foldl' genAttrs hasSuffix last mkOption pipe removeSuffix toUpper splitString stringToCharacters;
+  inherit (lib.types) submodule attrsOf;
+  inherit (lib.types.ints) u8;
+  inherit (builtins) attrNames elem elemAt filter hasAttr head listToAttrs mapAttrs substring stringLength;
+  hex01 = {
+    "0" = 0;
+    "1" = 1;
+    "2" = 2;
+    "3" = 3;
+    "4" = 4;
+    "5" = 5;
+    "6" = 6;
+    "7" = 7;
+    "8" = 8;
+    "9" = 9;
+    "a" = 10;
+    "b" = 11;
+    "c" = 12;
+    "d" = 13;
+    "e" = 14;
+    "f" = 15;
+    "A" = 10;
+    "B" = 11;
+    "C" = 12;
+    "D" = 13;
+    "E" = 14;
+    "F" = 15;
+  };
+  hex10 = {
+    "0" = 0;
+    "1" = 16;
+    "2" = 32;
+    "3" = 48;
+    "4" = 64;
+    "5" = 80;
+    "6" = 96;
+    "7" = 112;
+    "8" = 128;
+    "9" = 144;
+    "a" = 160;
+    "b" = 176;
+    "c" = 192;
+    "d" = 208;
+    "e" = 224;
+    "f" = 240;
+    "A" = 160;
+    "B" = 176;
+    "C" = 192;
+    "D" = 208;
+    "E" = 224;
+    "F" = 240;
+  };
+
+  hexToRgb = str: pipe str [
+    (str: stringToCharacters str)
+    (chars: {
+      r = hex10.${elemAt chars 0} + hex01.${elemAt chars 1};
+      g = hex10.${elemAt chars 2} + hex01.${elemAt chars 3};
+      b = hex10.${elemAt chars 4} + hex01.${elemAt chars 5};
+    })
+  ];
+
+  getSwatchName = path:
+    pipe path [
+      (toString)
+      (removeSuffix ".nix")
+      (splitString "/")
+      (last)
+      (splitString "-")
+      (strs: foldl' (acc: str:
+        acc + (if str != (head strs) then
+          (toUpper (substring 0 1 str)) + (substring 1 (stringLength str) str)
+          else str))
+        "" strs)
+    ];
+
+  findSwatchFiles = (filter (hasSuffix ".nix") (lib.filesystem.listFilesRecursive ../swatches));
+
+  colorSubmodule = {
+    options = {
+      r = mkOption {
+        type = u8;
+      };
+      g = mkOption {
+        type = u8;
+      };
+      b = mkOption {
+        type = u8;
+      };
+    };
+  };
+
+  swatchSubmodule = {
+    options = {
+      fg = mkOption {
+        type = submodule colorSubmodule;
+      };
+      bg = mkOption {
+        type = submodule colorSubmodule;
+      };
+      ol = mkOption {
+        type = submodule colorSubmodule;
+      };
+    };
+  };
+
+  wrappedColor = color: rec {
+    inherit (color) r g b;
+    asRgbDec = "rgb(${toString r}, ${toString g}, ${toString b})";
+    asRgbaDec = alphaDec: "rgba(${toString r}, ${toString g}, ${toString b}, ${toString alphaDec})";
+    asHex = "${lib.toHexString r}${lib.toHexString g}${lib.toHexString b}";
+    asHexWithHash = "#${asHex}";
+    asHexAlpha = alphaHex: "${asHex}${alphaHex}";
+    asHexAlphaWithHash = alphaHex: "#${asHex}${alphaHex}";
+    asDecInt = r * 256 + g * 16 + b;
+    asDecIntAlpha = decAlpha: asDecInt * 16 + decAlpha;
+    newFactored = factor: wrappedColor {
+      r = r * factor;
+      g = g * factor;
+      b = b * factor;
+    };
+    newBlended = toBlend: wrappedColor {
+      r = ((r + toBlend.r) / 2);
+      g = ((g + toBlend.g) / 2);
+      b = ((b + toBlend.b) / 2);
+    };
+  };
+
+  wrappedSwatch = swatch: let
+    wrapped = hasAttr "asHex" swatch.fg;
+  in rec {
+    fg = if wrapped then swatch.fg else wrappedColor swatch.fg;
+    bg = if wrapped then swatch.bg else wrappedColor swatch.bg;
+    ol = if wrapped then swatch.ol else wrappedColor swatch.ol;
+    newFactored = factor: wrappedSwatch {
+      fg = fg.newFactored factor;
+      bg = bg.newFactored factor;
+      ol = ol.newFactored factor;
+    };
+    newBlended = color: wrappedSwatch {
+      fg = fg.newBlended color;
+      bg = bg.newBlended color;
+      ol = ol.newBlended color;
+    };
+  };
+
+  swatchGenerators = listToAttrs (map (swatchFile: {
+    name = getSwatchName swatchFile;
+    value = colors: import swatchFile {
+      inherit colors lib config;
+      inherit (config.stylix) polarity;
+      mkSwatch = fg: bg: ol: { inherit fg bg ol; };
+    };
+  } ) findSwatchFiles);
+
+  getSwatches = targetOrder: let
+    foundTarget = findFirst (check: elem check (attrNames config.stylix.swatches)) "default" targetOrder;
+  in genAttrs (attrNames swatchGenerators) (name:
+    wrappedSwatch (config.stylix.swatches.${foundTarget}.${name})
+  );
+  
+  convertBase16ToWrappedColors = base16Attrs: {
+    base00 = hexToRgb base16Attrs.base00;
+    base01 = hexToRgb base16Attrs.base01;
+    base02 = hexToRgb base16Attrs.base02;
+    base03 = hexToRgb base16Attrs.base03;
+    base04 = hexToRgb base16Attrs.base04;
+    base05 = hexToRgb base16Attrs.base05;
+    base06 = hexToRgb base16Attrs.base06;
+    base07 = hexToRgb base16Attrs.base07;
+    base08 = hexToRgb base16Attrs.base08;
+    base09 = hexToRgb base16Attrs.base09;
+    base0A = hexToRgb base16Attrs.base0A;
+    base0B = hexToRgb base16Attrs.base0B;
+    base0C = hexToRgb base16Attrs.base0C;
+    base0D = hexToRgb base16Attrs.base0D;
+    base0E = hexToRgb base16Attrs.base0E;
+    base0F = hexToRgb base16Attrs.base0F;
+  };
+  
+  genSwatches = colors: mapAttrs (name: generator:
+    generator colors
+  ) swatchGenerators;
+  
+  genSwatchesFromBase16Attrs = colors: genSwatches (convertBase16ToWrappedColors colors);
+in {
+  config = {
+    lib.stylix = {
+        inherit swatchGenerators hexToRgb getSwatches genSwatches genSwatchesFromBase16Attrs;
+    };
+    stylix.swatches.default = (genSwatchesFromBase16Attrs (config.lib.stylix.colors));
+  };
+
+  options.stylix = {
+    swatches = mkOption {
+      type = attrsOf (submodule {
+        options = genAttrs (attrNames swatchGenerators) (name: mkOption {
+          type = submodule swatchSubmodule;
+        });
+      });
+    };
+  };
+}

--- a/stylix/swatches.nix
+++ b/stylix/swatches.nix
@@ -109,44 +109,44 @@ let
   blendFactor = config.stylix.blendFactor;
 
   wrappedColor = color: rec {
-    inherit (color) r g b;
-    asRgbDec = "rgb(${toString r}, ${toString g}, ${toString b})";
-    asRgbaDec = alphaDec: "rgba(${toString r}, ${toString g}, ${toString b}, ${toString alphaDec})";
-    asHex = "${to2HexStr r}${to2HexStr g}${to2HexStr b}";
+    inherit (color) red blue green;
+    asRgbDec = "rgb(${toString red}, ${toString green}, ${toString blue})";
+    asRgbaDec = alphaDec: "rgba(${toString red}, ${toString green}, ${toString blue}, ${toString alphaDec})";
+    asHex = "${to2HexStr red}${to2HexStr green}${to2HexStr blue}";
     asHexWithHash = "#${asHex}";
     asHexAlpha = alphaHex: "${asHex}${alphaHex}";
     asHexAlphaWithHash = alphaHex: "#${asHex}${alphaHex}";
-    asDecInt = r * 256 + g * 16 + b;
+    asDecInt = red * 256 + green * 16 + blue;
     asDecIntAlpha = decAlpha: asDecInt * 16 + decAlpha;
     newFactored = factor: wrappedColor {
-      r = constrainU8 (r * factor);
-      g = constrainU8 (g * factor);
-      b = constrainU8 (b * factor);
+      red = constrainU8 (red * factor);
+      green = constrainU8 (green * factor);
+      blue = constrainU8 (blue * factor);
     };
     newBlended = toBlend: wrappedColor {
-      r = constrainU8 ((r + toBlend.r) / 2);
-      g = constrainU8 ((g + toBlend.g) / 2);
-      b = constrainU8 ((b + toBlend.b) / 2);
+      red = constrainU8 ((red + toBlend.r) / 2);
+      green = constrainU8 ((green + toBlend.g) / 2);
+      blue = constrainU8 ((blue + toBlend.b) / 2);
     };
     newBrighter = newFactored (blendFactor + 1.0);
     newDarker = newFactored blendFactor;
   };
 
   wrappedSwatch = swatch: let
-    wrapped = hasAttr "asHex" swatch.fg;
+    wrapped = hasAttr "asHex" swatch.foreground;
   in rec {
-    fg = if wrapped then swatch.fg else wrappedColor swatch.fg;
-    bg = if wrapped then swatch.bg else wrappedColor swatch.bg;
-    ol = if wrapped then swatch.ol else wrappedColor swatch.ol;
+    foreground = if wrapped then swatch.foreground else wrappedColor swatch.foreground;
+    background = if wrapped then swatch.background else wrappedColor swatch.background;
+    outline = if wrapped then swatch.outline else wrappedColor swatch.outline;
     newFactored = factor: wrappedSwatch {
-      fg = fg.newFactored factor;
-      bg = bg.newFactored factor;
-      ol = ol.newFactored factor;
+      foreground = foreground.newFactored factor;
+      background = background.newFactored factor;
+      outline = outline.newFactored factor;
     };
     newBlended = color: wrappedSwatch {
-      fg = fg.newBlended color;
-      bg = bg.newBlended color;
-      ol = ol.newBlended color;
+      foreground = foreground.newBlended color;
+      background = background.newBlended color;
+      outline = outline.newBlended color;
     };
     newBrighter = color: newFactored (blendFactor + 1.0);
     newDarker = color: newFactored blendFactor;

--- a/swatches/tab-active-hovered.nix
+++ b/swatches/tab-active-hovered.nix
@@ -1,0 +1,1 @@
+{ colors, mkSwatch, ... }: with colors; mkSwatch base00 base05 base03

--- a/swatches/tab-active-unhovered.nix
+++ b/swatches/tab-active-unhovered.nix
@@ -1,0 +1,1 @@
+{ colors, mkSwatch, ... }: with colors; mkSwatch base05 base03 base02


### PR DESCRIPTION
## TLDR: Color swatch (highlight group) replacement for base16 calls
This is a proposal to supersede the current base## model with a swatch model inspired by vim highlight group as I mentioned in #249. I'm not attached to any changes here and this is 100% geared towards improving both end user ergonomics and  general devex so any and all feed back is welcome. This also is currently built so that no breaking changes happen, which means each module can be migrated in separate PRs, and end users will not need to change their configurations.
### Addresses Issues
- #207 
- #208 
- #205 

### Todos for this PR
- [x] investigate home-manager/darwin impl
- [x] user facing option to adjust the % factor used in blending
- [ ] factor based color blending
- [x] add a lib function to load colors directly from base16 packages
- [ ] swatch implementations 
- [ ] more color conversion functions
- [x] user facing base16scheme -> swatch conversion
- [x] additional end user facing functionality to help with manipulating swatches
- [ ] feed blending functions into the swatch generators as well
- [ ] expand overrides so that they are applied to 'lower' prio schemes when no base16scheme is supplied
- [ ] documentation (lucky last)
### Discussion topics
1. use this pr's sweeping changes to address #248, the option's base implementation is trivial, and we could just require they get implemented in the migration PRs
2. base24 implementation (addresses #252)
3. verbose color handles vs shorthand (eg 'outline' vs 'ol' and 'red' vs 'r')
4. specialized 'pure' color swatches (eg red blue etc)
5. additional swatch components (more than fg bg ol)
6. should colors remain unconverted as hex strings as a base line
7. potential #210 support, could list which swatches a given module uses
8. swatch naming conventions

### Drawbacks/Concerns
- Across the board it's going to be encroaching on java's level of verbosity vs the usual with colors; methodology
- Pretty certain it'll be slightly heavier on processing time and memory footprint. I tried to write it so much of it will be nooped away by nix's laziness but the options system and wrapping has me concerned that wrapping calls won't benefit from the usual memoization between modules. Compared to compiling something that's not in the cache it'll be peanuts but It's worth mentioning/discussing.

# Swatches
Swatches are a selection of 3 color components that correspond to the foreground, background, and outline colors of specific UI elements. This means that there will be separate swatches for different elements and their states, such as ButtonActivehovered, ButtonInactiveUnhovered, etc. By breaking these into their own components, it makes it both easier for developers to follow the style guide, and for end users to override particular elements.

This currently works off a set of .nix files in the new swatches directory. Each file returns a generator that creates a swatch from the base16 color space. These modules also generate options submodules that can be overriden by end users. This individual file approach was selected to reduce merge clashes on changes to and new implementations of swatches.

```Nix
#swatches/tab-active-hovered.nix
{ colors, mkSwatch, ... }: with colors; mkSwatch base00 base05 base03
```
This swatch file example is currently fed a set of colors corresponding to the base16 colors converted to u8 rgb ints, pkgs.lib, and a mkSwatch function for convenience. They return a set consisting of fg bg and ol attrs. Each of these components have r g b u8 ints. 

Currently the swatch names are derived from the file names, where the files are in kebab case and the names used in stylix are camel case. This is due to the way their loading is structured, their names are used to construct the stylix's options, which needs to happen before they can be imported.

# Usage
Redone, see below comment for details
_**NOTE: the pr's example colors and assignments are made up. I did not rtfm for them.**_ 