### PR TITLE
stylix: add config.lib.stylix.{mkHexColor,mkOpacityHexColor} functions

### DIFF
--- a/doc/src/modules.md
+++ b/doc/src/modules.md
@@ -182,6 +182,15 @@ individually.
 Also note that reading generated files with `builtins.readFile` can be very slow
 and should be avoided.
 
+
+### Hexadecimal colors
+
+- config.lib.stylix.mkHexColor`: Converts a hex `color` (e.g., `RRGGBB` or
+  `#RRGGBB`) to `0xRRGGBB`.
+
+- `config.lib.stylix.mkOpacityHexColor`: Converts a hex `color` and `opacity`
+  (0–1) to `0xRRGGBBAA`.
+
 ## How to apply other things
 
 For everything else, like fonts and wallpapers, you can just take option values

--- a/modules/river/hm.nix
+++ b/modules/river/hm.nix
@@ -6,14 +6,14 @@
   config = lib.mkIf (config.stylix.enable && config.stylix.targets.river.enable) {
     wayland.windowManager.river.settings =
       let
-        inherit (config.lib.stylix) colors;
+        inherit (config.lib.stylix) colors mkHexColor;
         inherit (config.stylix) cursor;
       in
       {
-        border-color-focused = "0x${colors.base0D}";
-        border-color-unfocused = "0x${colors.base03}";
-        border-color-urgent = "0x${colors.base08}";
-        background-color = "0x${colors.base00}";
+        border-color-focused = mkHexColor colors.base0D;
+        border-color-unfocused = mkHexColor colors.base03;
+        border-color-urgent = mkHexColor colors.base08;
+        background-color = mkHexColor colors.base00;
         xcursor-theme = lib.mkIf (
           config.stylix.cursor != null
         ) "${cursor.name} ${toString cursor.size}";

--- a/stylix/colors.nix
+++ b/stylix/colors.nix
@@ -1,0 +1,16 @@
+{ lib, ... }:
+{
+  config.lib.stylix = {
+    mkHexColor = color: "0x${lib.removePrefix "#" color}";
+
+    mkOpacityHexColor =
+      let
+        opacityHex =
+          percentage:
+          lib.throwIfNot (percentage >= 0 && percentage <= 1)
+            "value must be between 0 and 1 (inclusive): ${toString percentage}"
+            (lib.toHexString (builtins.floor (percentage * 255 + 0.5)));
+      in
+      color: opacity: "0x${opacityHex opacity}${lib.removePrefix "#" color}";
+  };
+}

--- a/stylix/darwin/default.nix
+++ b/stylix/darwin/default.nix
@@ -9,6 +9,7 @@ in
 {
   imports = [
     ./palette.nix
+    ../colors.nix
     ../fonts.nix
     ../home-manager-integration.nix
     ../opacity.nix

--- a/stylix/droid/default.nix
+++ b/stylix/droid/default.nix
@@ -6,6 +6,7 @@ in
   imports = [
     ./fonts.nix
     ./palette.nix
+    ../colors.nix
     ../fonts.nix
     ../home-manager-integration.nix
     ../opacity.nix

--- a/stylix/hm/default.nix
+++ b/stylix/hm/default.nix
@@ -11,6 +11,7 @@ in
     ./cursor.nix
     ./icons.nix
     ./palette.nix
+    ../colors.nix
     ../cursor.nix
     ../fonts.nix
     ../icons.nix

--- a/stylix/nixos/default.nix
+++ b/stylix/nixos/default.nix
@@ -10,6 +10,7 @@ in
   imports = [
     ./cursor.nix
     ./palette.nix
+    ../colors.nix
     ../cursor.nix
     ../fonts.nix
     ../home-manager-integration.nix


### PR DESCRIPTION
Adds essential repeating functions for hex color as seen in #838 and river.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [x] Tested locally
- [ ] Tested in [testbed](https://stylix.danth.me/testbeds.html)
- [x] Commit message follows [commit convention](https://stylix.danth.me/commit_convention.html)
- [x] Fits [style guide](https://stylix.danth.me/styling.html)
- [x] Respects license of any existing code used

## Notify maintainers

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->
