### PR TITLE
ci: add workflow to label merge conflicts

### DIFF
--- a/.github/workflows/conflicts.yml
+++ b/.github/workflows/conflicts.yml
@@ -1,0 +1,27 @@
+---
+name: Label Merge Conflicts
+
+on:  # yamllint disable-line rule:truthy
+  push:
+    branches:
+      - master
+      - release-**
+
+jobs:
+  conflicts:
+    runs-on: ubuntu-24.04
+    if: github.repository_owner == 'nix-community'
+    steps:
+      - uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          permission-contents: read
+          permission-pull-requests: write
+      - uses: mschilde/auto-label-merge-conflicts@v2
+        with:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          CONFLICT_LABEL_NAME: "status: merge conflict"
+          MAX_RETRIES: 5
+          WAIT_MS: 10000


### PR DESCRIPTION
makes it much more obvious when a pr has a merge conflict, also used by home-manager and nixpkgs

note this is somewhat related to https://github.com/danth/stylix/pull/1256

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [ ] Tested locally
- [ ] Tested in [testbed](https://stylix.danth.me/testbeds.html)
- [x] Commit message follows [commit convention](https://stylix.danth.me/commit_convention.html)
- [ ] Fits [style guide](https://stylix.danth.me/styling.html)
- [ ] Respects license of any existing code used

## Notify maintainers

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->
