### PR TITLE
home-manager: cast cursor size to int

### DIFF
--- a/stylix/hm/cursor.nix
+++ b/stylix/hm/cursor.nix
@@ -19,7 +19,8 @@ in
       )
       {
         home.pointerCursor = {
-          inherit (cfg) name package size;
+          inherit (cfg) name package;
+          size = builtins.floor (cfg.size + 0.5);
           x11.enable = true;
           gtk.enable = true;
         };


### PR DESCRIPTION
Fixes #1396
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [ ] Tested locally
- [ ] Tested in [testbed](https://nix-community.github.io/stylix/testbeds.html)
- [x] Commit message follows [commit convention](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Fits [style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Respects license of any existing code used

## Notify maintainers

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->
