### PR TITLE
stylix: revert improval of how discord testbed is disabled

### DIFF
--- a/flake/packages.nix
+++ b/flake/packages.nix
@@ -7,28 +7,46 @@
 {
 
   perSystem =
-    { pkgs, config, ... }:
+    {
+      pkgs,
+      system,
+      config,
+      ...
+    }:
     {
       # Build all packages with 'nix flake check' instead of only verifying they
       # are derivations.
       checks = config.packages;
 
-      packages = lib.mkMerge [
-        # Testbeds are virtual machines based on NixOS, therefore they are
-        # only available for Linux systems.
-        (lib.mkIf pkgs.stdenv.hostPlatform.isLinux (
-          import "${self}/stylix/testbed.nix" {
+      packages =
+        let
+          testbedPackages = import "${self}/stylix/testbed.nix" {
             inherit pkgs inputs lib;
-          }
-        ))
-        {
-          docs = pkgs.callPackage "${self}/doc" {
-            inherit inputs;
-            inherit (inputs.nixpkgs.lib) nixosSystem;
-            inherit (inputs.home-manager.lib) homeManagerConfiguration;
           };
-          palette-generator = pkgs.callPackage "${self}/palette-generator" { };
-        }
-      ];
+
+          # Discord is not available on arm64. This workaround filters out
+          # testbeds using that package, until we have a better way to handle
+          # this.
+          testbedPackages' =
+            if system == "aarch64-linux" then
+              lib.filterAttrs (
+                name: _: !lib.hasPrefix "testbed:discord:vencord" name
+              ) testbedPackages
+            else
+              testbedPackages;
+        in
+        lib.mkMerge [
+          # Testbeds are virtual machines based on NixOS, therefore they are
+          # only available for Linux systems.
+          (lib.mkIf pkgs.stdenv.hostPlatform.isLinux testbedPackages')
+          {
+            docs = pkgs.callPackage "${self}/doc" {
+              inherit inputs;
+              inherit (inputs.nixpkgs.lib) nixosSystem;
+              inherit (inputs.home-manager.lib) homeManagerConfiguration;
+            };
+            palette-generator = pkgs.callPackage "${self}/palette-generator" { };
+          }
+        ];
     };
 }

--- a/modules/discord/testbeds/vencord.nix
+++ b/modules/discord/testbeds/vencord.nix
@@ -6,14 +6,9 @@ let
   };
 in
 {
-  stylix.testbed = {
-    # Discord is not available on arm64.
-    enable = lib.meta.availableOn pkgs.stdenv.hostPlatform package;
-
-    ui.application = {
-      name = "discord";
-      inherit package;
-    };
+  stylix.testbed.ui.application = {
+    name = "discord";
+    inherit package;
   };
 
   environment.systemPackages = [ package ];


### PR DESCRIPTION
```
Revert the improval of how discord testbed is disabled to get the proper
commit structure into the commit history.

Reverts: 5113479d69e6 ("stylix: improve how discord testbed is disabled (#1291)")
```
