### PR TITLE
flake: use biome formatter for JSON & CSS

### DIFF
--- a/flake/default.nix
+++ b/flake/default.nix
@@ -45,7 +45,15 @@
                   };
                 })
               ];
-              includes = [ "*.js" ];
+              includes = [
+                "*.css"
+                "*.js"
+                "*.json"
+              ];
+              excludes = [
+                # Contains custom syntax that biome can't handle
+                "modules/swaync/base.css"
+              ];
             };
             ruff = {
               command = "ruff";

--- a/modules/vscode/package.json
+++ b/modules/vscode/package.json
@@ -4,15 +4,17 @@
   "version": "0.0.0",
   "publisher": "stylix",
   "description": "Theme configured via NixOS or Home Manager.",
-  "categories": [ "Themes" ],
+  "categories": ["Themes"],
   "engines": {
     "vscode": "^1.43.0"
   },
   "contributes": {
-    "themes": [{
-      "label": "Stylix",
-      "uiTheme": "vs",
-      "path": "./themes/stylix.json"
-    }]
+    "themes": [
+      {
+        "label": "Stylix",
+        "uiTheme": "vs",
+        "path": "./themes/stylix.json"
+      }
+    ]
   }
 }

--- a/modules/waybar/base.css
+++ b/modules/waybar/base.css
@@ -1,60 +1,60 @@
 #wireplumber,
 #pulseaudio,
 #sndio {
-    padding: 0 5px;
+  padding: 0 5px;
 }
 #wireplumber.muted,
 #pulseaudio.muted,
 #sndio.muted {
-    padding: 0 5px;
+  padding: 0 5px;
 }
 #upower,
 #battery {
-    padding: 0 5px;
+  padding: 0 5px;
 }
 #upower.charging,
 #battery.Charging {
-    padding: 0 5px;
+  padding: 0 5px;
 }
 #network {
-    padding: 0 5px;
+  padding: 0 5px;
 }
 #network.disconnected {
-    padding: 0 5px;
+  padding: 0 5px;
 }
 #user {
-    padding: 0 5px;
+  padding: 0 5px;
 }
 #clock {
-    padding: 0 5px;
+  padding: 0 5px;
 }
 #backlight {
-    padding: 0 5px;
+  padding: 0 5px;
 }
 #cpu {
-    padding: 0 5px;
+  padding: 0 5px;
 }
 #disk {
-    padding: 0 5px;
+  padding: 0 5px;
 }
 #idle_inhibitor {
-    padding: 0 5px;
+  padding: 0 5px;
 }
 #temperature {
-    padding: 0 5px;
+  padding: 0 5px;
 }
 #mpd {
-    padding: 0 5px;
+  padding: 0 5px;
 }
 #language {
-    padding: 0 5px;
+  padding: 0 5px;
 }
 #keyboard-state {
-    padding: 0 5px;
+  padding: 0 5px;
 }
 #memory {
-    padding: 0 5px;
+  padding: 0 5px;
 }
 #window {
-    padding: 0 5px;
+  padding: 0 5px;
 }


### PR DESCRIPTION
Was added in #1335 for formatting JavaScript. This PR extends it to also cover CSS and JSON.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [ ] Tested locally
- [ ] Tested in [testbed](https://nix-community.github.io/stylix/testbeds.html)
- [x] Commit message follows [commit convention](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Fits [style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Respects license of any existing code used

## Notify maintainers

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->

@trueNAHO 