### PR TITLE
stylix: allow choosing testbed desktop

### DIFF
--- a/doc/src/testbeds.md
+++ b/doc/src/testbeds.md
@@ -30,6 +30,10 @@ uses.
   - `enable` defaults to true; allows for conditionally disabling a testbed
   - `ui` and all of its suboptions are optional. Setting any will enable a
     graphical environment.
+    - `graphicalEnvironment` defaults to "gnome"; takes the string name of the graphical
+      environment to be used for the testbed. See
+      `stylix/testbed/graphicalEnvironments` for a complete list of available
+      graphical environments.
     - `command` takes a command to be run once the graphical environment
       has loaded
       - `text` takes the string of the command

--- a/modules/bspwm/testbeds/bspwm.nix
+++ b/modules/bspwm/testbeds/bspwm.nix
@@ -1,17 +1,13 @@
-{ lib, pkgs, ... }:
+{ pkgs, ... }:
 
 {
-  services.xserver = {
-    enable = true;
-    windowManager.bspwm.enable = true;
-  };
+  stylix.testbed.ui = {
+    graphicalEnvironment = "bspwm";
 
-  home-manager.sharedModules = lib.singleton {
-    xsession.windowManager.bspwm = {
-      enable = true;
-
-      # We need something to open a window so that we can check the window borders
-      startupPrograms = [ "${lib.getExe pkgs.kitty}" ];
+    # We need something to open a window so that we can check the window borders
+    application = {
+      name = "kitty";
+      package = pkgs.kitty;
     };
   };
 }

--- a/modules/gnome/testbeds/gnome.nix
+++ b/modules/gnome/testbeds/gnome.nix
@@ -1,6 +1,3 @@
 {
-  services = {
-    desktopManager.gnome.enable = true;
-    displayManager.gdm.enable = true;
-  };
+  stylix.testbed.ui.graphicalEnvironment = "gnome";
 }

--- a/modules/hyprland/testbeds/hyprland.nix
+++ b/modules/hyprland/testbeds/hyprland.nix
@@ -1,15 +1,13 @@
-{ lib, pkgs, ... }:
+{ pkgs, ... }:
 
 {
-  environment.loginShellInit = lib.getExe pkgs.hyprland;
-  programs.hyprland.enable = true;
+  stylix.testbed.ui = {
+    graphicalEnvironment = "hyprland";
 
-  home-manager.sharedModules = lib.singleton {
-    wayland.windowManager.hyprland = {
-      enable = true;
-
-      # We need something to open a window so that we can check the window borders
-      settings.bind = [ "ALT, RETURN, exec, ${lib.getExe pkgs.foot}" ];
+    # We need something to open a window so that we can check the window borders
+    application = {
+      name = "kitty";
+      package = pkgs.kitty;
     };
   };
 }

--- a/modules/kde/testbeds/kde.nix
+++ b/modules/kde/testbeds/kde.nix
@@ -1,7 +1,10 @@
 {
-  services = {
-    displayManager.sddm.enable = true;
-
-    desktopManager.plasma6.enable = true;
+  lib,
+  ...
+}:
+{
+  config = {
+    stylix.testbed.ui.graphicalEnvironment = "kde";
+    services.displayManager.autoLogin.enable = lib.mkForce false;
   };
 }

--- a/modules/mako/testbeds/mako.nix
+++ b/modules/mako/testbeds/mako.nix
@@ -1,25 +1,23 @@
 { lib, pkgs, ... }:
 
 {
-  # We use Hyprland because Gnome has its own notification daemon
-  environment.loginShellInit = lib.getExe pkgs.hyprland;
-  programs.hyprland.enable = true;
+  stylix.testbed.ui = {
+    # We use Hyprland because Gnome has its own notification daemon
+    graphicalEnvironment = "hyprland";
+    command.text =
+      # Run as a single command to ensure the same order between executions
+      lib.concatMapStringsSep " && "
+        (
+          urgency: "${lib.getExe pkgs.libnotify} --urgency ${urgency} ${urgency} urgency"
+        )
+        [
+          "low"
+          "normal"
+          "critical"
+        ];
+  };
 
   home-manager.sharedModules = lib.singleton {
     services.mako.enable = true;
-    wayland.windowManager.hyprland = {
-      enable = true;
-      settings.exec-once =
-        # Run as a single command to ensure the same order between executions
-        lib.concatMapStringsSep " && "
-          (
-            urgency: "${lib.getExe pkgs.libnotify} --urgency ${urgency} ${urgency} urgency"
-          )
-          [
-            "low"
-            "normal"
-            "critical"
-          ];
-    };
   };
 }

--- a/stylix/testbed/available-graphical-environments.nix
+++ b/stylix/testbed/available-graphical-environments.nix
@@ -1,5 +1,4 @@
 { lib }:
-
 lib.pipe ./graphical-environments [
   builtins.readDir
   (lib.mapAttrsToList (name: _: lib.removeSuffix ".nix" name))

--- a/stylix/testbed/available-graphical-environments.nix
+++ b/stylix/testbed/available-graphical-environments.nix
@@ -1,0 +1,6 @@
+{ lib }:
+
+lib.pipe ./graphical-environments [
+  builtins.readDir
+  (lib.mapAttrsToList (name: _: lib.removeSuffix ".nix" name))
+]

--- a/stylix/testbed/default.nix
+++ b/stylix/testbed/default.nix
@@ -13,19 +13,23 @@ let
       system = lib.nixosSystem {
         inherit (pkgs) system;
 
-        modules = [
-          ./modules/common.nix
-          ./modules/enable.nix
-          ./modules/application.nix
-          inputs.self.nixosModules.stylix
-          inputs.home-manager.nixosModules.home-manager
-          testbed
+        modules =
+          [
+            ./modules/common.nix
+            ./modules/enable.nix
+            ./modules/application.nix
+            inputs.self.nixosModules.stylix
+            inputs.home-manager.nixosModules.home-manager
+            testbed
 
-          # modules for external targets
-          inputs.nvf.nixosModules.default
-          inputs.nixvim.nixosModules.nixvim
-          inputs.spicetify-nix.nixosModules.spicetify
-        ];
+            # modules for external targets
+            inputs.nvf.nixosModules.default
+            inputs.nixvim.nixosModules.nixvim
+            inputs.spicetify-nix.nixosModules.spicetify
+          ]
+          ++ map (name: import ./graphical-environments/${name}.nix) (
+            import ./available-graphical-environments.nix { inherit lib; }
+          );
       };
     in
     pkgs.writeShellApplication {

--- a/stylix/testbed/graphical-environments/bspwm.nix
+++ b/stylix/testbed/graphical-environments/bspwm.nix
@@ -1,0 +1,31 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+{
+  config =
+    lib.mkIf (config.stylix.testbed.ui.graphicalEnvironment or null == "bspwm")
+      {
+        services.xserver = {
+          enable = true;
+          windowManager.bspwm.enable = true;
+        };
+
+        environment.systemPackages = [
+          # dex looks for `x-terminal-emulator` when running a terminal program
+          (pkgs.writeShellScriptBin "x-terminal-emulator" ''exec ${lib.getExe pkgs.kitty} "$@"'')
+        ];
+
+        home-manager.sharedModules = lib.singleton {
+          programs.kitty.enable = true;
+          xsession.windowManager.bspwm = {
+            enable = true;
+            startupPrograms = [
+              "find /run/current-system/sw/etc/xdg/autostart/ -type f -or -type l | xargs -P0 -L1 ${lib.getExe pkgs.dex}"
+            ];
+          };
+        };
+      };
+}

--- a/stylix/testbed/graphical-environments/gnome.nix
+++ b/stylix/testbed/graphical-environments/gnome.nix
@@ -1,0 +1,20 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+{
+  config =
+    lib.mkIf (config.stylix.testbed.ui.graphicalEnvironment or null == "gnome")
+      {
+        services.xserver = {
+          enable = true;
+          displayManager.gdm.enable = true;
+          desktopManager.gnome.enable = true;
+        };
+
+        # Disable the GNOME tutorial which pops up on first login.
+        environment.gnome.excludePackages = [ pkgs.gnome-tour ];
+      };
+}

--- a/stylix/testbed/graphical-environments/hyprland.nix
+++ b/stylix/testbed/graphical-environments/hyprland.nix
@@ -1,0 +1,32 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+{
+  config =
+    lib.mkIf (config.stylix.testbed.ui.graphicalEnvironment or null == "hyprland")
+      {
+        environment.loginShellInit = lib.getExe pkgs.hyprland;
+        programs.hyprland.enable = true;
+        environment.systemPackages = [
+          # dex looks for `x-terminal-emulator` when running a terminal program
+          (pkgs.writeShellScriptBin "x-terminal-emulator" ''exec ${lib.getExe pkgs.kitty} "$@"'')
+        ];
+
+        home-manager.sharedModules = lib.singleton {
+          programs.kitty.enable = true;
+          wayland.windowManager.hyprland = {
+            enable = true;
+            settings = {
+              exec-once = "find /run/current-system/sw/etc/xdg/autostart/ -type f -or -type l | xargs -P0 -L1 ${lib.getExe pkgs.dex}";
+              ecosystem = {
+                no_update_news = true;
+                no_donation_nag = true;
+              };
+            };
+          };
+        };
+      };
+}

--- a/stylix/testbed/graphical-environments/kde.nix
+++ b/stylix/testbed/graphical-environments/kde.nix
@@ -1,0 +1,15 @@
+{
+  config,
+  lib,
+  ...
+}:
+{
+  config =
+    lib.mkIf (config.stylix.testbed.ui.graphicalEnvironment or null == "kde")
+      {
+        services = {
+          displayManager.sddm.enable = true;
+          desktopManager.plasma6.enable = true;
+        };
+      };
+}

--- a/stylix/testbed/modules/application.nix
+++ b/stylix/testbed/modules/application.nix
@@ -26,6 +26,13 @@ in
               used may change in the future.
             '';
           };
+          graphicalEnvironment = lib.mkOption {
+            type = lib.types.enum (
+              import ../available-graphical-environments.nix { inherit lib; }
+            );
+            default = "gnome";
+            description = "The graphical environment to use.";
+          };
           application = lib.mkOption {
             description = ''
               Options defining an application to be launched using its provided
@@ -84,18 +91,10 @@ in
   };
 
   config = lib.mkIf (config.stylix.testbed.ui != null) {
-    services = {
-      displayManager.gdm.enable = true;
-      desktopManager.gnome.enable = true;
-    };
-
     services.displayManager.autoLogin = {
       enable = true;
       user = user.username;
     };
-
-    # Disable the GNOME tutorial which pops up on first login.
-    environment.gnome.excludePackages = [ pkgs.gnome-tour ];
 
     # for use when application is set
     environment.systemPackages =


### PR DESCRIPTION
This adds `stylix.testbed.ui.desktop` which allows the testbed to pick what desktop environment/window manager will be ran inside the VM.

This PR is currently a PoC and I'm open to any suggestions. I'm actively working on it, so everything is subject to change.

Relevant: https://github.com/danth/stylix/pull/1192#discussion_r2069722780

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [x] Tested locally
- [x] Tested in [testbed](https://stylix.danth.me/testbeds.html)
- [x] Commit message follows [commit convention](https://stylix.danth.me/commit_convention.html)
- [x] Fits [style guide](https://stylix.danth.me/styling.html)
- [x] Respects license of any existing code used

## Notify maintainers

@danth @trueNAHO @awwpotato @Flameopathic 

Who else?

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->
