### PR TITLE
Add `mkEnableTargetWith` and use it for documenting dynamic `autoEnable` conditions

### DIFF
--- a/doc/src/modules.md
+++ b/doc/src/modules.md
@@ -106,6 +106,13 @@ the following applies:
 - There is no reliable way to detect whether the target is installed, *and*
 enabling it unconditionally would cause problems.
 
+> [!CAUTION]
+> The boolean value after `mkEnableTarget` should usually be a static `true` or
+> `false` literal.
+>
+> Using a dynamic value requires you to document the dynamic expression using
+> `mkEnableTargetWith`'s `autoEnableExpr` argument.
+
 ### Overlays
 
 If your module is provided as an overlay it uses a special format, where config

--- a/modules/feh/hm.nix
+++ b/modules/feh/hm.nix
@@ -15,6 +15,14 @@ mkTarget {
     || i3.enable
     || spectrwm.enable
     || xmonad.enable;
+  autoEnableExpr = ''
+    with config.xsession.windowManager;
+    bspwm.enable
+    || herbstluftwm.enable
+    || i3.enable
+    || spectrwm.enable
+    || xmonad.enable
+  '';
 
   configElements =
     { imageScalingMode, image }:

--- a/modules/feh/nixos.nix
+++ b/modules/feh/nixos.nix
@@ -11,6 +11,10 @@ mkTarget {
   autoEnable =
     with config.services.xserver.windowManager;
     xmonad.enable || i3.enable;
+  autoEnableExpr = ''
+    with services.xserver.windowManager;
+    xmonad.enable || i3.enable
+  '';
 
   configElements =
     { image, imageScalingMode }:

--- a/modules/gnome/hm.nix
+++ b/modules/gnome/hm.nix
@@ -44,7 +44,11 @@ let
 in
 {
   options.stylix.targets.gnome = {
-    enable = config.lib.stylix.mkEnableTarget "GNOME" pkgs.stdenv.hostPlatform.isLinux;
+    enable = config.lib.stylix.mkEnableTargetWith {
+      name = "GNOME";
+      autoEnable = pkgs.stdenv.hostPlatform.isLinux;
+      autoEnableExpr = "pkgs.stdenv.hostPlatform.isLinux";
+    };
     useWallpaper = config.lib.stylix.mkEnableWallpaper "GNOME" true;
   };
 

--- a/modules/hyprland/hm.nix
+++ b/modules/hyprland/hm.nix
@@ -7,9 +7,11 @@
 mkTarget {
   name = "hyprland";
   humanName = "Hyprland";
-  extraOptions.hyprpaper.enable = config.lib.stylix.mkEnableTarget "Hyprpaper" (
-    config.stylix.image != null
-  );
+  extraOptions.hyprpaper.enable = config.lib.stylix.mkEnableTargetWith {
+    name = "Hyprpaper";
+    autoEnable = config.stylix.image != null;
+    autoEnableExpr = "stylix.image != null";
+  };
   configElements = [
     (
       { colors }:

--- a/modules/qt/hm.nix
+++ b/modules/qt/hm.nix
@@ -13,9 +13,11 @@
     #
     # [1]: https://github.com/nix-community/stylix/issues/933
     # [2]: https://github.com/nix-community/home-manager/issues/6565
-    enable = config.lib.stylix.mkEnableTarget "QT" (
-      pkgs.stdenv.hostPlatform.isLinux && osConfig != null
-    );
+    enable = config.lib.stylix.mkEnableTargetWith {
+      name = "QT";
+      autoEnable = pkgs.stdenv.hostPlatform.isLinux && osConfig != null;
+      autoEnableExpr = "pkgs.stdenv.hostPlatform.isLinux && osConfig != null";
+    };
 
     platform = lib.mkOption {
       description = ''

--- a/modules/qt/nixos.nix
+++ b/modules/qt/nixos.nix
@@ -1,9 +1,4 @@
-{
-  lib,
-  pkgs,
-  config,
-  ...
-}:
+{ lib, config, ... }:
 
 let
 
@@ -16,7 +11,7 @@ let
 in
 {
   options.stylix.targets.qt = {
-    enable = config.lib.stylix.mkEnableTarget "QT" pkgs.stdenv.hostPlatform.isLinux;
+    enable = config.lib.stylix.mkEnableTarget "QT" true;
     platform = lib.mkOption {
       description = ''
         Selects the platform theme to use for Qt applications.

--- a/modules/swaylock/hm.nix
+++ b/modules/swaylock/hm.nix
@@ -26,15 +26,19 @@ in
     })
   ];
   options.stylix.targets.swaylock = {
-    enable =
-      config.lib.stylix.mkEnableTarget "Swaylock"
-        # When the state version is older than 23.05, Swaylock enables itself
-        # automatically if `settings != {}` [1]. Therefore, Swaylock theming
-        # shouldn't be enabled by default for such state versions, to avoid
-        # inadvertently installing Swaylock when it's not desired.
-        #
-        # [1]: https://github.com/nix-community/home-manager/blob/5cfbf5cc37a3bd1da07ae84eea1b828909c4456b/modules/programs/swaylock.nix#L12-L17
-        (lib.versionAtLeast config.home.stateVersion "23.05");
+    enable = config.lib.stylix.mkEnableTargetWith {
+      name = "Swaylock";
+      # When the state version is older than 23.05, Swaylock enables itself
+      # automatically if `settings != {}` [1]. Therefore, Swaylock theming
+      # shouldn't be enabled by default for such state versions, to avoid
+      # inadvertently installing Swaylock when it's not desired.
+      #
+      # [1]: https://github.com/nix-community/home-manager/blob/5cfbf5cc37a3bd1da07ae84eea1b828909c4456b/modules/programs/swaylock.nix#L12-L17
+      autoEnable = lib.versionAtLeast config.home.stateVersion "23.05";
+      autoEnableExpr = ''
+        lib.versionAtLeast home.stateVersion "23.05"
+      '';
+    };
 
     useWallpaper = config.lib.stylix.mkEnableWallpaper "Swaylock" true;
   };

--- a/stylix/mk-target.nix
+++ b/stylix/mk-target.nix
@@ -66,6 +66,27 @@
       This should be disabled if manual setup is required or if auto-enabling
       causes issues.
 
+      The default (`true`) is inherited from `mkEnableTargetWith`.
+
+    `autoEnableExpr` (String)
+    : A string representation of `autoEnable`, for use in documentation.
+
+      Not required if `autoEnable` is a literal `true` or `false`, but **must**
+      be used when `autoEnable` is a dynamic expression.
+
+      E.g. `"pkgs.stdenv.hostPlatform.isLinux"`.
+
+    `autoWrapEnableExpr` (Boolean)
+    : Whether to automatically wrap `autoEnableExpr` with parenthesis, when it
+      contains a potentially problematic infix.
+
+      The default (`true`) is inherited from `mkEnableTargetWith`.
+
+    `enableExample` (Boolean or literal expression)
+    : An example to include on the enable option. The default is calculated
+      automatically by `mkEnableTargetWith` and depends on `autoEnable` and
+      whether an `autoEnableExpr` is used.
+
     `extraOptions` (Attribute set)
     : Additional options to be added in the `stylix.targets.${name}` namespace
       along the `stylix.targets.${name}.enable` option.
@@ -152,12 +173,15 @@
 {
   name,
   humanName,
-  autoEnable ? true,
+  autoEnable ? null,
+  autoEnableExpr ? null,
+  autoWrapEnableExpr ? null,
+  enableExample ? null,
   extraOptions ? { },
   configElements ? [ ],
   generalConfig ? null,
   imports ? [ ],
-}:
+}@args:
 let
   module =
     { config, lib, ... }:
@@ -212,7 +236,19 @@ let
       inherit imports;
 
       options.stylix.targets.${name}.enable =
-        config.lib.stylix.mkEnableTarget humanName autoEnable;
+        let
+          enableArgs =
+            {
+              name = humanName;
+            }
+            // lib.optionalAttrs (args ? autoEnable) { inherit autoEnable; }
+            // lib.optionalAttrs (args ? autoEnableExpr) { inherit autoEnableExpr; }
+            // lib.optionalAttrs (args ? autoWrapEnableExpr) {
+              autoWrapExpr = autoWrapEnableExpr;
+            }
+            // lib.optionalAttrs (args ? enableExample) { example = enableExample; };
+        in
+        config.lib.stylix.mkEnableTargetWith enableArgs;
 
       config = lib.mkIf (config.stylix.enable && cfg.enable) (
         lib.mkMerge (

--- a/stylix/target.nix
+++ b/stylix/target.nix
@@ -38,9 +38,16 @@
     in
     {
       mkEnableTarget =
-        humanName: autoEnable:
+        name: autoEnable:
+        config.lib.stylix.mkEnableTargetWith { inherit name autoEnable; };
+
+      mkEnableTargetWith =
+        {
+          name,
+          autoEnable ? true,
+        }:
         self.mkEnableIf {
-          description = "Whether to enable theming for ${humanName}.";
+          description = "Whether to enable theming for ${name}.";
           default = cfg.autoEnable && autoEnable;
           ${if autoEnable then "defaultText" else null} =
             lib.literalExpression "stylix.autoEnable";

--- a/stylix/target.nix
+++ b/stylix/target.nix
@@ -44,7 +44,7 @@
           example = !autoEnable;
         }
         // lib.optionalAttrs autoEnable {
-          defaultText = lib.literalMD "same as `stylix.autoEnable`";
+          defaultText = lib.literalExpression "stylix.autoEnable";
         };
       mkEnableWallpaper =
         humanName: autoEnable:
@@ -55,7 +55,7 @@
           type = lib.types.bool;
         }
         // lib.optionalAttrs autoEnable {
-          defaultText = lib.literalMD "`stylix.image != null`";
+          defaultText = lib.literalExpression "stylix.image != null";
         };
     };
 }

--- a/stylix/target.nix
+++ b/stylix/target.nix
@@ -34,28 +34,44 @@
   config.lib.stylix =
     let
       cfg = config.stylix;
+      self = config.lib.stylix;
     in
     {
       mkEnableTarget =
         humanName: autoEnable:
-        lib.mkEnableOption "theming for ${humanName}"
-        // {
+        self.mkEnableIf {
+          description = "Whether to enable theming for ${humanName}.";
           default = cfg.autoEnable && autoEnable;
+          ${if autoEnable then "defaultText" else null} =
+            lib.literalExpression "stylix.autoEnable";
           example = !autoEnable;
-        }
-        // lib.optionalAttrs autoEnable {
-          defaultText = lib.literalExpression "stylix.autoEnable";
         };
+
       mkEnableWallpaper =
         humanName: autoEnable:
-        lib.mkOption {
-          default = config.stylix.image != null && autoEnable;
-          example = config.stylix.image == null;
+        self.mkEnableIf {
           description = "Whether to set the wallpaper for ${humanName}.";
+          default = config.stylix.image != null && autoEnable;
+          defaultText =
+            if autoEnable then lib.literalExpression "stylix.image != null" else false;
+          example = config.stylix.image == null;
+        };
+
+      mkEnableIf =
+        {
+          description,
+          default,
+          defaultText ? null,
+          example ? if args ? defaultText then true else !default,
+        }@args:
+        lib.mkOption {
           type = lib.types.bool;
-        }
-        // lib.optionalAttrs autoEnable {
-          defaultText = lib.literalExpression "stylix.image != null";
+          defaultText = if args ? defaultText then defaultText else default;
+          inherit
+            default
+            description
+            example
+            ;
         };
     };
 }


### PR DESCRIPTION
> [!NOTE]
> This PR is comprised of intentionally separate commits, please don't squash :slightly_smiling_face:

This is a solution to the issues uncovered by #1212. This should fix #98 (not tested).

- Avoid evaluating dynamic conditions while rendering the docs.
- Define literal expressions describing dynamic conditions.
- Tested: all workarounds can be removed in [#1212](https://github.com/danth/stylix/pull/1212), when merged with this PR.

Previously, the literal markdown `` same as `stylix.autoEnable` `` was used. When an additional `conditionText` is supplied, it will now use the literal expression ``  stylix.autoEnable && ${expr} ``.

If the `expr` contains any [nix operators](https://nix.dev/manual/nix/2.28/language/operators) with a lower priority than `&&`, it will be auto-wrapped in parentheses, unless `autoWrapExpr = false` is used.

![image](https://github.com/user-attachments/assets/96adb39c-5c84-4168-b5be-bcd7ee30cf73)

![image](https://github.com/user-attachments/assets/b7dd121a-50cb-4c64-a797-e91ca0636a10)


We could stick with the previous markdown approach, but I'm unsure what the best way to approach merging it with a `autoEnableExpr` or `autoEnableText` or `autoEnableMD` style arg would be. Suggestions and/or followup PRs welcome.



<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [x] Tested locally
- [ ] Tested in [testbed](https://stylix.danth.me/testbeds.html)
- [x] Commit message follows [commit convention](https://stylix.danth.me/commit_convention.html)
- [ ] Fits [style guide](https://stylix.danth.me/styling.html)
- [ ] Respects license of any existing code used

## Notify relevant people 

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->

- @Flameopathic : related to `mkTarget`
