### PR TITLE
stylix: bump release to 25.11

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -2,7 +2,7 @@
 # This version uses `sync-labels: false`, meaning that a non-match will NOT
 # remove the label
 ---
-"backport release-24.11":
+"backport release-25.05":
   - changed-files:
       - any-glob-to-any-file:
           - ".github/workflows/*"

--- a/flake.lock
+++ b/flake.lock
@@ -203,11 +203,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747279714,
-        "narHash": "sha256-UdxlE8yyrKiGq3bgGyJ78AdFwh+fuRAruKtyFY5Zq5I=",
+        "lastModified": 1747763032,
+        "narHash": "sha256-9j3oCbemeH7bTVXJ3pDWxOptbxDx2SdK1jY2AHpjQiw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "954615c510c9faa3ee7fb6607ff72e55905e69f2",
+        "rev": "29dda415f5b2178278283856c6f9f7b48a2a4353",
         "type": "github"
       },
       "original": {
@@ -218,11 +218,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1747327360,
-        "narHash": "sha256-LSmTbiq/nqZR9B2t4MRnWG7cb0KVNU70dB7RT4+wYK4=",
+        "lastModified": 1747542820,
+        "narHash": "sha256-GaOZntlJ6gPPbbkTLjbd8BMWaDYafhuuYRNrxCGnPJw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e06158e58f3adee28b139e9c2bcfcc41f8625b46",
+        "rev": "292fa7d4f6519c074f0a50394dbbe69859bb6043",
         "type": "github"
       },
       "original": {

--- a/stylix/release.nix
+++ b/stylix/release.nix
@@ -3,7 +3,7 @@
   options.stylix = {
     release = lib.mkOption {
       description = "The version of NixOS that Stylix is built to support";
-      default = "25.05";
+      default = "25.11";
       internal = true;
       readOnly = true;
     };


### PR DESCRIPTION
fixes #1315 
related to #1277 

> [!NOTE]
> 25.05 has already been branched off so this will not end up in it.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [ ] Tested locally
- [ ] Tested in [testbed](https://nix-community.github.io/stylix/testbeds.html)
- [x] Commit message follows [commit convention](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Fits [style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Respects license of any existing code used

## Notify maintainers

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->
