### PR TITLE
wayprompt: use mkTarget

### DIFF
--- a/modules/wayprompt/hm.nix
+++ b/modules/wayprompt/hm.nix
@@ -1,35 +1,38 @@
-{ config, lib, ... }:
-let
-  cfg = config.stylix.targets.wayprompt;
+{ mkTarget, lib, ... }:
+mkTarget {
+  name = "wayprompt";
+  humanName = "Wayprompt";
 
-  opacity = lib.toHexString (builtins.ceil (config.stylix.opacity.popups * 255));
-in
-{
-  options.stylix.targets.wayprompt.enable =
-    config.lib.stylix.mkEnableTarget "Wayprompt" true;
+  configElements = [
+    (
+      { colors, opacity }:
+      let
+        opacity' = lib.toHexString (builtins.ceil (opacity.popups * 255));
+      in
+      {
+        programs.wayprompt.settings.colours = with colors; {
+          background = "${base00-hex}${opacity'}";
+          border = base0D;
+          text = base05;
+          error-text = base08;
 
-  config = lib.mkIf (config.stylix.enable && cfg.enable) {
-    programs.wayprompt.settings.colours = with config.lib.stylix.colors; {
-      background = "${base00-hex}${opacity}";
-      border = base0D;
-      text = base05;
-      error-text = base08;
+          pin-background = base01;
+          pin-border = base05;
+          pin-square = base05;
 
-      pin-background = base01;
-      pin-border = base05;
-      pin-square = base05;
+          ok-button = green;
+          ok-button-border = green;
+          ok-button-text = base00;
 
-      ok-button = green;
-      ok-button-border = green;
-      ok-button-text = base00;
+          not-ok-button = yellow;
+          not-ok-button-border = yellow;
+          not-ok-button-text = base00;
 
-      not-ok-button = yellow;
-      not-ok-button-border = yellow;
-      not-ok-button-text = base00;
-
-      cancel-button = red;
-      cancel-button-border = red;
-      cancel-button-text = base00;
-    };
-  };
+          cancel-button = red;
+          cancel-button-border = red;
+          cancel-button-text = base00;
+        };
+      }
+    )
+  ];
 }

--- a/modules/wayprompt/hm.nix
+++ b/modules/wayprompt/hm.nix
@@ -12,25 +12,25 @@ mkTarget {
       {
         programs.wayprompt.settings.colours = with colors; {
           background = "${base00-hex}${opacity'}";
-          border = base0D;
-          text = base05;
-          error-text = base08;
+          border = base0D-hex;
+          text = base05-hex;
+          error-text = base08-hex;
 
-          pin-background = base01;
-          pin-border = base05;
-          pin-square = base05;
+          pin-background = base01-hex;
+          pin-border = base05-hex;
+          pin-square = base05-hex;
 
           ok-button = green;
           ok-button-border = green;
-          ok-button-text = base00;
+          ok-button-text = base00-hex;
 
           not-ok-button = yellow;
           not-ok-button-border = yellow;
-          not-ok-button-text = base00;
+          not-ok-button-text = base00-hex;
 
           cancel-button = red;
           cancel-button-border = red;
-          cancel-button-text = base00;
+          cancel-button-text = base00-hex;
         };
       }
     )


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

Also, used the `-hex` variants of color specs for consistency and future-proofing.

The diff visualization is a bit messy, couldn’t be helped.

**EDIT**: ouch! I just saw that this was tackled in #1371 (although a [search](https://github.com/nix-community/stylix/pulls?q=is%3Apr+is%3Aopen+wayprompt) for `wayprompt` on the list of open pull requests doesn’t show it :-/)

Well, the good news is that since both implementations look identical (save for my changes on the second commit, namely adding the `-hex` suffix to color specs), and I’ve tested mine locally, this means one less thing to worry about. 
## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [x] Tested locally
- [ ] Tested in [testbed](https://nix-community.github.io/stylix/testbeds.html)
- [x] Commit message follows [commit convention](https://nix-community.github.io/stylix/commit_convention.html)
- [x] Fits [style guide](https://nix-community.github.io/stylix/styling.html)
- [x] Respects license of any existing code used

## Notify maintainers

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->
CC: @awwpotato
maintainers: @nukdokplex @panchoh (adding myself feels funny :-)