### PR TITLE
gnome: update CSS to version 48.1

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -182,16 +182,16 @@
     "gnome-shell": {
       "flake": false,
       "locked": {
-        "lastModified": 1732369855,
-        "narHash": "sha256-JhUWbcYPjHO3Xs3x9/Z9RuqXbcp5yhPluGjwsdE2GMg=",
+        "lastModified": 1744584021,
+        "narHash": "sha256-0RJ4mJzf+klKF4Fuoc8VN8dpQQtZnKksFmR2jhWE1Ew=",
         "owner": "GNOME",
         "repo": "gnome-shell",
-        "rev": "dadd58f630eeea41d645ee225a63f719390829dc",
+        "rev": "52c517c8f6c199a1d6f5118fae500ef69ea845ae",
         "type": "github"
       },
       "original": {
         "owner": "GNOME",
-        "ref": "47.2",
+        "ref": "48.1",
         "repo": "gnome-shell",
         "type": "github"
       }
@@ -218,11 +218,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1745930157,
-        "narHash": "sha256-y3h3NLnzRSiUkYpnfvnS669zWZLoqqI6NprtLQ+5dck=",
+        "lastModified": 1747327360,
+        "narHash": "sha256-LSmTbiq/nqZR9B2t4MRnWG7cb0KVNU70dB7RT4+wYK4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "46e634be05ce9dc6d4db8e664515ba10b78151ae",
+        "rev": "e06158e58f3adee28b139e9c2bcfcc41f8625b46",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -55,7 +55,7 @@
       # TODO: Unlocking the input and pointing to official repository requires
       # updating the patch:
       # https://github.com/nix-community/stylix/pull/224#discussion_r1460339607.
-      url = "github:GNOME/gnome-shell/47.2";
+      url = "github:GNOME/gnome-shell/48.1";
       flake = false;
     };
 

--- a/modules/gnome/colors.scss.mustache
+++ b/modules/gnome/colors.scss.mustache
@@ -1,5 +1,7 @@
 // _default-colors.scss
 
+$accent_color: #{{base0D-hex}};
+
 $destructive_bg_color: #{{base08-hex}};
 $destructive_fg_color: #{{base00-hex}};
 $destructive_color: #{{base08-hex}};
@@ -28,8 +30,8 @@ $border_opacity: 1;
 $shadow_color: transparent;
 $text_shadow_color: transparent;
 
-$focus_color: $selected_bg_color;
-$focus_border_color: transparentize(#{{base05-hex}}, 0.5);
+$border_opacity: .875;
+$focus_border_opacity: .2;
 
 // _colors.scss
 


### PR DESCRIPTION
Fixes #1293.

~~Note that there are problems in the testbed in the published version of this PR, since updating our Nixpkgs input to have the new GNOME version would trigger #1294 and cause the checks on this PR to fail. However, I tested this locally with the input updated and the `gnome-text-editor` target disabled.~~

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [ ] Tested locally
- [x] Tested in [testbed](https://stylix.danth.me/testbeds.html)
- [x] Commit message follows [commit convention](https://stylix.danth.me/commit_convention.html)
- [ ] Fits [style guide](https://stylix.danth.me/styling.html)
- [ ] Respects license of any existing code used

## Notify maintainers

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->
