### PR TITLE
doc: simplify 'Development Setup' section

### DIFF
--- a/docs/src/modules.md
+++ b/docs/src/modules.md
@@ -5,12 +5,19 @@
 Currently the easiest way to test Stylix is to use the new code in your actual
 configuration.
 
-You might find it useful to change the flake reference in your configuration
-from `github:nix-community/stylix` to `git+file:/home/user/path/to/stylix` so that you
-don't need to push your changes to GitHub during testing.
+You might find it useful to override Stylix' input flake reference on your
+flake, from `github:nix-community/stylix` to
+`git+file:/home/user/path/to/stylix`, so that you don't need to push changes to
+GitHub during testing.
 
-Then, remember to run `nix flake lock --update-input stylix` to refresh the
-flake each time you make an edit.
+To do that, instead of editing your `flake.nix`, you can leverage `nix`'
+`--override-input` parameter (which can also be supplied through their
+frontends: `nixos-rebuild`, `nix-on-droid` and even `nh`). It allows you to
+deploy your changes in one fell swoop, without having to update the lock file of
+your flake every time you make an edit.
+
+Just append `--override-input stylix git+file:/home/user/path/to/stylix` to your
+standard `nix` (or `nix` frontend) incantation.
 
 Nix only reads files which are tracked by Git, so you also need to `git add
 «file»` after creating a new file.


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

By leveraging nix’ `--override-input` parameter, we spare the user from having to run `nix flake lock --update-input stylix` after every edit of their local Stylix fork.

“But, `nix-on-droid` does not support that flag!”, you might say.
Well, now it [does](https://github.com/nix-community/nix-on-droid/pull/457), muahaha!

EDIT: the following table was going to be part of the PR, but was ultimately discarded. I’ll leave it here to support the changes to the docs.

- On NixOS

  ```console
  # nixos-rebuild switch --override-input stylix git+file:/home/user/path/to/stylix
  ```

- or, equivalently

  ```console
  $ nix build .#nixosConfigurations.«hostname».config.system.build.toplevel --override-input stylix git+file:/home/user/path/to/stylix
  # result/bin/switch-to-configuration switch
  ```

- On Nix-Darwin

  ```console
  $ nix build .#darwinConfigurations.«hostname».system
  $ ./result/sw/bin/darwin-rebuild switch
  ```

- On Nix-on-Droid

  ```console
  $ nix-on-droid switch --flake .#«device» --override-input stylix git+file:/home/user/path/to/stylix
  ```

- With NH

  ```console
  $ nh {os,home,darwin} {switch,test,build,etc} -- --override-input stylix git+file:/home/user/path/to/stylix
  ```




## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [x] Tested locally
- [ ] Tested in [testbed](https://stylix.danth.me/testbeds.html)
- [x] Commit message follows [commit convention](https://stylix.danth.me/commit_convention.html)
- [x] Fits [style guide](https://stylix.danth.me/styling.html)
- [x] Respects license of any existing code used

## Notify maintainers

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->
@awwpotato @danth @Flameopathic  @trueNAHO