### PR TITLE
treewide: change repository owner to nix-community

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -14,9 +14,9 @@ body:
         If you need help or are unsure whether this is a Stylix bug, please
         consider reading the [documentation](https://stylix.danth.me) or asking
         for help in a [GitHub
-        Discussion](https://github.com/danth/stylix/discussions) or the [Stylix
-        Matrix Room](https://matrix.to/#/#stylix:danth.me) before opening an
-        issue.
+        Discussion](https://github.com/nix-community/stylix/discussions) or the
+        [Stylix Matrix Room](https://matrix.to/#/#stylix:danth.me) before
+        opening an issue.
 
       options:
         - label: >-
@@ -27,7 +27,7 @@ body:
 
         - label: >-
             I assert that this is not a duplicate of an [existing
-            issue](https://github.com/danth/stylix/issues?q=is%3Aissue).
+            issue](https://github.com/nix-community/stylix/issues?q=is%3Aissue).
 
           required: true
 

--- a/.github/ISSUE_TEMPLATE/change_option.yml
+++ b/.github/ISSUE_TEMPLATE/change_option.yml
@@ -13,7 +13,7 @@ body:
       options:
         - label: >-
             I assert that this is not a duplicate of an [existing feature
-            request](https://github.com/danth/stylix/issues?q=is%3Aissue).
+            request](https://github.com/nix-community/stylix/issues?q=is%3Aissue).
 
           required: true
 

--- a/.github/ISSUE_TEMPLATE/change_target.yml
+++ b/.github/ISSUE_TEMPLATE/change_target.yml
@@ -13,7 +13,7 @@ body:
       options:
         - label: >-
             I assert that this is not a duplicate of an [existing feature
-            request](https://github.com/danth/stylix/issues?q=is%3Aissue).
+            request](https://github.com/nix-community/stylix/issues?q=is%3Aissue).
 
           required: true
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,7 +3,7 @@ blank_issues_enabled: true
 
 contact_links:
   - name: Ask on GitHub Discussions
-    url: https://github.com/danth/stylix/discussions/new/choose
+    url: https://github.com/nix-community/stylix/discussions/new/choose
     about: For questions or informal discussions
 
   - name: Ask on Matrix

--- a/.github/ISSUE_TEMPLATE/new_option.yml
+++ b/.github/ISSUE_TEMPLATE/new_option.yml
@@ -13,7 +13,7 @@ body:
       options:
         - label: >-
             I assert that this is not a duplicate of an [existing feature
-            request](https://github.com/danth/stylix/issues?q=is%3Aissue).
+            request](https://github.com/nix-community/stylix/issues?q=is%3Aissue).
 
           required: true
 

--- a/.github/ISSUE_TEMPLATE/new_target.yml
+++ b/.github/ISSUE_TEMPLATE/new_target.yml
@@ -13,7 +13,7 @@ body:
       options:
         - label: >-
             I assert that this is not a duplicate of an [existing feature
-            request](https://github.com/danth/stylix/issues?q=is%3Aissue).
+            request](https://github.com/nix-community/stylix/issues?q=is%3Aissue).
 
           required: true
 

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -15,7 +15,7 @@ jobs:
 
     if: >
       (
-        github.repository_owner == 'danth' &&
+        github.repository_owner == 'nix-community' &&
         github.event.pull_request.merged == true &&
         (
           github.event_name != 'labeled' ||

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -21,7 +21,7 @@ jobs:
   labels:
     name: label-pr
     runs-on: ubuntu-24.04
-    if: github.repository_owner == 'danth' && !contains(github.event.pull_request.title, '[skip treewide]')   # yamllint disable-line rule:line-length
+    if: github.repository_owner == 'nix-community' && !contains(github.event.pull_request.title, '[skip treewide]')   # yamllint disable-line rule:line-length
     steps:
       - uses: actions/create-github-app-token@v2
         id: app-token

--- a/.github/workflows/update-flake.yml
+++ b/.github/workflows/update-flake.yml
@@ -9,7 +9,7 @@ on:  # yamllint disable-line rule:truthy
 jobs:
   flake-update:
     runs-on: ubuntu-latest
-    if: github.repository_owner == 'danth'
+    if: github.repository_owner == 'nix-community'
     strategy:
       matrix:
         branch: [master, release-24.11]

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ philosophy.
 ## Resources
 
 - [Documentation](https://danth.github.io/stylix)
-- [GitHub Discussions](https://github.com/danth/stylix/discussions)
+- [GitHub Discussions](https://github.com/nix-community/stylix/discussions)
 - [Matrix room](https://matrix.to/#/#stylix:danth.me)
 
 ## Example configurations
@@ -40,7 +40,7 @@ philosophy.
 Try a live demo of this dark theme by running:
 
 ```console
-nix run github:danth/stylix#testbed:gnome:default:dark:image:scheme:cursor
+nix run github:nix-community/stylix#testbed:gnome:default:dark:image:scheme:cursor
 ```
 
 ### KDE Plasma 5

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -5,8 +5,8 @@ language = "en"
 [preprocessor.alerts]
 
 [output.html]
-git-repository-url = "https://github.com/danth/stylix"
-edit-url-template = "https://github.com/danth/stylix/edit/master/docs/{path}"
+git-repository-url = "https://github.com/nix-community/stylix"
+edit-url-template = "https://github.com/nix-community/stylix/edit/master/docs/{path}"
 no-section-label = true
 
 [output.html.fold]

--- a/docs/default.nix
+++ b/docs/default.nix
@@ -345,11 +345,11 @@ let
   # Permalink to view a source file on GitHub. If the commit isn't known,
   # then fall back to the latest commit.
   declarationCommit = inputs.self.rev or "master";
-  declarationPermalink = "https://github.com/danth/stylix/blob/${declarationCommit}";
+  declarationPermalink = "https://github.com/nix-community/stylix/blob/${declarationCommit}";
 
   # Renders a single option declaration. Example output:
   #
-  # - [modules/module1/nixos.nix](https://github.com/danth/stylix/blob/«commit»/modules/module1/nixos.nix)
+  # - [modules/module1/nixos.nix](https://github.com/nix-community/stylix/blob/«commit»/modules/module1/nixos.nix)
   renderDeclaration =
     declaration:
     let

--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -10,7 +10,7 @@ screens, and display managers.
 {
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-    stylix.url = "github:danth/stylix";
+    stylix.url = "github:nix-community/stylix";
   };
 
   outputs =
@@ -34,7 +34,7 @@ Stylix release. For example:
 ```nix
 {
   nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
-  stylix.url = "github:danth/stylix/release-24.11";
+  stylix.url = "github:nix-community/stylix/release-24.11";
 }
 ```
 
@@ -66,7 +66,7 @@ to NixOS via [Flakes][nix-flakes].
       inputs.nixpkgs.follows = "nixpkgs";
     };
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-    stylix.url = "github:danth/stylix";
+    stylix.url = "github:nix-community/stylix";
   };
 
   outputs =
@@ -106,7 +106,7 @@ similar fashion to NixOS via [Flakes][nix-flakes].
       inputs.nixpkgs.follows = "nixpkgs";
     };
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.05";
-    stylix.url = "github:danth/stylix";
+    stylix.url = "github:nix-community/stylix";
   };
 
   outputs =
@@ -147,7 +147,7 @@ by someone else.
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     home-manager.url = "github:nix-community/home-manager";
-    stylix.url = "github:danth/stylix";
+    stylix.url = "github:nix-community/stylix";
   };
 
   outputs =
@@ -177,7 +177,7 @@ matching Stylix release. For example:
 {
   nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
   home-manager.url = "github:nix-community/home-manager/release-24.11";
-  stylix.url = "github:danth/stylix/release-24.11";
+  stylix.url = "github:nix-community/stylix/release-24.11";
 }
 ```
 
@@ -197,7 +197,7 @@ Home Manager module as the `homeModules.stylix` attribute.
 ```nix
 let
   stylix = pkgs.fetchFromGitHub {
-    owner = "danth";
+    owner = "nix-community";
     repo = "stylix";
     rev = "...";
     sha256 = "...";

--- a/docs/src/modules.md
+++ b/docs/src/modules.md
@@ -6,7 +6,7 @@ Currently the easiest way to test Stylix is to use the new code in your actual
 configuration.
 
 You might find it useful to change the flake reference in your configuration
-from `github:danth/stylix` to `git+file:/home/user/path/to/stylix` so that you
+from `github:nix-community/stylix` to `git+file:/home/user/path/to/stylix` so that you
 don't need to push your changes to GitHub during testing.
 
 Then, remember to run `nix flake lock --update-input stylix` to refresh the

--- a/docs/src/testbeds.md
+++ b/docs/src/testbeds.md
@@ -47,7 +47,7 @@ the repository:
 
 ```console
 user@host:~$ nix flake show
-github:danth/stylix
+github:nix-community/stylix
 └───packages
     └───x86_64-linux
         ├───docs: package 'stylix-book'

--- a/flake.nix
+++ b/flake.nix
@@ -54,7 +54,7 @@
     gnome-shell = {
       # TODO: Unlocking the input and pointing to official repository requires
       # updating the patch:
-      # https://github.com/danth/stylix/pull/224#discussion_r1460339607.
+      # https://github.com/nix-community/stylix/pull/224#discussion_r1460339607.
       url = "github:GNOME/gnome-shell/47.2";
       flake = false;
     };
@@ -80,7 +80,7 @@
       # functionality [1], it might be easiest to lock this input to avoid
       # wasted maintenance effort.
       #
-      # [1]: https://github.com/danth/stylix/issues/571
+      # [1]: https://github.com/nix-community/stylix/issues/571
       url = "github:tinted-theming/tinted-foot/fd1b924b6c45c3e4465e8a849e67ea82933fcbe4";
       flake = false;
     };
@@ -92,7 +92,7 @@
       # functionality [1], it might be easiest to lock this input to avoid
       # wasted maintenance effort.
       #
-      # [1]: https://github.com/danth/stylix/issues/534
+      # [1]: https://github.com/nix-community/stylix/issues/534
       url = "github:tinted-theming/tinted-kitty/eb39e141db14baef052893285df9f266df041ff8";
       flake = false;
     };

--- a/modules/kde/hm.nix
+++ b/modules/kde/hm.nix
@@ -175,7 +175,7 @@ let
       inherit Id Name;
       Description = "Generated from your Home Manager configuration";
       ServiceTypes = [ "Plasma/LookAndFeel" ];
-      Website = "https://github.com/danth/stylix";
+      Website = "https://github.com/nix-community/stylix";
     };
     KPackageStructure = "Plasma/LookAndFeel";
   };

--- a/modules/mangohud/hm.nix
+++ b/modules/mangohud/hm.nix
@@ -33,7 +33,7 @@
             fps_color = "${base0B}, ${base0A}, ${base08}";
 
             # TODO: Use the point unit:
-            # https://github.com/danth/stylix/issues/251.
+            # https://github.com/nix-community/stylix/issues/251.
             font_scale = 1.33333;
           };
       };

--- a/modules/micro/hm.nix
+++ b/modules/micro/hm.nix
@@ -10,7 +10,7 @@
   config = lib.mkIf (config.stylix.enable && config.stylix.targets.micro.enable) {
     # TODO: Provide a real colorscheme once [1] is resolved.
     #
-    # [1]: https://github.com/danth/stylix/issues/249
+    # [1]: https://github.com/nix-community/stylix/issues/249
     programs.micro.settings.colorscheme = "simple";
   };
 }

--- a/modules/qt/hm.nix
+++ b/modules/qt/hm.nix
@@ -11,7 +11,7 @@
     # non-NixOS distro path") once [2] ("bug: setting qt.style.name = kvantum
     # makes host systemd unusable") is resolved.
     #
-    # [1]: https://github.com/danth/stylix/issues/933
+    # [1]: https://github.com/nix-community/stylix/issues/933
     # [2]: https://github.com/nix-community/home-manager/issues/6565
     enable = config.lib.stylix.mkEnableTarget "QT" (
       pkgs.stdenv.hostPlatform.isLinux && osConfig != null

--- a/modules/qutebrowser/hm.nix
+++ b/modules/qutebrowser/hm.nix
@@ -266,7 +266,7 @@ in
             };
 
             # TODO: Use the pixel unit:
-            # https://github.com/danth/stylix/issues/251.
+            # https://github.com/nix-community/stylix/issues/251.
             size.default = builtins.floor (sizes.applications * 4 / 3 + 0.5);
           };
         };

--- a/modules/xfce/hm.nix
+++ b/modules/xfce/hm.nix
@@ -1,7 +1,7 @@
 { config, lib, ... }:
 
 {
-  # Disabled by default due to https://github.com/danth/stylix/issues/180
+  # Disabled by default due to https://github.com/nix-community/stylix/issues/180
   options.stylix.targets.xfce.enable =
     config.lib.stylix.mkEnableTarget "Xfce" false;
 


### PR DESCRIPTION
Preparing to migrate the repository into https://github.com/nix-community. The most important change here is in the Actions workflows, as they check the owner's name to decide whether to run.

The documentation is still at https://stylix.danth.me for the time being.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [ ] Tested locally
- [ ] Tested in [testbed](https://stylix.danth.me/testbeds.html)
- [x] Commit message follows [commit convention](https://stylix.danth.me/commit_convention.html)
- [ ] Fits [style guide](https://stylix.danth.me/styling.html)
- [ ] Respects license of any existing code used

## Notify maintainers

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->
