### PR TITLE
yazi: Change deprecated "manager" to new name "mgr"

### DIFF
--- a/modules/yazi/hm.nix
+++ b/modules/yazi/hm.nix
@@ -16,9 +16,9 @@ mkTarget {
           mkSame = c: (mkBoth c c);
         in
         {
-          manager = rec {
+          mgr = rec {
             # Reusing bat themes, since it's suggested in the stying guide
-            # https://yazi-rs.github.io/docs/configuration/theme#manager
+            # https://yazi-rs.github.io/docs/configuration/theme#mgr
             syntect_theme = colors {
               template = ../bat/base16-stylix.tmTheme.mustache;
               extension = ".tmTheme";


### PR DESCRIPTION
The latest release of yazi (which is already in nixos-unstable) changed the "manager" field to "mgr" (see https://github.com/sxyazi/yazi/releases/tag/v25.5.28). This fixes it so yazi stops complaining and trying to fix the read-only theme file



<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [x] Tested locally
- [ ] Tested in [testbed](https://nix-community.github.io/stylix/testbeds.html)
- [x] Commit message follows [commit convention](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Fits [style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Respects license of any existing code used

## Notify maintainers

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->
