### PR TITLE
 doc: update documentation to reflect #1083

### DIFF
--- a/doc/default.nix
+++ b/doc/default.nix
@@ -57,13 +57,19 @@ let
   #     {
   #       "src/options/modules/«module».md" = {
   #         referenceSection = "Modules";
-  #         readme = ''
-  #           Content of modules/«module»/README.md, or a default title
-  #           followed by a note about that file not existing.
+  #         readme =
+  #           # Generated from modules/«module»/meta.nix
+  #           ''
+  #             # «name»
   #
-  #           Summary of module maintainers, or a warning that the module
-  #           is unmaintained.
-  #         '';
+  #             «Links to homepage(s)»
+  #
+  #             «Maintainers info»
+  #
+  #             ---
+  #
+  #             «Optional description»
+  #           '';
   #         optionsByPlatform = {
   #           home_manager = [ ... ];
   #           nixos = [ ... ];
@@ -447,15 +453,20 @@ let
       ${renderedOptions}
     '';
 
-  # Renders the list of options for all platforms on a page, preceded by either
-  # the relevant README, or the default README if it doesn't exist.
+  # Renders the list of options for all platforms on a page, preceded by the
+  # module's metadata generated from modules/«module»/meta.nix.
   #
   # Example output:
   #
-  #     # Module 1
+  #     # «name»
   #
-  #     This is the content of `modules/module1/README.md`, including the title
-  #     above.
+  #     «Links to homepage(s)»
+  #
+  #     «Maintainers info»
+  #
+  #     ---
+  #
+  #     «Optional description»
   #
   #     ## Home Manager options
   #     *None provided.*

--- a/doc/src/modules.md
+++ b/doc/src/modules.md
@@ -225,8 +225,8 @@ this documentation, ensure that any custom options created using `mkOption` are
 given an appropriate `type` and a detailed `description`. This may use Markdown
 syntax for formatting and links.
 
-For modules needing more general documentation, create
-`modules/«module»/README.md`:
+For modules needing more general documentation, add a `description` to
+`modules/«module»/meta.nix`:
 
 ```markdown
 # Module Name


### PR DESCRIPTION
Follow up to #1083.

Remove references to `modules/«module»/README.md`, as this was replaced by `modules/«module»/meta.nix`.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [ ] Tested locally
- [ ] Tested in [testbed](https://nix-community.github.io/stylix/testbeds.html)
- [x] Commit message follows [commit convention](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Fits [style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Respects license of any existing code used

## Notify maintainers

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->
