### PR TITLE
gnome: install User Themes extension

### DIFF
--- a/modules/gnome/hm.nix
+++ b/modules/gnome/hm.nix
@@ -49,6 +49,8 @@ in
   };
 
   config = lib.mkIf (config.stylix.enable && cfg.enable) {
+    home.packages = [ pkgs.gnomeExtensions.user-themes ];
+
     dconf.settings = {
       "org/gnome/desktop/background" = {
         color-shading-type = "solid";


### PR DESCRIPTION
It was always intended that Stylix would install this extension itself, as the Home Manager module's functionality relies on it.

I'm not sure whether this code has always been missing, or if it was accidentally removed at some point, as I only noticed when #1305 started happening and I went to check whether the extension was enabled.

Note that the extension is less than 100 KiB and isn't executed unless GNOME is running (it's not on `$PATH` or anything), so although installing this for all users is not ideal, it shouldn't cause any major problems.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [x] Tested locally
- [ ] Tested in [testbed](https://stylix.danth.me/testbeds.html)
- [x] Commit message follows [commit convention](https://stylix.danth.me/commit_convention.html)
- [ ] Fits [style guide](https://stylix.danth.me/styling.html)
- [ ] Respects license of any existing code used

## Notify maintainers

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->
