### PR TITLE
doc: use stricter, more minimal module evals

### DIFF
--- a/doc/default.nix
+++ b/doc/default.nix
@@ -14,11 +14,24 @@ let
   # Prefix to remove from option declaration file paths.
   rootPrefix = toString ../. + "/";
 
+  # A stub pkgs used while evaluating the stylix modules for the docs
+  noPkgs = {
+    # Needed for type-checking
+    inherit (pkgs) _type;
+
+    # Permit access to (pkgs.formats.foo { }).type
+    formats = builtins.mapAttrs (_: fmt: args: {
+      inherit (fmt args) type;
+    }) pkgs.formats;
+  };
+
   evalDocs =
     module:
     lib.evalModules {
       modules = [ ./eval_compat.nix ] ++ lib.toList module;
-      specialArgs = { inherit pkgs; };
+      specialArgs = {
+        pkgs = noPkgs;
+      };
     };
 
   # TODO: Include Nix Darwin options

--- a/doc/default.nix
+++ b/doc/default.nix
@@ -1,7 +1,7 @@
 {
   lib,
   pkgs,
-  inputs,
+  self,
   callPackage,
   writeText,
   stdenvNoCC,
@@ -27,13 +27,13 @@ let
     home_manager = {
       name = "Home Manager";
       configuration = evalDocs [
-        inputs.self.homeModules.stylix
+        self.homeModules.stylix
         ./hm_compat.nix
       ];
     };
     nixos = {
       name = "NixOS";
-      configuration = evalDocs inputs.self.nixosModules.stylix;
+      configuration = evalDocs self.nixosModules.stylix;
     };
   };
 
@@ -324,7 +324,7 @@ let
 
   # Permalink to view a source file on GitHub. If the commit isn't known,
   # then fall back to the latest commit.
-  declarationCommit = inputs.self.rev or "master";
+  declarationCommit = self.rev or "master";
   declarationPermalink = "https://github.com/nix-community/stylix/blob/${declarationCommit}";
 
   # Renders a single option declaration. Example output:

--- a/doc/default.nix
+++ b/doc/default.nix
@@ -2,9 +2,6 @@
   lib,
   pkgs,
   inputs,
-  nixosSystem,
-  homeManagerConfiguration,
-  system,
   callPackage,
   writeText,
   stdenvNoCC,
@@ -17,38 +14,26 @@ let
   # Prefix to remove from option declaration file paths.
   rootPrefix = toString ../. + "/";
 
-  nixosConfiguration = nixosSystem {
-    inherit system;
-    modules = [
-      inputs.home-manager.nixosModules.home-manager
-      inputs.self.nixosModules.stylix
-    ];
-  };
-
-  homeConfiguration = homeManagerConfiguration {
-    inherit pkgs;
-    modules = [
-      inputs.self.homeModules.stylix
-      {
-        home = {
-          homeDirectory = "/home/book";
-          stateVersion = "22.11";
-          username = "book";
-        };
-      }
-    ];
-  };
+  evalDocs =
+    module:
+    lib.evalModules {
+      modules = [ ./eval_compat.nix ] ++ lib.toList module;
+      specialArgs = { inherit pkgs; };
+    };
 
   # TODO: Include Nix Darwin options
 
   platforms = {
     home_manager = {
       name = "Home Manager";
-      configuration = homeConfiguration;
+      configuration = evalDocs [
+        inputs.self.homeModules.stylix
+        ./hm_compat.nix
+      ];
     };
     nixos = {
       name = "NixOS";
-      configuration = nixosConfiguration;
+      configuration = evalDocs inputs.self.nixosModules.stylix;
     };
   };
 

--- a/doc/eval_compat.nix
+++ b/doc/eval_compat.nix
@@ -1,0 +1,26 @@
+{ lib, ... }:
+{
+  options = {
+    # Declare the arbitrarily named __stub attribute to allow modules to evaluate
+    # 'options.programs ? «OPTION»'.
+    #
+    # TODO: Replace 'options.programs ? «OPTION»' instances with
+    # 'options ? programs.«OPTION»' to remove this __stub workaround.
+    programs.__stub = lib.mkSinkUndeclaredOptions { };
+
+    # The config.lib option, as found in NixOS and home-manager.
+    # Many option declarations depend on `config.lib.stylix`.
+    lib = lib.mkOption {
+      type = lib.types.attrsOf lib.types.attrs;
+      description = ''
+        This option allows modules to define helper functions, constants, etc.
+      '';
+      default = { };
+      visible = false;
+    };
+  };
+
+  # Third-party options are not included in the module eval,
+  # so disable checking options definitions have matching declarations
+  config._module.check = false;
+}

--- a/doc/eval_compat.nix
+++ b/doc/eval_compat.nix
@@ -1,24 +1,11 @@
 { lib, ... }:
 {
-  options = {
-    # Declare the arbitrarily named __stub attribute to allow modules to evaluate
-    # 'options.programs ? «OPTION»'.
-    #
-    # TODO: Replace 'options.programs ? «OPTION»' instances with
-    # 'options ? programs.«OPTION»' to remove this __stub workaround.
-    programs.__stub = lib.mkSinkUndeclaredOptions { };
-
-    # The config.lib option, as found in NixOS and home-manager.
-    # Many option declarations depend on `config.lib.stylix`.
-    lib = lib.mkOption {
-      type = lib.types.attrsOf lib.types.attrs;
-      description = ''
-        This option allows modules to define helper functions, constants, etc.
-      '';
-      default = { };
-      visible = false;
-    };
-  };
+  # Declare the arbitrarily named __stub attribute to allow modules to evaluate
+  # 'options.programs ? «OPTION»'.
+  #
+  # TODO: Replace 'options.programs ? «OPTION»' instances with
+  # 'options ? programs.«OPTION»' to remove this __stub workaround.
+  options.programs.__stub = lib.mkSinkUndeclaredOptions { };
 
   # Third-party options are not included in the module eval,
   # so disable checking options definitions have matching declarations

--- a/doc/hm_compat.nix
+++ b/doc/hm_compat.nix
@@ -1,0 +1,12 @@
+{ lib, ... }:
+{
+  # Declare the arbitrarily named __stub attribute to allow modules to evaluate
+  # 'options.services ? «OPTION»'.
+  #
+  # TODO: Replace 'options.services ? «OPTION»' instances with
+  # 'options ? services.«OPTION»' to remove this __stub workaround.
+  options.services.__stub = lib.mkSinkUndeclaredOptions { };
+
+  # Some modules use home-manager's `osConfig` arg
+  config._module.args.osConfig = null;
+}

--- a/flake/packages.nix
+++ b/flake/packages.nix
@@ -22,8 +22,6 @@
         {
           doc = pkgs.callPackage ../doc {
             inherit inputs;
-            inherit (inputs.nixpkgs.lib) nixosSystem;
-            inherit (inputs.home-manager.lib) homeManagerConfiguration;
           };
           serve-docs = pkgs.callPackage ../doc/server.nix {
             inherit (config.packages) doc;

--- a/flake/packages.nix
+++ b/flake/packages.nix
@@ -21,7 +21,7 @@
         ))
         {
           doc = pkgs.callPackage ../doc {
-            inherit inputs;
+            inherit (inputs) self;
           };
           serve-docs = pkgs.callPackage ../doc/server.nix {
             inherit (config.packages) doc;

--- a/stylix/fonts.nix
+++ b/stylix/fonts.nix
@@ -58,7 +58,12 @@ in
         mkFontSizeOption =
           { default, target }:
           lib.mkOption {
-            inherit default;
+            default = if builtins.isInt default then default else cfg.sizes.${default};
+            defaultText =
+              if builtins.isInt default then
+                default
+              else
+                lib.literalExpression "config.stylix.fonts.sizes.${default}";
 
             description = ''
               The font size used for ${target}.
@@ -94,12 +99,12 @@ in
 
         terminal = mkFontSizeOption {
           target = "terminals and text editors";
-          default = cfg.sizes.applications;
+          default = "applications";
         };
 
         popups = mkFontSizeOption {
           target = "notifications, popups, and other overlay elements of the desktop";
-          default = cfg.sizes.desktop;
+          default = "desktop";
         };
       };
 

--- a/stylix/target.nix
+++ b/stylix/target.nix
@@ -113,7 +113,11 @@
               lib.literalExpression "config.stylix.image != null"
             else
               false;
-          example = config.stylix.image == null;
+          example =
+            if autoEnable then
+              lib.literalExpression "config.stylix.image == null"
+            else
+              true;
         };
 
       mkEnableIf =


### PR DESCRIPTION
## Summary

### doc: use minimal module evals

We don't actually need fully blown NixOS or home-manager configurations just to read the declared `options`.

Instead, we can directly call `lib.evalModules` to build a minimal configuration containing only stylix modules.

This is faster, simpler, more compartmentalised, etc.

This should allow for removing the option declaration location based filtering. Draft PR: https://github.com/danth/stylix/pull/1215.

This may also make adding nix-darwin docs easier, in the future.

### doc: ensure `pkgs` is not used in option docs

Using a stubbed instance of `pkgs` while evaling the modules for the docs ensures no options accidentally use real packages in their description/default/example text.

This highlighted an issue that was resolved in https://github.com/danth/stylix/pull/1225.

### doc: ensure `config` is not used in option docs

With a few exceptions for `lib.stylix` functions. These are needed for declaring options and are currently accessed via `config`:

- `mkEnableIf`
- `mkEnableTarget`
- `mkEnableTargetWith`
- `mkEnableWallpaper`

Once these exceptions are removed, we will have solved https://github.com/nix-community/stylix/issues/98.

Additionally, `mkTarget` is used for creating entire modules (including options), but that is already accessed without using `config`.

A potential solution is to pass a `stylib` to modules via `importApply` (or similar), as discussed here: https://github.com/nix-community/stylix/issues/98#issuecomment-2956991911

However that shouldn't block this PR and will be easier to reason about as independent PRs.

## Testing

I've tested that the docs still build.

I've spot checked that a few pages look the same as the current docs.

## Issues

The additional strictness imposed by this PR has uncovered pre-existing issues with options, which are contributing to #98. Not only does this cause issues with nixos docs, it also means that "dynamic" values are not documented correctly.

Most of these cases were fixed in #1244, however a few other cases have been found and fixed as part of this PR.

**To be clear:** these are not new issues introduced by this PR; this PR does **not** need to fix them, as workarounds are implemented.

---

cc @awwpotato


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [x] Tested locally
- [ ] Tested in [testbed](https://stylix.danth.me/testbeds.html)
- [x] Commit message follows [commit convention](https://stylix.danth.me/commit_convention.html)
- [ ] Fits [style guide](https://stylix.danth.me/styling.html)
- [ ] Respects license of any existing code used

