### PR TITLE
doc: Add VSCode color customization tip

### DIFF
--- a/modules/vscode/meta.nix
+++ b/modules/vscode/meta.nix
@@ -6,4 +6,28 @@
     Flameopathic
     danth
   ];
+  description = ''
+    When theming is enabled for VSCode, Stylix will create and apply its own
+    VSCode theme, as well as configure settings concerning fonts.
+    > [!TIP]
+    > The theme created is called
+    > [`Stylix`](
+    > https://github.com/nix-community/stylix/blob/master/modules/vscode/templates/theme.nix),
+    > and if one so desires, its colors can be changed using
+    > `programs.vscode.profiles.<name>.userSettings`
+    > (exactly as one would customize any other VSCode theme).
+    > See the example below; the syntax is explained in the
+    > [VSCode documentation](
+    > https://code.visualstudio.com/docs/configure/themes#_customize-a-color-theme).
+    > ```nix
+    > programs.vscode.profiles.default.userSettings = {
+    >   "workbench.colorCustomizations" = {
+    >     "[Stylix]" = {
+    >       "editor.wordHighlightBackground"  = "#''${colors.base02}66";
+    >       "editor.hoverHighlightBackground" = "#''${colors.base02}66";
+    >     };
+    >   };
+    > };
+    > ```
+  '';
 }


### PR DESCRIPTION
This PR simply adds a tip in the description of the VSCode documentation page, that the colors can be overridden using the [VSCode settings](https://code.visualstudio.com/docs/configure/themes#_customize-a-color-theme).

Feel free to suggest rewording or reject this PR if it feels unnecessary. I personally first went looking at the docs, then Nix source code, to see if there was any option I could override, when the VSCode settings solution is surprisingly simple.

(I personally simply wanted to change the` wordHighlightBackground` and `hoverHighlightBackground` colors, since they are the same color as the normal text selection color and thus I could not see which part of the word I have selected).


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [x] Tested locally
- [ ] Tested in [testbed](https://nix-community.github.io/stylix/testbeds.html)
- [x] Commit message follows [commit convention](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Fits [style guide](https://nix-community.github.io/stylix/styling.html)
- [x] Respects license of any existing code used

## Notify maintainers
<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->
@Flameopathic 
@danth 