### PR TITLE
gnome: fix obsolete option warning

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -218,11 +218,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1747542820,
-        "narHash": "sha256-GaOZntlJ6gPPbbkTLjbd8BMWaDYafhuuYRNrxCGnPJw=",
+        "lastModified": 1748370509,
+        "narHash": "sha256-QlL8slIgc16W5UaI3w7xHQEP+Qmv/6vSNTpoZrrSlbk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "292fa7d4f6519c074f0a50394dbbe69859bb6043",
+        "rev": "4faa5f5321320e49a78ae7848582f684d64783e9",
         "type": "github"
       },
       "original": {

--- a/modules/gnome/nixos.nix
+++ b/modules/gnome/nixos.nix
@@ -22,8 +22,8 @@ in
         config.stylix.enable
         && config.stylix.targets.gnome.enable
         && (
-          config.services.xserver.desktopManager.gnome.enable
-          || config.services.xserver.displayManager.gdm.enable
+          config.services.desktopManager.gnome.enable
+          || config.services.displayManager.gdm.enable
         )
       )
       {


### PR DESCRIPTION
## Things done

`config.services.xserver.desktopManager.gnome.enable` changed to `config.services.desktopManager.gnome.enable`

`config.services.xserver.displayManager.gdm.enable` changed to `config.services.displayManager.gdm.enable`

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [x] Tested locally
- [ ] Tested in [testbed](https://nix-community.github.io/stylix/testbeds.html)
- [x] Commit message follows [commit convention](https://nix-community.github.io/stylix/commit_convention.html)
- [x] Fits [style guide](https://nix-community.github.io/stylix/styling.html)
- [x] Respects license of any existing code used

## Notify maintainers

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->
