### PR TITLE
firefox: add naho as maintainer

### DIFF
--- a/modules/firefox/meta.nix
+++ b/modules/firefox/meta.nix
@@ -9,6 +9,7 @@
   maintainers = with lib.maintainers; [
     Flameopathic
     danth
+    naho
   ];
   description = ''
     This module supports [Firefox](https://www.mozilla.org/firefox/), in addition


### PR DESCRIPTION
```
Although qutebrowser is my main browser, I occasionally use LibreWolf
and Tor Browser. Consequently, I am adding myself as a maintainer to
this rather important module.
```



<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [ ] Tested locally
- [ ] Tested in [testbed](https://nix-community.github.io/stylix/testbeds.html)
- [X] Commit message follows [commit convention](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Fits [style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Respects license of any existing code used

## Notify maintainers

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->
