### PR TITLE
bemenu: fix undefined variable error

### DIFF
--- a/modules/bemenu/hm.nix
+++ b/modules/bemenu/hm.nix
@@ -39,7 +39,11 @@ mkTarget {
       }
     )
     (
-      { colors, opacity }:
+      {
+        colors,
+        opacity,
+        cfg,
+      }:
       {
         programs.bemenu.settings =
           with colors.withHashtag;
@@ -63,8 +67,8 @@ mkTarget {
             nf = "${base05}"; # Normal fg
             scf = "${base03}"; # Scrollbar fg
 
-            ab = "${if alternate then base00 else base01}"; # Alternate bg
-            af = "${if alternate then base04 else base05}"; # Alternate fg
+            ab = "${if cfg.alternate then base00 else base01}"; # Alternate bg
+            af = "${if cfg.alternate then base04 else base05}"; # Alternate fg
           };
       }
     )


### PR DESCRIPTION
af4f2b56 broke bemenu, with

```nix

       error: undefined variable 'alternate'
       at /nix/store/j55w5xjmb9i002c4hi65m555vag99g8q-source/modules/bemenu/hm.nix:66:24:
           65|
           66|             ab = "${if alternate then base00 else base01}"; # Alternate bg
             |                        ^
           67|             af = "${if alternate then base04 else base05}"; # Alternate fg
```
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [x] Tested locally
- [ ] Tested in [testbed](https://nix-community.github.io/stylix/testbeds.html)
- [x] Commit message follows [commit convention](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Fits [style guide](https://nix-community.github.io/stylix/styling.html)
- [x] Respects license of any existing code used

## Notify maintainers

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->
