### PR TITLE
wayprompt: drop `-hex` suffix on single color value

### DIFF
--- a/modules/wayprompt/hm.nix
+++ b/modules/wayprompt/hm.nix
@@ -10,7 +10,7 @@ mkTarget {
     in
     {
       programs.wayprompt.settings.colours = with colors; {
-        background = "${base00-hex}${opacity'}";
+        background = "${base00}${opacity'}";
         border = base0D;
         text = base05;
         error-text = base08;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

To reduce the surprise factor when comparing it to the other color specs in this file.

See the conversation starting [here](https://github.com/nix-community/stylix/pull/1378#discussion_r2106267423).

Ref: #1378

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [x] Tested locally
- [ ] Tested in [testbed](https://nix-community.github.io/stylix/testbeds.html)
- [x] Commit message follows [commit convention](https://nix-community.github.io/stylix/commit_convention.html)
- [x] Fits [style guide](https://nix-community.github.io/stylix/styling.html)
- [x] Respects license of any existing code used

## Notify maintainers

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->
maintainers: @nukdokplex, @panchoh