### PR TITLE
[release-25.05] ci: don't backport ci to 24.11

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -2,11 +2,6 @@
 # This version uses `sync-labels: false`, meaning that a non-match will NOT
 # remove the label
 ---
-"backport release-24.11":
-  - changed-files:
-      - any-glob-to-any-file:
-          - ".github/workflows/*"
-
 dependencies:
   - changed-files:
       - any-glob-to-any-file: "flake.lock"


### PR DESCRIPTION
designed to keep stable and unstable in sync, but shouldn't be in stable branch.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [ ] Tested locally
- [ ] Tested in [testbed](https://nix-community.github.io/stylix/testbeds.html)
- [ ] Commit message follows [commit convention](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Fits [style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Respects license of any existing code used

## Notify maintainers

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->
