### PR TITLE
hyprland: fix hyprpaper enable condition

### DIFF
--- a/modules/hyprland/hm.nix
+++ b/modules/hyprland/hm.nix
@@ -42,11 +42,12 @@ mkTarget {
     )
     (
       { cfg }:
-      (lib.mkIf cfg.hyprpaper.enable {
-        services.hyprpaper.enable = true;
-        stylix.targets.hyprpaper.enable = true;
-        wayland.windowManager.hyprland.settings.misc.disable_hyprland_logo = true;
-      })
+      lib.mkIf (config.wayland.windowManager.hyprland.enable && cfg.hyprpaper.enable)
+        {
+          services.hyprpaper.enable = true;
+          stylix.targets.hyprpaper.enable = true;
+          wayland.windowManager.hyprland.settings.misc.disable_hyprland_logo = true;
+        }
     )
   ];
 }


### PR DESCRIPTION
https://github.com/nix-community/stylix/pull/1130#issuecomment-2900037709
cc @Lyndeno @Flameopathic 
entire module was previously guard by `config.wayland.windowManager.hyprland.enable`, which got lost in the switch to mkTarget
https://github.com/nix-community/stylix/blob/a2f8840bed6daade6b980426c9f72dd672e92329/modules/hyprland/hm.nix#L19
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [ ] Tested locally
- [ ] Tested in [testbed](https://nix-community.github.io/stylix/testbeds.html)
- [ ] Commit message follows [commit convention](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Fits [style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Respects license of any existing code used

## Notify maintainers

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->
@trueNAHO @skoove