### PR TITLE
doc: set site-url

### DIFF
--- a/docs/book.toml
+++ b/docs/book.toml
@@ -5,6 +5,7 @@ language = "en"
 [preprocessor.alerts]
 
 [output.html]
+site-url = "/stylix/"
 git-repository-url = "https://github.com/nix-community/stylix"
 edit-url-template = "https://github.com/nix-community/stylix/edit/master/docs/{path}"
 no-section-label = true


### PR DESCRIPTION
Documentation has moved to https://nix-community.github.io/stylix/, so this is necessary again for the 404 page to work correctly.

Reverts aeb550add3bfa1ce3ce249c3b3dad71ebb018318
Closes #1303

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [ ] Tested locally
- [ ] Tested in [testbed](https://stylix.danth.me/testbeds.html)
- [x] Commit message follows [commit convention](https://stylix.danth.me/commit_convention.html)
- [ ] Fits [style guide](https://stylix.danth.me/styling.html)
- [ ] Respects license of any existing code used

## Notify maintainers

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->
