### PR TITLE
gpg-agent: init

### DIFF
--- a/modules/gpg-agent/hm.nix
+++ b/modules/gpg-agent/hm.nix
@@ -1,0 +1,15 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+{
+  options.stylix.targets.gpg-agent.enable =
+    config.lib.stylix.mkEnableTarget "gpg-agent" true;
+
+  config = lib.mkIf (
+    config.stylix.enable && config.stylix.targets.gpg-agent.enable
+  ) { services.gpg-agent.pinentryPackage = pkgs.pinentry-qt; };
+}


### PR DESCRIPTION
```
With commit b7f50a56c3cc ("qt: add flexible theming with sensible
defaults (#780)"), the Qt pinentry package is a reasonable default
value:

> NixOS stopped building gtk2 pinentry by default in
> https://github.com/NixOS/nixpkgs/pull/270266 and there does not appear
> to be a reasonable other default.
>
> -- home-manager, "gpg-agent: don't set a default for pinentry",
>    https://github.com/nix-community/home-manager/commit/458544594ba7f0333cf5718045ee7a8eaf5de433

Closes: https://github.com/danth/stylix/issues/184
```
