### PR TITLE
kitty: tinted-kitty commit bump

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -323,7 +323,6 @@
       "original": {
         "owner": "tinted-theming",
         "repo": "tinted-kitty",
-        "rev": "de6f888497f2c6b2279361bfc790f164bfd0f3fa",
         "type": "github"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -313,17 +313,17 @@
     "tinted-kitty": {
       "flake": false,
       "locked": {
-        "lastModified": 1716423189,
-        "narHash": "sha256-2xF3sH7UIwegn+2gKzMpFi3pk5DlIlM18+vj17Uf82U=",
+        "lastModified": 1735730497,
+        "narHash": "sha256-4KtB+FiUzIeK/4aHCKce3V9HwRvYaxX+F1edUrfgzb8=",
         "owner": "tinted-theming",
         "repo": "tinted-kitty",
-        "rev": "eb39e141db14baef052893285df9f266df041ff8",
+        "rev": "de6f888497f2c6b2279361bfc790f164bfd0f3fa",
         "type": "github"
       },
       "original": {
         "owner": "tinted-theming",
         "repo": "tinted-kitty",
-        "rev": "eb39e141db14baef052893285df9f266df041ff8",
+        "rev": "de6f888497f2c6b2279361bfc790f164bfd0f3fa",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -86,14 +86,7 @@
     };
 
     tinted-kitty = {
-      # Lock the tinted-kitty input to prevent upstream breaking changes.
-      #
-      # Considering that Stylix eventually re-implements this input's
-      # functionality [1], it might be easiest to lock this input to avoid
-      # wasted maintenance effort.
-      #
-      # [1]: https://github.com/nix-community/stylix/issues/534
-      url = "github:tinted-theming/tinted-kitty/de6f888497f2c6b2279361bfc790f164bfd0f3fa";
+      url = "github:tinted-theming/tinted-kitty";
       flake = false;
     };
 

--- a/flake.nix
+++ b/flake.nix
@@ -93,7 +93,7 @@
       # wasted maintenance effort.
       #
       # [1]: https://github.com/nix-community/stylix/issues/534
-      url = "github:tinted-theming/tinted-kitty/eb39e141db14baef052893285df9f266df041ff8";
+      url = "github:tinted-theming/tinted-kitty/de6f888497f2c6b2279361bfc790f164bfd0f3fa";
       flake = false;
     };
 

--- a/modules/kitty/hm.nix
+++ b/modules/kitty/hm.nix
@@ -4,7 +4,7 @@ let
   cfg = config.stylix.targets.kitty;
   theme = config.lib.stylix.colors {
     templateRepo = config.stylix.inputs.tinted-kitty;
-    target = if cfg.variant256Colors then "default-256" else "default";
+    target = if cfg.variant256Colors then "base16-256-deprecated" else "base16";
   };
 in
 {


### PR DESCRIPTION
It's archived now so why not use the latest commit?

Updating to the latest and final commit of [github:tinted-theming/tinted-kitty](https://github.com/tinted-theming/tinted-kitty) fixes color inconsistency, where bright tones of primary colors were assigned arbitrary colors of the selected theme (e.g. background colors in catppuccin).

## Things done

- [x] Tested locally
- [x] Tested in [testbed](https://stylix.danth.me/testbeds.html)
- [ ] Tested 256 colors
- [x] Commit message follows [commit convention](https://stylix.danth.me/commit_convention.html)
- [x] Fits [style guide](https://stylix.danth.me/styling.html)
- [x] Respects license of any existing code used

## Notify maintainers

@trueNAHO 
