### PR TITLE
xfce: add support for changing the default panel color and the xfce-terminal pallete.

### DIFF
--- a/modules/gtk/gtk.css.mustache
+++ b/modules/gtk/gtk.css.mustache
@@ -15,6 +15,8 @@
 @define-color error_fg_color #{{base00-hex}};
 @define-color window_bg_color #{{base00-hex}};
 @define-color window_fg_color #{{base05-hex}};
+@define-color panel_bg_color #{{base00-hex}};
+@define-color panel_fg_color #{{base05-hex}};
 @define-color view_bg_color #{{base00-hex}};
 @define-color view_fg_color #{{base05-hex}};
 @define-color headerbar_bg_color #{{base01-hex}};

--- a/modules/xfce/hm.nix
+++ b/modules/xfce/hm.nix
@@ -6,35 +6,35 @@
     config.lib.stylix.mkEnableTarget "Xfce" false;
 
   config = lib.mkIf (config.stylix.enable && config.stylix.targets.xfce.enable) {
-    xfconf.settings = with config.stylix.fonts; {
-      xfwm4 = {
+    xfconf.settings = {
+      xfwm4 = with config.stylix.fonts; {
         "general/title_font" = "${sansSerif.name} ${toString sizes.desktop}";
       };
-      xsettings = {
+      xsettings = with config.stylix.fonts; {
         "Gtk/FontName" = "${sansSerif.name} ${toString sizes.applications}";
         "Gtk/MonospaceFontName" = "${monospace.name} ${toString sizes.applications}";
       };
       xfce4-terminal = with config.lib.stylix.colors.withHashtag; {
         "color-palette" = lib.strings.concatStringsSep ";" [
-          "${base00}"
-          "${base08}"
-          "${base0B}"
-          "${base0A}"
-          "${base0D}"
-          "${base0E}"
-          "${base0C}"
-          "${base05}"
-          "${base02}"
-          "${base08}"
-          "${base0B}"
-          "${base0A}"
-          "${base0D}"
-          "${base0E}"
-          "${base0C}"
-          "${base07}"
+          base00
+          base08
+          base0B
+          base0A
+          base0D
+          base0E
+          base0C
+          base05
+          base02
+          base08
+          base0B
+          base0A
+          base0D
+          base0E
+          base0C
+          base07
         ];
-        "color-foreground" = "${base05}";
-        "color-background" = "${base00}";
+        "color-foreground" = base05;
+        "color-background" = base00;
         "color-bold-is-bright" = false;
       };
     };

--- a/modules/xfce/hm.nix
+++ b/modules/xfce/hm.nix
@@ -14,6 +14,29 @@
         "Gtk/FontName" = "${sansSerif.name} ${toString sizes.applications}";
         "Gtk/MonospaceFontName" = "${monospace.name} ${toString sizes.applications}";
       };
+      xfce4-terminal = with config.lib.stylix.colors.withHashtag; {
+        "color-palette" = lib.strings.concatStringsSep ";" [
+          "${base00}"
+          "${base08}"
+          "${base0B}"
+          "${base0A}"
+          "${base0D}"
+          "${base0E}"
+          "${base0C}"
+          "${base05}"
+          "${base02}"
+          "${base08}"
+          "${base0B}"
+          "${base0A}"
+          "${base0D}"
+          "${base0E}"
+          "${base0C}"
+          "${base07}"
+        ];
+        "color-foreground" = "${base05}";
+        "color-background" = "${base00}";
+        "color-bold-is-bright" = false;
+      };
     };
   };
 }


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

1. The xfce panel uses the panel_fg/bg_color colors from the GTK theme, and from the stylix generated theme, it doesn't find them and sets all panel backgrounds to rgb 0 0 0.
2. Added support for theming xfce4-terminal via the xfce target. 

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [x] Tested locally
- [ ] Tested in [testbed](https://stylix.danth.me/testbeds.html)
- [x] Commit message follows [commit convention](https://stylix.danth.me/commit_convention.html)
- [x] Fits [style guide](https://stylix.danth.me/styling.html)
- [x] Respects license of any existing code used

## Notify maintainers
<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->
@danth