### PR TITLE
{firefox, floorp, librewolf}: add better default and remove warning

### DIFF
--- a/modules/firefox/hm.nix
+++ b/modules/firefox/hm.nix
@@ -56,7 +56,11 @@ in
       lib.nameValuePair target.path {
         enable = config.lib.stylix.mkEnableTarget target.name true;
 
-        disableWarnings = lib.mkEnableOption "Disable profile related Warnings";
+        enableProfileWarning = lib.mkOption {
+          type = lib.types.bool;
+          default = true;
+          description = "Whether to warn when any ${target.name} profiles are detected as being set through Home Manager but not themed through Stylix.";
+        };
 
         profileNames = lib.mkOption {
           description = "The ${target.name} profile names to apply styling on.";
@@ -165,14 +169,17 @@ in
         missingProfiles = lib.lists.subtractLists (builtins.attrNames
           config.programs.${target.path}.profiles
         ) config.stylix.targets.${target.path}.profileNames;
-        warn = !config.stylix.targets.${target.path}.disableWarnings;
       in
       lib.optional
-        (config.programs.${target.path}.enable && missingProfiles != [ ] && warn)
+        (
+          config.programs.${target.path}.enable
+          && missingProfiles != [ ]
+          && config.programs.${target.path}.enableProfileWarnings
+        )
         ''
           stylix: ${target.path}: `config.stylix.targets.${target.path}.profileNames` does not include the following profiles:
           ${lib.concatStringsSep ", " missingProfiles}
-          If this was intentional, you can disable this warning by setting `config.stylix.targets.${target.path}.disableWarnings'.
+          If this was intentional, you can disable this warning by setting `config.stylix.targets.${target.path}.enableProfileWarnings = false;'.
         ''
     );
   };

--- a/modules/firefox/hm.nix
+++ b/modules/firefox/hm.nix
@@ -173,8 +173,8 @@ in
       lib.optional
         (
           config.programs.${target.path}.enable
-          && missingProfiles != [ ]
           && config.programs.${target.path}.enableProfileWarnings
+          && missingProfiles != [ ]
         )
         ''
           stylix: ${target.path}: `config.stylix.targets.${target.path}.profileNames` does not include the following profile(s):

--- a/modules/firefox/hm.nix
+++ b/modules/firefox/hm.nix
@@ -59,7 +59,7 @@ in
         profileNames = lib.mkOption {
           description = "The ${target.name} profile names to apply styling on.";
           type = lib.types.listOf lib.types.str;
-          default = [ ];
+          default = [ "Default" ];
         };
 
         colorTheme.enable = lib.mkEnableOption "[Firefox Color](https://color.firefox.com/) on ${target.name}";
@@ -156,15 +156,6 @@ in
           })
         ];
       }) cfg.profileNames
-    );
-    warnings = eachTarget (
-      { target, ... }:
-      lib.optional
-        (
-          config.programs.${target.path}.enable
-          && config.stylix.targets.${target.path}.profileNames == [ ]
-        )
-        ''stylix: ${target.path}: `config.stylix.targets.${target.path}.profileNames` is not set. Declare profile names with 'config.stylix.targets.${target.path}.profileNames = [ "<PROFILE_NAME>" ];'.''
     );
   };
 }

--- a/modules/firefox/hm.nix
+++ b/modules/firefox/hm.nix
@@ -176,11 +176,7 @@ in
           && config.programs.${target.path}.enableProfileWarnings
           && missingProfiles != [ ]
         )
-        ''
-          stylix: ${target.path}: `config.stylix.targets.${target.path}.profileNames` does not include the following profile(s):
-          ${lib.concatStringsSep ", " missingProfiles}
-          If this was intentional, you can disable this warning by setting `config.stylix.targets.${target.path}.enableProfileWarnings = false;'.
-        ''
+        "stylix: ${target.path}: `config.stylix.targets.${target.path}.profileNames` does not include the following profile(s): ${lib.concatStringsSep ", " missingProfiles}. If this is intentional, you can disable this warning by setting `config.stylix.targets.${target.path}.enableProfileWarnings = false;'."
     );
   };
 }

--- a/modules/firefox/hm.nix
+++ b/modules/firefox/hm.nix
@@ -177,7 +177,7 @@ in
           && config.programs.${target.path}.enableProfileWarnings
         )
         ''
-          stylix: ${target.path}: `config.stylix.targets.${target.path}.profileNames` does not include the following profiles:
+          stylix: ${target.path}: `config.stylix.targets.${target.path}.profileNames` does not include the following profile(s):
           ${lib.concatStringsSep ", " missingProfiles}
           If this was intentional, you can disable this warning by setting `config.stylix.targets.${target.path}.enableProfileWarnings = false;'.
         ''


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

## Things done

I like about stylix that it is as no-config as it can get with styling. As such, I didn't like that I have to specify which FF profiles I'm using, when for most it will be just "Default". I removed the warning and added a default that applies to most people without removing any configurability.

Additionally, I would personally like it if one of the coloring options was enabled by default.
The Firefox module is really the only one breaking this "no config" expectation. All other programs just style in some way by default.

I get that this option has been added because there is no way to augment submodules without introducing infinite recursion. I learned that while trying to fix it. But until there is a better solution to this (like improving the module system from nixpkgs) I think this is better that warning.

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [x] Tested locally
- [x] Tested in [testbed](https://stylix.danth.me/testbeds.html)
- [x] Commit message follows [commit convention](https://stylix.danth.me/commit_convention.html)
- [x] Fits [style guide](https://stylix.danth.me/styling.html)
- [x] Respects license of any existing code used

## Notify maintainers

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->
