### PR TITLE
qutebrowser: remove lib.mkDefault option declaration

### DIFF
--- a/modules/qutebrowser/hm.nix
+++ b/modules/qutebrowser/hm.nix
@@ -246,9 +246,9 @@ in
             };
           };
 
-          webpage.preferred_color_scheme = lib.mkIf (config.stylix.polarity == "dark") (
-            lib.mkDefault config.stylix.polarity
-          );
+          webpage.preferred_color_scheme = lib.mkIf (
+            config.stylix.polarity == "dark"
+          ) config.stylix.polarity;
         };
 
         fonts = {


### PR DESCRIPTION
```
Do not declare the
programs.qutebrowser.settings.webpage.preferred_color_scheme option with
lib.mkDefault to avoid accidentally overriding it [1] ("treewide:
declare options with lib.mkDefault").

[1]: https://github.com/danth/stylix/pull/388
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [ ] Tested locally
- [ ] Tested in [testbed](https://stylix.danth.me/testbeds.html)
- [X] Commit message follows [commit convention](https://stylix.danth.me/commit_convention.html)
- [ ] Fits [style guide](https://stylix.danth.me/styling.html)
- [ ] Respects license of any existing code used

## Notify maintainers

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->
