### PR TITLE
firefox, zen-browser: add darkReader option

### DIFF
--- a/modules/firefox/dark-reader.nix
+++ b/modules/firefox/dark-reader.nix
@@ -1,0 +1,47 @@
+# NOTE: also used by /modules/zen-browser
+{
+  name,
+  pkgs,
+  lib,
+}:
+[
+  (
+    { cfg, inputs }:
+    let
+      inherit (pkgs.stdenv.hostPlatform) system;
+      inherit (inputs.nur.legacyPackages.${system}.repos.rycee) firefox-addons;
+    in
+    lib.mkIf cfg.darkReader.enable {
+      programs.${name}.profiles = lib.genAttrs cfg.profileNames (_: {
+        extensions.packages = [ firefox-addons.darkreader ];
+      });
+    }
+  )
+  (
+    { cfg, colors }:
+    lib.mkIf cfg.darkReader.enable {
+      programs.${name}.profiles = lib.genAttrs cfg.profileNames (_: {
+        extensions = {
+          settings."addon@darkreader.org".settings.theme = with colors.withHashtag; {
+            lightSchemeBackgroundColor = base00;
+            darkSchemeBackgroundColor = base00;
+            lightSchemeTextColor = base05;
+            darkSchemeTextColor = base05;
+            selectionColor = base0D;
+          };
+        };
+      });
+    }
+  )
+  (
+    { cfg, fonts }:
+    lib.mkIf cfg.darkReader.enable {
+      programs.${name}.profiles = lib.genAttrs cfg.profileNames (_: {
+        extensions = {
+          settings."addon@darkreader.org".settings.theme.fontFamily =
+            fonts.sansSerif.name;
+        };
+      });
+    }
+  )
+]

--- a/modules/firefox/each-config.nix
+++ b/modules/firefox/each-config.nix
@@ -24,6 +24,8 @@ mkTarget {
     colorTheme.enable = lib.mkEnableOption "[Firefox Color](https://color.firefox.com) on ${humanName}";
 
     firefoxGnomeTheme.enable = lib.mkEnableOption "[Firefox GNOME theme](https://github.com/rafaelmardojai/firefox-gnome-theme) on ${humanName}";
+
+    darkReader.enable = lib.mkEnableOption "[Dark Reader](https://darkreader.org/) theming on ${humanName}";
   };
 
   config = [
@@ -159,5 +161,6 @@ mkTarget {
         );
       }
     )
-  ];
+  ]
+  ++ import ./dark-reader.nix { inherit name pkgs lib; };
 }

--- a/modules/firefox/testbeds/firefox-dark-reader.nix
+++ b/modules/firefox/testbeds/firefox-dark-reader.nix
@@ -1,0 +1,9 @@
+{ lib, ... }:
+{
+  imports = [ ./firefox.nix ];
+
+  home-manager.sharedModules = lib.singleton {
+    stylix.targets.firefox.darkReader.enable = true;
+    programs.firefox.profiles.stylix.extensions.force = true;
+  };
+}

--- a/modules/zen-browser/hm.nix
+++ b/modules/zen-browser/hm.nix
@@ -1,6 +1,7 @@
 {
   mkTarget,
   lib,
+  pkgs,
   config,
   options,
   ...
@@ -20,48 +21,56 @@ mkTarget {
       default = true;
       description = "enables userChrome and userContent css styles for the browser";
     };
+
+    darkReader.enable = lib.mkEnableOption "[Dark Reader](https://darkreader.org/) theming";
   };
 
-  config = lib.optionals (options.programs ? zen-browser) [
-    (
-      { cfg }:
-      {
-        warnings =
-          lib.optional (config.programs.zen-browser.enable && cfg.profileNames == [ ])
-            ''stylix: zen-browser: `config.stylix.targets.zen-browser.profileNames` is not set. Declare profile names with 'config.stylix.targets.zen-browser.profileNames = [ "<PROFILE_NAME>" ];'.'';
-      }
-    )
-    (
-      { cfg, fonts }:
-      {
-        programs.zen-browser.profiles = lib.genAttrs cfg.profileNames (_: {
-          settings = {
-            "font.name.monospace.x-western" = fonts.monospace.name;
-            "font.name.sans-serif.x-western" = fonts.sansSerif.name;
-            "font.name.serif.x-western" = fonts.serif.name;
-          };
-        });
-      }
-    )
-    (import ../firefox/reader-mode.nix {
-      inherit lib;
-      name = "zen-browser";
-    })
-    (
-      { cfg, colors }:
-      {
-        programs.zen-browser.profiles = lib.mkIf cfg.enableCss (
-          lib.genAttrs cfg.profileNames (_: {
+  config = lib.optionals (options.programs ? zen-browser) (
+    [
+      (
+        { cfg }:
+        {
+          warnings =
+            lib.optional (config.programs.zen-browser.enable && cfg.profileNames == [ ])
+              ''stylix: zen-browser: `config.stylix.targets.zen-browser.profileNames` is not set. Declare profile names with 'config.stylix.targets.zen-browser.profileNames = [ "<PROFILE_NAME>" ];'.'';
+        }
+      )
+      (
+        { cfg, fonts }:
+        {
+          programs.zen-browser.profiles = lib.genAttrs cfg.profileNames (_: {
             settings = {
-              "toolkit.legacyUserProfileCustomizations.stylesheets" = true;
+              "font.name.monospace.x-western" = fonts.monospace.name;
+              "font.name.sans-serif.x-western" = fonts.sansSerif.name;
+              "font.name.serif.x-western" = fonts.serif.name;
             };
+          });
+        }
+      )
+      (import ../firefox/reader-mode.nix {
+        inherit lib;
+        name = "zen-browser";
+      })
+      (
+        { cfg, colors }:
+        {
+          programs.zen-browser.profiles = lib.mkIf cfg.enableCss (
+            lib.genAttrs cfg.profileNames (_: {
+              settings = {
+                "toolkit.legacyUserProfileCustomizations.stylesheets" = true;
+              };
 
-            userChrome = import ./userChrome.nix { inherit colors; };
+              userChrome = import ./userChrome.nix { inherit colors; };
 
-            userContent = import ./userContent.nix { inherit colors; };
-          })
-        );
-      }
-    )
-  ];
+              userContent = import ./userContent.nix { inherit colors; };
+            })
+          );
+        }
+      )
+    ]
+    ++ import ../firefox/dark-reader.nix {
+      inherit lib pkgs;
+      name = "zen-browser";
+    }
+  );
 }


### PR DESCRIPTION
~~Haven't tested locally yet~~
Currently not working because dark reader doesn't have support for config via hm.

resolves #495 
cc: @brckd 