### PR TITLE
stylix: improve how discord testbed is disabled

### DIFF
--- a/flake/packages.nix
+++ b/flake/packages.nix
@@ -7,46 +7,28 @@
 {
 
   perSystem =
-    {
-      pkgs,
-      system,
-      config,
-      ...
-    }:
+    { pkgs, config, ... }:
     {
       # Build all packages with 'nix flake check' instead of only verifying they
       # are derivations.
       checks = config.packages;
 
-      packages =
-        let
-          testbedPackages = import "${self}/stylix/testbed.nix" {
+      packages = lib.mkMerge [
+        # Testbeds are virtual machines based on NixOS, therefore they are
+        # only available for Linux systems.
+        (lib.mkIf pkgs.stdenv.hostPlatform.isLinux (
+          import "${self}/stylix/testbed.nix" {
             inherit pkgs inputs lib;
-          };
-
-          # Discord is not available on arm64. This workaround filters out
-          # testbeds using that package, until we have a better way to handle
-          # this.
-          testbedPackages' =
-            if system == "aarch64-linux" then
-              lib.filterAttrs (
-                name: _: !lib.hasPrefix "testbed:discord:vencord" name
-              ) testbedPackages
-            else
-              testbedPackages;
-        in
-        lib.mkMerge [
-          # Testbeds are virtual machines based on NixOS, therefore they are
-          # only available for Linux systems.
-          (lib.mkIf pkgs.stdenv.hostPlatform.isLinux testbedPackages')
-          {
-            docs = pkgs.callPackage "${self}/doc" {
-              inherit inputs;
-              inherit (inputs.nixpkgs.lib) nixosSystem;
-              inherit (inputs.home-manager.lib) homeManagerConfiguration;
-            };
-            palette-generator = pkgs.callPackage "${self}/palette-generator" { };
           }
-        ];
+        ))
+        {
+          docs = pkgs.callPackage "${self}/doc" {
+            inherit inputs;
+            inherit (inputs.nixpkgs.lib) nixosSystem;
+            inherit (inputs.home-manager.lib) homeManagerConfiguration;
+          };
+          palette-generator = pkgs.callPackage "${self}/palette-generator" { };
+        }
+      ];
     };
 }

--- a/modules/discord/testbeds/vencord.nix
+++ b/modules/discord/testbeds/vencord.nix
@@ -6,9 +6,14 @@ let
   };
 in
 {
-  stylix.testbed.ui.application = {
-    name = "discord";
-    inherit package;
+  stylix.testbed = {
+    # Discord is not available on arm64.
+    enable = lib.meta.availableOn pkgs.stdenv.hostPlatform package;
+
+    ui.application = {
+      name = "discord";
+      inherit package;
+    };
   };
 
   environment.systemPackages = [ package ];

--- a/stylix/testbed.nix
+++ b/stylix/testbed.nix
@@ -189,8 +189,8 @@ let
   makeTestbed =
     testbed: stylix:
     let
-      name = builtins.concatStringsSep testbedFieldSeparator (
-        map
+      name =
+        lib.concatMapStringsSep testbedFieldSeparator
           (
             field:
             lib.throwIf (lib.hasInfix testbedFieldSeparator field)
@@ -205,8 +205,7 @@ let
             "image${lib.optionalString (stylix.image or null == null) "less"}"
             "scheme${lib.optionalString (stylix.base16Scheme or null == null) "less"}"
             "cursor${lib.optionalString (stylix.cursor or null == null) "less"}"
-          ]
-      );
+          ];
 
       system = lib.nixosSystem {
         inherit (pkgs) system;

--- a/stylix/testbed.nix
+++ b/stylix/testbed.nix
@@ -37,6 +37,28 @@ let
       };
     };
 
+  enableModule =
+    { lib, config, ... }:
+    {
+      options.stylix.testbed.enable = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        example = lib.literalExpression "lib.meta.availableOn pkgs.stdenv.hostPlatform pkgs.discord";
+        description = ''
+          Whether to enable this testbed.
+
+          The testbed will not be included as a flake output if set to false.
+        '';
+      };
+
+      config.assertions = [
+        {
+          assertion = config.stylix.testbed.enable;
+          message = "Building a disabled testbed. This testbed should have been filtered out!";
+        }
+      ];
+    };
+
   applicationModule =
     { config, lib, ... }:
     {
@@ -217,6 +239,7 @@ let
 
         modules = [
           commonModule
+          enableModule
           applicationModule
           inputs.self.nixosModules.stylix
           inputs.home-manager.nixosModules.home-manager
@@ -228,6 +251,8 @@ let
           }
         ];
       };
+
+      inherit (system.config.stylix.testbed) enable;
 
       script = pkgs.writeShellApplication {
         inherit name;
@@ -248,7 +273,7 @@ let
         '';
       };
     in
-    {
+    lib.optionalAttrs enable {
       ${name} = script;
     };
 

--- a/stylix/testbed.nix
+++ b/stylix/testbed.nix
@@ -305,5 +305,5 @@ in
 # Testbeds are merged using lib.attrsets.unionOfDisjoint to throw an error if
 # testbed names collide.
 builtins.foldl' lib.attrsets.unionOfDisjoint { } (
-  lib.flatten (map makeTestbeds autoload)
+  builtins.concatMap makeTestbeds autoload
 )


### PR DESCRIPTION
> [!NOTE]
> This PR includes some commits that do not make sense to be squashed, such as slightly off-topic cleanup and refactoring.

- **stylix: use `concatMapStringSep` in testbed.nix**
- **stylix: use `concatMap` in testbeds.nix**
- **stylix: refactor textbed.nix autoload**
- **stylix: add testbed enable option**
- **stylix: use a cheaper module eval for the `enable` option**
- **discord: use new enable option for testbed**


### Summary

I've added a `stylix.testbed.enable` option to testbeds.

When set to false, the testbed is not included in the output of `stylix/testbed.nix`.

> ### enable
>
> Whether to enable this testbed.
>
> The testbed will not be included as a flake output if set to false;
>
> > [!CAUTION]
> >
> > This option's value can only evaluate `lib` and `pkgs` inputs,
> > if it reads other inputs, the testbed will fail to evaluate;
> > e.g., `config` or `options`.
> >
> > This restriction was made for performance reasons.
> > See `isEnabled`.
>
> *Type*: `boolean`
> *Default*: `true`
> *Example*: `lib.meta.availableOn pkgs.stdenv.hostPlatform pkgs.discord`


### Discord

This is used to make the discord testbed conditional:

```nix
# Discord is not available on arm64.
stylix.testbed.enable = lib.meta.availableOn pkgs.stdenv.hostPlatform package;
```


### Performance

I found in testing that needing to evaluate the testbed system configurations is somewhat expensive, which was causing `nix flake show` to hang as it needed to read the `enable` option from each testbed before knowing what flake outputs exist.

I've solved this by adding a second, _much cheaper_ minimal configuration, which only evals the testbed module without any nixos modules. This has plenty of downsides, but we're unlikely to run into any of them here.

### Potential future issues

The most likely issue would be a testbed module requesting a non-standard module arg, such as `osConfig`. This could be solved by adding some stub args to the miminal eval's `_module.args`.

Another issue may be the enable option value depending on an overlayed `pkgs` instance. This could be solved by declaring the `nixpkgs.overlays` option, and applying it to `_module.args.pkgs`.

It is also possible that the `enable` option would want to depend on another `config` value usually present in a system configuration. This cannot be supported without massive performance hits.

However given that you currently only use this option for one module, and it will be rare to use it in others, the chances of these restrictions causing problems seem low.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [x] Tested locally
- [ ] Tested in [testbed](https://stylix.danth.me/testbeds.html)
- [x] Commit message follows [commit convention](https://stylix.danth.me/commit_convention.html)
- [ ] Fits [style guide](https://stylix.danth.me/styling.html)
- [ ] Respects license of any existing code used

## Notify maintainers

- Discord: @Flameopathic
