### PR TITLE
gnome-text-editor: use mkTarget

### DIFF
--- a/modules/gnome-text-editor/nixos.nix
+++ b/modules/gnome-text-editor/nixos.nix
@@ -2,8 +2,4 @@
 mkTarget {
   name = "gnome-text-editor";
   humanName = "GNOME Text Editor";
-
-  configElements = {
-    dconf.settings."org/gnome/TextEditor".style-scheme = "stylix";
-  };
 }

--- a/modules/gnome-text-editor/overlay.nix
+++ b/modules/gnome-text-editor/overlay.nix
@@ -1,4 +1,8 @@
-{ config, lib, ... }:
+{
+  lib,
+  config,
+  ...
+}:
 let
   style = config.lib.stylix.colors {
     template = ../gedit/template.xml.mustache;
@@ -6,13 +10,12 @@ let
   };
 in
 {
-  options.stylix.targets.gnome-text-editor.enable =
-    config.lib.stylix.mkEnableTarget "GNOME Text Editor" true;
-
   overlay =
     _: prev:
     lib.optionalAttrs
-      (config.stylix.enable && config.stylix.targets.gnome-text-editor.enable)
+      (
+        config.stylix.enable && config.stylix.targets.gnome-text-editor.enable or false
+      )
       {
         gnome-text-editor = prev.gnome-text-editor.overrideAttrs (oldAttrs: {
           postFixup = ''


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [ ] Tested locally
- [ ] Tested in [testbed](https://nix-community.github.io/stylix/testbeds.html)
- [x] Commit message follows [commit convention](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Fits [style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Respects license of any existing code used

## Notify maintainers

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->
