### PR TITLE
stylix: add addEnableOption to mkTarget

### DIFF
--- a/stylix/mk-target.nix
+++ b/stylix/mk-target.nix
@@ -59,6 +59,10 @@
     : The descriptive target name passed to the lib.mkEnableOption function
       when generating the `stylix.targets.${name}.enable` option.
 
+    `addEnableOption` (Boolean)
+    : Whether to add the `stylix.targets.${name}.enable}` option, defaulting to
+      `true`.
+
     `autoEnable` (Boolean)
     : Whether the target should be automatically enabled by default according
       to the `stylix.autoEnable` option.
@@ -152,6 +156,7 @@
 {
   name,
   humanName,
+  addEnableOption ? true,
   autoEnable ? true,
   extraOptions ? { },
   configElements ? [ ],
@@ -208,8 +213,9 @@ let
           c;
     in
     {
-      options.stylix.targets.${name}.enable =
-        config.lib.stylix.mkEnableTarget humanName autoEnable;
+      options.stylix.targets.${name} = lib.optionalAttrs addEnableOption {
+        enable = config.lib.stylix.mkEnableTarget humanName autoEnable;
+      };
 
       config = lib.mkIf (config.stylix.enable && cfg.enable) (
         lib.mkMerge (


### PR DESCRIPTION
required for [gnome-text-editor](https://github.com/nix-community/stylix/blob/master/modules/gnome-text-editor/hm.nix) to be moved to mkTarget
cc: @trueNAHO @MattSturgeon @Flameopathic 
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [ ] Tested locally
- [ ] Tested in [testbed](https://nix-community.github.io/stylix/testbeds.html)
- [x] Commit message follows [commit convention](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Fits [style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Respects license of any existing code used

## Notify maintainers

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->
