### PR TITLE
fontconfig: align Home Manager with NixOS and enhance docs

### DIFF
--- a/doc/src/configuration.md
+++ b/doc/src/configuration.md
@@ -111,6 +111,18 @@ or at `~/.config/stylix/palette.html` on Home Manager.
 
 ## Fonts
 
+Fonts can apply in three ways:
+
+1. An app's own font options
+  (e.g. [the Alacritty module](./options/modules/alacritty.html) sets home-manager's
+  `programs.alacritty.settings.font`).
+
+2. Widely, through
+  [the Fontconfig module](./options/modules/fontconfig.html).
+
+3. Made available in an environment using
+  [the font packages module](./options/modules/font-packages.html).
+
 The default combination of fonts is:
 
 ```nix

--- a/modules/font-packages/meta.nix
+++ b/modules/font-packages/meta.nix
@@ -6,10 +6,6 @@
     This module makes the Stylix fonts available in the environment of each of
     the platforms that this module supports.
 
-    ### Related modules
-
-    <!-- If updating this section, make sure to update it on the linked pages too. -->
-
-    - [Fontconfig](fontconfig.md)
+    Also see [general fonts documentation](../../configuration.html#fonts).
   '';
 }

--- a/modules/fontconfig/fontconfig.nix
+++ b/modules/fontconfig/fontconfig.nix
@@ -1,0 +1,16 @@
+{ mkTarget }:
+mkTarget {
+  name = "fontconfig";
+  humanName = "Fontconfig";
+
+  configElements =
+    { fonts }:
+    {
+      fonts.fontconfig.defaultFonts = {
+        monospace = [ fonts.monospace.name ];
+        serif = [ fonts.serif.name ];
+        sansSerif = [ fonts.sansSerif.name ];
+        emoji = [ fonts.emoji.name ];
+      };
+    };
+}

--- a/modules/fontconfig/hm.nix
+++ b/modules/fontconfig/hm.nix
@@ -1,9 +1,6 @@
-{ mkTarget, ... }:
-mkTarget {
-  name = "fontconfig";
-  humanName = "Fontconfig";
-
-  configElements = {
-    fonts.fontconfig.enable = true;
-  };
+{ lib, mkTarget, ... }:
+{
+  imports = [
+    (lib.modules.importApply ./fontconfig.nix { inherit mkTarget; })
+  ];
 }

--- a/modules/fontconfig/meta.nix
+++ b/modules/fontconfig/meta.nix
@@ -4,14 +4,9 @@
   homepage = "https://fontconfig.org";
   maintainers = [ lib.maintainers.mightyiam ];
   description = ''
-    On NixOS, `fonts.fontconfig.defaultFonts` options are declared without
-    enabling `fonts.fontconfig.enable`. On Home Manager, only the
-    `fonts.fontconfig.enable` option is declared and enabled.
+    This module adds the Stylix fonts to `fonts.fontconfig.defaultFonts` in
+    each of the platforms that this module supports.
 
-    ### Related modules
-
-    <!-- If updating this section, make sure to update it on the linked pages too. -->
-
-    - [Font packages](font-packages.md)
+    Also see [general fonts documentation](../../configuration.html#fonts).
   '';
 }

--- a/modules/fontconfig/nixos.nix
+++ b/modules/fontconfig/nixos.nix
@@ -1,16 +1,6 @@
-{ mkTarget, ... }:
-mkTarget {
-  name = "fontconfig";
-  humanName = "Fontconfig";
-
-  configElements =
-    { fonts }:
-    {
-      fonts.fontconfig.defaultFonts = {
-        monospace = [ fonts.monospace.name ];
-        serif = [ fonts.serif.name ];
-        sansSerif = [ fonts.sansSerif.name ];
-        emoji = [ fonts.emoji.name ];
-      };
-    };
+{ lib, mkTarget, ... }:
+{
+  imports = [
+    (lib.modules.importApply ./fontconfig.nix { inherit mkTarget; })
+  ];
 }


### PR DESCRIPTION
Not much to see here...

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [x] Tested locally
- [ ] Tested in [testbed](https://stylix.danth.me/testbeds.html)
- [x] Commit message follows [commit convention](https://stylix.danth.me/commit_convention.html)
- [x] Fits [style guide](https://stylix.danth.me/styling.html)
- [x] Respects license of any existing code used

## Notify maintainers

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->
