### PR TITLE
stylix: test the global enable option using assertions

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -162,11 +162,10 @@
                   nix-fast-build
                 ];
                 text = ''
-                  cores="$(nproc)"
                   system="$(nix eval --expr builtins.currentSystem --impure --raw)"
                   nix-fast-build \
                     --eval-max-memory-size 512 \
-                    --eval-workers "$cores" \
+                    --eval-workers 1 \
                     --flake ".#checks.$system" \
                     --no-link \
                     --skip-cached \

--- a/stylix/testbed.nix
+++ b/stylix/testbed.nix
@@ -147,7 +147,7 @@ let
       );
 
       systems = {
-        clean = lib.nixosSystem {
+        base = lib.nixosSystem {
           inherit (pkgs) system;
 
           modules = [
@@ -159,7 +159,21 @@ let
           ];
         };
 
-        disabled = systems.clean.extendModules {
+        clean = systems.base.extendModules {
+          modules = [
+            {
+              options.stylix.targets = lib.mkOption {
+                description = ''
+                  Mock option to replace Stylix options in testbeds before
+                  Stylix is installed; since the testbed may define options
+                  related to the target it is testing.
+                '';
+              };
+            }
+          ];
+        };
+
+        disabled = systems.base.extendModules {
           modules = [
             inputs.self.nixosModules.stylix
           ];


### PR DESCRIPTION
This adds a pair of assertions to each testbed: that the system is not changed in any way when Stylix is disabled, and that it is changed when Stylix is enabled.

I originally wanted this to compare the value of every option, but that uncovered a variety of errors in upstream code which is not normally evaluated - things like `meta.maintainers` definitions using undefined variables. I realised it would also require filtering out certain subtrees, such as the stylix.enable option itself, which we expect to change.

In the end, I opted to just compare the toplevel derivations instead.

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [x] Tested locally
- [ ] Tested in [testbed](https://stylix.danth.me/testbeds.html)
- [x] Commit message follows [commit convention](https://stylix.danth.me/commit_convention.html)
- [ ] Fits [style guide](https://stylix.danth.me/styling.html)

### Maintainer CC

<!---
If you are editing an existing target, consider pinging relevant
`modules/<module>/meta.nix` module maintainers.
-->
