### PR TITLE
doc: remove redundant option-location filtering

### DIFF
--- a/doc/default.nix
+++ b/doc/default.nix
@@ -321,6 +321,9 @@ let
       # This also normalises things like `defaultText` and `visible="shallow"`.
       lib.optionAttrSetToDocList
 
+      # Remove hidden options
+      (builtins.filter (opt: opt.visible && !opt.internal))
+
       # Insert the options into `index`
       (builtins.foldl' (
         foldIndex: option:
@@ -428,40 +431,38 @@ let
   #     | Default | The default value, if provided. Usually a code block. |
   #     | Example | An example value, if provided. Usually a code block.  |
   #     | Source  | - [modules/module1/nixos.nix](https://github.com/...) |
-  renderOption =
-    option:
-    lib.optionalString (option.visible && !option.internal) ''
-      ### ${option.name}
+  renderOption = option: ''
+    ### ${option.name}
 
-      ${option.description or ""}
+    ${option.description or ""}
 
-      ${lib.concatStrings (
-        [
-          "<table class=\"option-details\">"
-          "<colgroup>"
-          "<col span=\"1\">"
-          "<col span=\"1\">"
-          "</colgroup>"
-          "<tbody>"
-        ]
-        ++ (lib.optional (option ? type) (renderDetailsRow "Type" option.type))
-        ++ (lib.optional (option ? default) (
-          renderDetailsRow "Default" (renderValue option.default)
-        ))
-        ++ (lib.optional (option ? example) (
-          renderDetailsRow "Example" (renderValue option.example)
-        ))
-        ++ (lib.optional (option ? declarations) (
-          renderDetailsRow "Source" (
-            lib.concatLines (map renderDeclaration option.declarations)
-          )
-        ))
-        ++ [
-          "</tbody>"
-          "</table>"
-        ]
-      )}
-    '';
+    ${lib.concatStrings (
+      [
+        "<table class=\"option-details\">"
+        "<colgroup>"
+        "<col span=\"1\">"
+        "<col span=\"1\">"
+        "</colgroup>"
+        "<tbody>"
+      ]
+      ++ (lib.optional (option ? type) (renderDetailsRow "Type" option.type))
+      ++ (lib.optional (option ? default) (
+        renderDetailsRow "Default" (renderValue option.default)
+      ))
+      ++ (lib.optional (option ? example) (
+        renderDetailsRow "Example" (renderValue option.example)
+      ))
+      ++ (lib.optional (option ? declarations) (
+        renderDetailsRow "Source" (
+          lib.concatLines (map renderDeclaration option.declarations)
+        )
+      ))
+      ++ [
+        "</tbody>"
+        "</table>"
+      ]
+    )}
+  '';
 
   # Render the list of options for a single platform. Example output:
   #

--- a/doc/default.nix
+++ b/doc/default.nix
@@ -154,150 +154,147 @@ let
       option,
     }:
     # Only include options which are declared by a module within Stylix.
-    if lib.hasPrefix rootPrefix declaration then
+    let
+      subPath = lib.removePrefix rootPrefix (toString declaration);
+      pathComponents = lib.splitString "/" subPath;
+    in
+    # Options declared in the modules directory go to the Modules section,
+    # otherwise they're assumed to be shared between modules, and go to the
+    # Platforms section.
+    if builtins.elemAt pathComponents 0 == "modules" then
       let
-        subPath = lib.removePrefix rootPrefix (toString declaration);
-        pathComponents = lib.splitString "/" subPath;
+        module = builtins.elemAt pathComponents 1;
       in
-      # Options declared in the modules directory go to the Modules section,
-      # otherwise they're assumed to be shared between modules, and go to the
-      # Platforms section.
-      if builtins.elemAt pathComponents 0 == "modules" then
-        let
-          module = builtins.elemAt pathComponents 1;
-        in
-        insert {
-          inherit index platform option;
-          page = "src/options/modules/${module}.md";
-          emptyPage = {
-            referenceSection = "Modules";
+      insert {
+        inherit index platform option;
+        page = "src/options/modules/${module}.md";
+        emptyPage = {
+          referenceSection = "Modules";
 
-            readme =
-              let
-                maintainers =
-                  lib.throwIfNot (metadata ? ${module}.maintainers)
-                    "stylix: ${module} is missing `meta.maintainers`"
-                    metadata.${module}.maintainers;
+          readme =
+            let
+              maintainers =
+                lib.throwIfNot (metadata ? ${module}.maintainers)
+                  "stylix: ${module} is missing `meta.maintainers`"
+                  metadata.${module}.maintainers;
 
-                joinItems =
-                  items:
-                  if builtins.length items <= 2 then
-                    builtins.concatStringsSep " and " items
-                  else
-                    builtins.concatStringsSep ", " (
-                      lib.dropEnd 1 items ++ [ "and ${lib.last items}" ]
-                    );
+              joinItems =
+                items:
+                if builtins.length items <= 2 then
+                  builtins.concatStringsSep " and " items
+                else
+                  builtins.concatStringsSep ", " (
+                    lib.dropEnd 1 items ++ [ "and ${lib.last items}" ]
+                  );
 
-                # Render a maintainer's name and a link to the best contact
-                # information we have for them.
-                #
-                # The reasoning behind the order of preference is as follows:
-                #
-                # - GitHub:
-                #   - May link to multiple contact methods
-                #   - More likely to have up-to-date information than the
-                #     maintainers list
-                #   - Protects the email address from crawlers
-                # - Email:
-                #   - Very commonly used
-                # - Matrix:
-                #   - Only other contact method in the schema
-                #     (as of March 2025)
-                # - Name:
-                #   - If no other information is available, then just show
-                #     the maintainer's name without a link
-                renderMaintainer =
-                  maintainer:
-                  if maintainer ? github then
-                    "[${maintainer.name}](https://github.com/${maintainer.github})"
-                  else if maintainer ? email then
-                    "[${maintainer.name}](mailto:${maintainer.email})"
-                  else if maintainer ? matrix then
-                    "[${maintainer.name}](https://matrix.to/#/${maintainer.matrix})"
-                  else
-                    maintainer.name;
+              # Render a maintainer's name and a link to the best contact
+              # information we have for them.
+              #
+              # The reasoning behind the order of preference is as follows:
+              #
+              # - GitHub:
+              #   - May link to multiple contact methods
+              #   - More likely to have up-to-date information than the
+              #     maintainers list
+              #   - Protects the email address from crawlers
+              # - Email:
+              #   - Very commonly used
+              # - Matrix:
+              #   - Only other contact method in the schema
+              #     (as of March 2025)
+              # - Name:
+              #   - If no other information is available, then just show
+              #     the maintainer's name without a link
+              renderMaintainer =
+                maintainer:
+                if maintainer ? github then
+                  "[${maintainer.name}](https://github.com/${maintainer.github})"
+                else if maintainer ? email then
+                  "[${maintainer.name}](mailto:${maintainer.email})"
+                else if maintainer ? matrix then
+                  "[${maintainer.name}](https://matrix.to/#/${maintainer.matrix})"
+                else
+                  maintainer.name;
 
-                renderedMaintainers = joinItems (map renderMaintainer maintainers);
+              renderedMaintainers = joinItems (map renderMaintainer maintainers);
 
-                ghHandles = toString (
-                  map (m: lib.optionalString (m ? github) "@${m.github}") maintainers
-                );
+              ghHandles = toString (
+                map (m: lib.optionalString (m ? github) "@${m.github}") maintainers
+              );
 
-                maintainersText = lib.optionalString (
-                  maintainers != [ ]
-                ) "**Maintainers**: ${renderedMaintainers} (`${ghHandles}`)";
+              maintainersText = lib.optionalString (
+                maintainers != [ ]
+              ) "**Maintainers**: ${renderedMaintainers} (`${ghHandles}`)";
 
-                # Render homepages as hyperlinks in readme
-                homepage = metadata.${module}.homepage or null;
+              # Render homepages as hyperlinks in readme
+              homepage = metadata.${module}.homepage or null;
 
-                renderedHomepages = joinItems (
-                  lib.mapAttrsToList (name: url: "[${name}](${url})") homepage
-                );
+              renderedHomepages = joinItems (
+                lib.mapAttrsToList (name: url: "[${name}](${url})") homepage
+              );
 
-                homepageText =
-                  if homepage == null then
-                    ""
-                  else if builtins.isString homepage then
-                    "**Homepage**: [${homepage}](${homepage})\n"
-                  else if builtins.isAttrs homepage then
-                    lib.throwIf (builtins.length (builtins.attrNames homepage) == 1)
-                      "stylix: ${module}: `meta.homepage.${builtins.head (builtins.attrNames homepage)}` should be simplified to `meta.homepage`"
-                      "**Homepages**: ${renderedHomepages}\n"
-                  else
-                    throw "stylix: ${module}: unexpected type for `meta.homepage`: ${builtins.typeOf homepage}";
+              homepageText =
+                if homepage == null then
+                  ""
+                else if builtins.isString homepage then
+                  "**Homepage**: [${homepage}](${homepage})\n"
+                else if builtins.isAttrs homepage then
+                  lib.throwIf (builtins.length (builtins.attrNames homepage) == 1)
+                    "stylix: ${module}: `meta.homepage.${builtins.head (builtins.attrNames homepage)}` should be simplified to `meta.homepage`"
+                    "**Homepages**: ${renderedHomepages}\n"
+                else
+                  throw "stylix: ${module}: unexpected type for `meta.homepage`: ${builtins.typeOf homepage}";
 
-                name = lib.throwIfNot (
-                  metadata ? ${module}.name
-                ) "stylix: ${module} is missing `meta.name`" metadata.${module}.name;
+              name = lib.throwIfNot (
+                metadata ? ${module}.name
+              ) "stylix: ${module} is missing `meta.name`" metadata.${module}.name;
 
-              in
-              lib.concatMapStrings (paragraph: "${paragraph}\n\n") [
-                "# ${name}"
-                homepageText
-                maintainersText
-                "---"
-                metadata.${module}.description or ""
-              ];
+            in
+            lib.concatMapStrings (paragraph: "${paragraph}\n\n") [
+              "# ${name}"
+              homepageText
+              maintainersText
+              "---"
+              metadata.${module}.description or ""
+            ];
 
-            # Module pages initialise all platforms to an empty list, so that
-            # '*None provided.*' indicates platforms where the module isn't
-            # available.
-            optionsByPlatform = lib.mapAttrs (_: _: [ ]) platforms;
-          };
-        }
-      else
-        let
-          page = "src/options/platforms/${platform}.md";
-          path = ./. + "/${page}";
-        in
-        insert {
-          inherit
-            index
-            platform
-            page
-            option
-            ;
-          emptyPage = {
-            referenceSection = "Platforms";
-            readme =
-              if builtins.pathExists path then
-                builtins.readFile path
-              else
-                ''
-                  # ${platform.name}
-                  > [!NOTE]
-                  > Documentation is not available for this platform. Its
-                  > main options are listed below, and you may find more
-                  > specific options in the documentation for each module.
-                '';
-
-            # Platform pages only initialise that platform, since showing other
-            # platforms here would be nonsensical.
-            optionsByPlatform.${platform} = [ ];
-          };
-        }
+          # Module pages initialise all platforms to an empty list, so that
+          # '*None provided.*' indicates platforms where the module isn't
+          # available.
+          optionsByPlatform = lib.mapAttrs (_: _: [ ]) platforms;
+        };
+      }
     else
-      index;
+      let
+        page = "src/options/platforms/${platform}.md";
+        path = ./. + "/${page}";
+      in
+      insert {
+        inherit
+          index
+          platform
+          page
+          option
+          ;
+        emptyPage = {
+          referenceSection = "Platforms";
+          readme =
+            if builtins.pathExists path then
+              builtins.readFile path
+            else
+              ''
+                # ${platform.name}
+                > [!NOTE]
+                > Documentation is not available for this platform. Its
+                > main options are listed below, and you may find more
+                > specific options in the documentation for each module.
+              '';
+
+          # Platform pages only initialise that platform, since showing other
+          # platforms here would be nonsensical.
+          optionsByPlatform.${platform} = [ ];
+        };
+      };
 
   insertOption =
     {
@@ -315,16 +312,24 @@ let
 
   insertPlatform =
     index: platform:
-    builtins.foldl'
-      (
+    lib.pipe platforms.${platform}.configuration.options [
+
+      # Drop options that come from the module system
+      (lib.flip builtins.removeAttrs [ "_module" ])
+
+      # Get a list of all options, flattening sub-options recursively.
+      # This also normalises things like `defaultText` and `visible="shallow"`.
+      lib.optionAttrSetToDocList
+
+      # Insert the options into `index`
+      (builtins.foldl' (
         foldIndex: option:
         insertOption {
           index = foldIndex;
           inherit platform option;
         }
-      )
-      index
-      (lib.optionAttrSetToDocList platforms.${platform}.configuration.options);
+      ) index)
+    ];
 
   index = builtins.foldl' insertPlatform { } (builtins.attrNames platforms);
 

--- a/doc/default.nix
+++ b/doc/default.nix
@@ -392,6 +392,10 @@ let
       declarationString = toString declaration;
       subPath = lib.removePrefix rootPrefix declarationString;
     in
+    # NOTE: This assertion ensures all options in the docs come from stylix.
+    # See https://github.com/nix-community/stylix/pull/631
+    # It may be necessary to remove or relax this assertion to include options
+    # with arbitrary (non-path) declaration locations.
     lib.throwIfNot (lib.hasPrefix rootPrefix declarationString)
       "declaration not in ${rootPrefix}: ${declarationString}"
       "- [${subPath}](${declarationPermalink}/${subPath})";


### PR DESCRIPTION
Follow up to #1212, originally discussed in https://github.com/danth/stylix/pull/1205#discussion_r2071539928.

The bulk of the diff is caused by a change of indentation, viewing the diff with [whitespace ignored](https://github.com/nix-community/stylix/pull/1215/files?w=1) is recommended.

Now #1212 is merged, we no longer need the option declaration location filtering, since all options present in the configuration will come from stylix modules.

One exception is the module system's builtin options, which all live in `_module`. We can simply `removeAttrs ["_module"]` before using `optionAttrSetToDocList` to remove those, though.

Additionally, I've slightly simplified the hidden-option filtering, by moving it to immediately after `optionAttrSetToDocList`.

There is still one assertion that checks the option decl starts with the expected prefix. However this has less to do with actively filtering out options and more to do with ensuring `renderDeclaration` knows how to render the particular location. This assertion continues to act as a smoke test, that may catch some regressions of #631. If you ever do need to include options declared elsewhere (e.g. out-of-tree options or arbitrary non-path option location strings), then you will need to remove or relax this assertion to accommodate those options. I've added a comment noting this.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

## Things done

1. Removed option declaration location filtering
2. Moved option visibility filtering to `insertPlatform`, immediately after calling `lib.optionAttrSetToDocList`
3. Kept the smokescreen assertion for unexpected locations
4. Added a comment to the assertion


<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [x] Tested locally
- [ ] Tested in [testbed](https://stylix.danth.me/testbeds.html)
- [x] Commit message follows [commit convention](https://stylix.danth.me/commit_convention.html)
- [ ] Fits [style guide](https://stylix.danth.me/styling.html)
- [ ] Respects license of any existing code used

## Testing

To test, I applied the patch @trueNAHO uses and recursively diffed the docs output vs master:

```diff
diff --git a/doc/default.nix b/doc/default.nix
index 2de597e..b45c816 100644
--- a/doc/default.nix
+++ b/doc/default.nix
@@ -380,7 +380,7 @@ let
 
   # Permalink to view a source file on GitHub. If the commit isn't known,
   # then fall back to the latest commit.
-  declarationCommit = self.rev or "master";
+  declarationCommit = "100b968012804d6526c5f48a32c30680916bc474";
   declarationPermalink = "https://github.com/nix-community/stylix/blob/${declarationCommit}";
 
   # Renders a single option declaration. Example output:
```

```sh
nix build .#doc --out-link docs-with-pr
nix build github:nix-community/stylix#doc --out-link docs-master
diff -r docs-master/ docs-with-pr/
```

This shows no diff, although the input must be slightly different as the two builds have a different in-store path:

```sh
$ realpath docs-master
/nix/store/ls294ykkg8q6dhvy5adnvixfhm4mn8ji-stylix-book
$ realpath docs-with-pr
/nix/store/gaayagl9580yqy21z77wnl3zb0g6cz3q-stylix-book
```