### PR TITLE
adwaita-icon-theme: recolor folder icons

### DIFF
--- a/modules/adwaita-icon-theme/nixos.nix
+++ b/modules/adwaita-icon-theme/nixos.nix
@@ -1,0 +1,31 @@
+{ config, lib, ... }:
+
+{
+  options.stylix.targets.adwaita-icon-theme.enable =
+    config.lib.stylix.mkEnableTarget "Adwaita icon theme" true;
+
+  config.nixpkgs.overlays = lib.mkIf config.stylix.targets.adwaita-icon-theme.enable [
+    (self: super: {
+      gnome = super.gnome.overrideScope (gnomeSelf: gnomeSuper: {
+        adwaita-icon-theme = gnomeSuper.adwaita-icon-theme.overrideAttrs (oldAttrs: {
+          # 428be2 can be removed when the following commit is released:
+          # https://github.com/GNOME/adwaita-icon-theme/commit/4533eff4a4800b84ad0a0d2d253d60e2fe9215f7
+
+          postPatch =
+            (oldAttrs.postPatch or "") +
+            (with config.lib.stylix.colors; ''
+              find . -name '*.svg' | while read -r file; do
+                substituteInPlace "$file" \
+                  --replace '#428be2' '#${base01}' \
+                  --replace '#438de6' '#${base01}' \
+                  --replace '#a4caee' '#${base02}' \
+                  --replace '#afd4ff' '#00000000' \
+                  --replace '#62a0ea' '#00000000' \
+                  --replace '#c0d5ea' '#00000000'
+              done
+            '');
+        });
+      });
+    })
+  ];
+}


### PR DESCRIPTION
![Screenshot of Nautilus](https://github.com/danth/stylix/assets/28959268/8a3c6156-103c-4638-b1b4-884ff2b3b2e4)

Issues:

- `base02` and `base01` are used since this needs two shades of the same color. It should really be using `base0D` since the original icons were blue, but then we don't have a lighter shade for the icon and the tab at the top.
- This causes every package related to GNOME to be compiled from source. It's possible to work around this by placing the icon theme directly into `environment.systemPackages` with `meta.priority` set to override the original scheme. However, this is difficult to implement in Stylix since doing that would install the icon theme when it's not needed.