### PR TITLE
stylix: improve type for `stylix.image` option

### DIFF
--- a/stylix/palette.nix
+++ b/stylix/palette.nix
@@ -29,7 +29,10 @@ in
     };
 
     image = lib.mkOption {
-      type = with lib.types; nullOr (coercedTo package toString path);
+      type = lib.types.nullOr lib.types.path;
+      # Ensure the path is copied to the store
+      apply =
+        value: if value == null || lib.isDerivation value then value else "${value}";
       description = ''
         Wallpaper image.
 


### PR DESCRIPTION
Previously:
- Out-of-store paths were not necessarily copied to store.
- Derivations were needlessly coerced to strings.
- `package` and `path` were both used, despite `path` being a superset of `package`.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [ ] Tested locally
- [ ] Tested in [testbed](https://nix-community.github.io/stylix/testbeds.html)
- [x] Commit message follows [commit convention](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Fits [style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Respects license of any existing code used

## Notify maintainers

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->
