### PR TITLE
waybar: add option to add custom CSS after stylix

### DIFF
--- a/modules/waybar/hm.nix
+++ b/modules/waybar/hm.nix
@@ -1,4 +1,8 @@
-{ config, lib, ... }:
+{
+  config,
+  lib,
+  ...
+}:
 let
   cfg = config.stylix.targets.waybar;
   colorlessModules = place: ''
@@ -29,6 +33,26 @@ in
       type = lib.types.bool;
       default = true;
       description = "adds fully functional css (otherwise just adds colors and fonts)";
+    };
+    customCss = lib.mkOption {
+      type = lib.types.string;
+      default = "";
+      description = "add custom CSS to the end of waybar's configuration";
+      example =
+        # css
+        ''
+          * {
+            font-size: 16px;
+            min-height: 0;
+            border-radius: 1rem;
+            padding: 0.1rem;
+          }
+
+          window#waybar {
+            background: rgba(255, 255, 255, 0.5);
+            color: rgb(0, 0, 0);
+          }
+        '';
     };
     enableLeftBackColors = lib.mkOption {
       type = lib.types.bool;
@@ -92,6 +116,7 @@ in
           else
             colorlessModules "right"
         )
-      );
+      )
+      + cfg.customCss;
   };
 }


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

## Things done

Using stylix with waybar appears to prevent you from using custom CSS at all for waybar since it uses the only provided option by HM (`programs.waybar.style`) and that cannot be easily merged while getting the stylix logic (at least for me). 

So this adds a `customCss` option to `stylix.targets.waybar` that will append the user-provided CSS to the end of the option, after stylix's colors and everything else.

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [x] Tested locally
- [ ] Tested in [testbed](https://nix-community.github.io/stylix/testbeds.html)
- [x] Commit message follows [commit convention](https://nix-community.github.io/stylix/commit_convention.html)
- [x] Fits [style guide](https://nix-community.github.io/stylix/styling.html)
- [x] Respects license of any existing code used

## Notify maintainers

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->

@awwpotato 