### PR TITLE
stylix: fix link to docs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ philosophy.
 
 ## Resources
 
-- [Documentation](https://danth.github.io/stylix)
+- [Documentation](https://nix-community.github.io/stylix/)
 - [GitHub Discussions](https://github.com/nix-community/stylix/discussions)
 - [Matrix room](https://matrix.to/#/#stylix:danth.me)
 


### PR DESCRIPTION
link was still pointing at old documentation



<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

## Things done

Fixed dead link in README

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [ ] Tested locally
- [ ] Tested in [testbed](https://stylix.danth.me/testbeds.html)
- [ ] Commit message follows [commit convention](https://stylix.danth.me/commit_convention.html)
- [ ] Fits [style guide](https://stylix.danth.me/styling.html)
- [ ] Respects license of any existing code used

## Notify maintainers

@danth 

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->
