### PR TITLE
alacritty: fix mkTarget usage

### DIFF
--- a/modules/alacritty/hm.nix
+++ b/modules/alacritty/hm.nix
@@ -1,53 +1,49 @@
 # Documentation is available at:
 # - https://alacritty.org/config-alacritty.html
 # - `man 5 alacritty`
-{ config, mkTarget, ... }:
+{ mkTarget, ... }:
 mkTarget {
   name = "alacritty";
   humanName = "Alacritty";
   configElements = [
     (
       { colors }:
-      with colors.withHashtag;
       {
-        programs.alacritty.settings = {
-          window.opacity = config.stylix.opacity.terminal;
-          colors = with colors; {
-            primary = {
-              foreground = base05;
-              background = base00;
-              bright_foreground = base07;
-            };
-            selection = {
-              text = base05;
-              background = base02;
-            };
-            cursor = {
-              text = base00;
-              cursor = base05;
-            };
-            normal = {
-              black = base00;
-              white = base05;
-              inherit
-                red
-                green
-                yellow
-                blue
-                magenta
-                cyan
-                ;
-            };
-            bright = {
-              black = base03;
-              white = base07;
-              red = bright-red;
-              green = bright-green;
-              yellow = bright-yellow;
-              blue = bright-blue;
-              magenta = bright-magenta;
-              cyan = bright-cyan;
-            };
+        programs.alacritty.settings.colors = with colors.withHashtag; {
+          primary = {
+            foreground = base05;
+            background = base00;
+            bright_foreground = base07;
+          };
+          selection = {
+            text = base05;
+            background = base02;
+          };
+          cursor = {
+            text = base00;
+            cursor = base05;
+          };
+          normal = {
+            black = base00;
+            white = base05;
+            inherit
+              red
+              green
+              yellow
+              blue
+              magenta
+              cyan
+              ;
+          };
+          bright = {
+            black = base03;
+            white = base07;
+            red = bright-red;
+            green = bright-green;
+            yellow = bright-yellow;
+            blue = bright-blue;
+            magenta = bright-magenta;
+            cyan = bright-cyan;
           };
         };
       }
@@ -67,7 +63,7 @@ mkTarget {
     (
       { opacity }:
       {
-        programs.alacritty.settings.window.opacity = config.stylix.opacity.terminal;
+        programs.alacritty.settings.window.opacity = opacity.terminal;
       }
     )
   ];


### PR DESCRIPTION
the `with colors` got messed up, and opacity was also being applied wrong

cc @Flameopathic @MattSturgeon @trueNAHO 
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [ ] Tested locally
- [ ] Tested in [testbed](https://nix-community.github.io/stylix/testbeds.html)
- [x] Commit message follows [commit convention](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Fits [style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Respects license of any existing code used

## Notify maintainers

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->
