### PR TITLE
stylix: add imports to mkTarget

### DIFF
--- a/stylix/mk-target.nix
+++ b/stylix/mk-target.nix
@@ -156,6 +156,7 @@
   extraOptions ? { },
   configElements ? [ ],
   generalConfig ? null,
+  imports ? [ ],
 }:
 let
   module =
@@ -208,6 +209,8 @@ let
           c;
     in
     {
+      inherit imports;
+
       options.stylix.targets.${name}.enable =
         config.lib.stylix.mkEnableTarget humanName autoEnable;
 


### PR DESCRIPTION
imports is necessary for renamed/removed options. Note that imports is "unsafe" and might cause failure to check `!= null` (maybe a different way would be better?)

cc @trueNAHO @MattSturgeon @Flameopathic 
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [ ] Tested locally
- [ ] Tested in [testbed](https://nix-community.github.io/stylix/testbeds.html)
- [x] Commit message follows [commit convention](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Fits [style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Respects license of any existing code used

## Notify maintainers

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->
