### PR TITLE
qutebrowser: simplify dark mode setting

### DIFF
--- a/modules/qutebrowser/hm.nix
+++ b/modules/qutebrowser/hm.nix
@@ -248,7 +248,7 @@ in
 
           webpage.preferred_color_scheme = lib.mkIf (
             config.stylix.polarity == "dark"
-          ) config.stylix.polarity;
+          ) "dark";
         };
 
         fonts = {


### PR DESCRIPTION
This only activates when the polarity is "dark", so we can hardcode that value rather than referencing the polarity option again.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [ ] Tested locally
- [ ] Tested in [testbed](https://nix-community.github.io/stylix/testbeds.html)
- [x] Commit message follows [commit convention](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Fits [style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Respects license of any existing code used

## Notify maintainers

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->
