### PR TITLE
ci: add 'has port to stable' label for backports

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -45,3 +45,15 @@ jobs:
           label_pattern: "^backport: ([^ ]+)$"
           pull_title: "[${target_branch}] ${pull_title}"
           pull_description: "This is an automated backport of #${pull_number}."
+
+      - name: "Add 'has: port to stable' label"
+        if: steps.backport.outputs.created_pull_numbers != ''
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          REPOSITORY: ${{ github.repository }}
+          NUMBER: ${{ github.event.number }}
+        run: |
+          gh api \
+            --method POST \
+            /repos/"$REPOSITORY"/issues/"$NUMBER"/labels \
+            -f "labels[]=has: port to stable"


### PR DESCRIPTION
copied from the nixpkgs backport workflow. Having this would make it a lot easier to keep track of what's been backported (I'm trying to keep stable more in sync for this release).
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [ ] Tested locally
- [ ] Tested in [testbed](https://nix-community.github.io/stylix/testbeds.html)
- [ ] Commit message follows [commit convention](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Fits [style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Respects license of any existing code used

## Notify maintainers

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->
