### PR TITLE
stylix: check base16Scheme is not null before using mkSchemeAttrs

### DIFF
--- a/stylix/palette.nix
+++ b/stylix/palette.nix
@@ -164,7 +164,14 @@ in
   config = {
     # This attrset can be used like a function too, see
     # https://github.com/SenchoPens/base16.nix/blob/b390e87cd404e65ab4d786666351f1292e89162a/README.md#theme-step-22
-    lib.stylix.colors = (cfg.base16.mkSchemeAttrs cfg.base16Scheme).override cfg.override;
+    #
+    # NOTE: base16Scheme is nullable. If null, we cannot pass it to mkSchemeAttrs.
+    # See https://github.com/nix-community/stylix/pull/1408
+    lib.stylix.colors =
+      if cfg.base16Scheme == null then
+        null
+      else
+        (cfg.base16.mkSchemeAttrs cfg.base16Scheme).override cfg.override;
 
     assertions = lib.mkIf cfg.enable [
       {


### PR DESCRIPTION
The issue happens when `config.stylix.base16Scheme` is null and it is passed to `mkSchemeAttrs` to create `config.lib.stylix.colors`. This leads to an eval failure while checking assertions, meaning the assertions themselves never get printed.

Fixes #1046 and #1385

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [x] Tested locally
  - Tested with MRE described in #1385
- [ ] Tested in [testbed](https://nix-community.github.io/stylix/testbeds.html)
- [x] Commit message follows [commit convention](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Fits [style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Respects license of any existing code used

## Notify maintainers

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->
