### PR TITLE
treewide: adjust notification colors to represent urgency

### DIFF
--- a/doc/src/styling.md
+++ b/doc/src/styling.md
@@ -86,10 +86,10 @@ over other applications. Examples include the mako notification daemon and
 avizo.
 
 - Window border: base0D
-- Low urgency background color: base06
-- Low urgency text color: base0A
-- High urgency background color: base0F
-- High urgency text color: base08
+- Background color: base00
+- Text color: base05
+- High urgency border color: base08
+- Low urgency border color: base03
 - Incomplete part of progress bar: base01
 - Complete part of progress bar: base02
 

--- a/modules/dunst/hm.nix
+++ b/modules/dunst/hm.nix
@@ -29,13 +29,13 @@ mkTarget {
             urgency_low = {
               background = base01 + dunstOpacity;
               foreground = base05;
-              frame_color = base0B;
+              frame_color = base03;
             };
 
             urgency_normal = {
               background = base01 + dunstOpacity;
               foreground = base05;
-              frame_color = base0E;
+              frame_color = base0D;
             };
 
             urgency_critical = {

--- a/modules/fnott/hm.nix
+++ b/modules/fnott/hm.nix
@@ -42,8 +42,8 @@ mkTarget {
               background = bg base00;
             };
 
-            low.border-color = fg base0B;
-            normal.border-color = fg base0E;
+            low.border-color = fg base03;
+            normal.border-color = fg base0D;
             critical.border-color = fg base08;
           };
       }

--- a/modules/mako/hm.nix
+++ b/modules/mako/hm.nix
@@ -28,12 +28,12 @@ mkTarget {
 
               "urgency=low" = {
                 background-color = "${base00}${makoOpacity}";
-                border-color = base0D;
+                border-color = base03;
                 text-color = base0A;
               };
               "urgency=high" = {
                 background-color = "${base00}${makoOpacity}";
-                border-color = base0D;
+                border-color = base08;
                 text-color = base08;
               };
             };

--- a/modules/mako/hm.nix
+++ b/modules/mako/hm.nix
@@ -29,12 +29,12 @@ mkTarget {
               "urgency=low" = {
                 background-color = "${base00}${makoOpacity}";
                 border-color = base03;
-                text-color = base0A;
+                text-color = base05;
               };
               "urgency=high" = {
                 background-color = "${base00}${makoOpacity}";
                 border-color = base08;
-                text-color = base08;
+                text-color = base05;
               };
             };
           };

--- a/modules/swaync/base.css
+++ b/modules/swaync/base.css
@@ -47,7 +47,6 @@ trough {
 .notification-action {
   color: @base05;
   background: @base01;
-  border: 1px solid @base0D;
 }
 
 .notification-action:hover {

--- a/modules/swaync/base.css
+++ b/modules/swaync/base.css
@@ -8,12 +8,18 @@ trough {
   background: @base01;
 }
 
-.notification.low,
+.notification.low {
+  border: 1px solid @base03;
+}
+
+.notification.low progress {
+  background: @base03;
+}
+
 .notification.normal {
   border: 1px solid @base0D;
 }
 
-.notification.low progress,
 .notification.normal progress {
   background: @base0F;
 }


### PR DESCRIPTION
- **dunst: change colors for low priority to base03 and default priority to base0D**
- **fnott: change colors for low priority to base03 and default priority to base0D**
- **mako: change colors for low priority to base03 and default priority to base0D**
- **swaync: change colors for low priority to base03 and default priority to base0D**

This change helps new users quickly distinguish whether a notification is
important. Previously, every notification had a colored border, which made even
low-priority messages appear urgent or significant. Closes #1247.

<details>
<summary>dunst</summary>

![image](https://github.com/user-attachments/assets/9d95ff25-5528-4b7a-b44a-f4cf848aa601)
(dunst looks weird as the default config does not have space between notifications)
</details>

<details>
<summary>fnott</summary>

![image](https://github.com/user-attachments/assets/dfb578d3-29fd-4767-8249-d614c00fa912)
</details>

<details>
<summary>mako</summary>

![image](https://github.com/user-attachments/assets/f4a2b3f4-7c32-4917-90a8-e11bf234c74e)
</details>

<details>
<summary>swaync</summary>

![image](https://github.com/user-attachments/assets/54f1af64-1569-4e9b-902e-f1c33a76eb8a)
(SwayNC looked really weird, but I seem to have fixed it with the last commit)
</details>

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->

- [x] Tested locally
- [ ] Tested in [testbed](https://stylix.danth.me/testbeds.html)
- [x] Commit message follows [commit convention](https://stylix.danth.me/commit_convention.html)
- [x] Fits [style guide](https://stylix.danth.me/styling.html)
- [x] Respects license of any existing code used

## Notify maintainers

@naho @awwpotato @mateusauler @themaxmur

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->
