### PR TITLE
ci: fix backport conditions

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,6 +1,6 @@
 ---
 # Derived from
-# https://github.com/NixOS/nixpkgs/blob/2ab6f6d61630889491f86396b27a76ffb6fbc7bb/.github/workflows/backport.yml
+# https://github.com/NixOS/nixpkgs/blob/2566f9dcb469b06241519a8185863d67773f943a/.github/workflows/backport.yml
 name: Backport
 
 on:  # yamllint disable-line rule:truthy
@@ -15,11 +15,11 @@ jobs:
 
     if: >
       (
-        github.repository_owner == 'nix-community' &&
+        vars.APP_ID &&
         github.event.pull_request.merged == true &&
         (
-          github.event_name != 'labeled' ||
-          startsWith('backport: ', github.event.label.name)
+          github.event.action != 'labeled' ||
+          startsWith(github.event.label.name, 'backport: ')
         )
       )
 


### PR DESCRIPTION

- Check APP_ID variable instead of owner
- Fix `event_name` → `event.action`
- Fix `startsWith` parameter order

See:

- https://github.com/NixOS/nixpkgs/commit/b62d9a22fbab05be9b6fdb473d89fc2fd9fe4c1d
- https://github.com/NixOS/nixpkgs/commit/01900de145ad773dc3d289cb8dcfc35b7b9c32a2
- https://github.com/NixOS/nixpkgs/commit/b6375b21c0996de13051110c80ff72ec1669261c

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [ ] Tested locally
- [ ] Tested in [testbed](https://nix-community.github.io/stylix/testbeds.html)
- [x] Commit message follows [commit convention](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Fits [style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Respects license of any existing code used

## Notify maintainers

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->
