### PR TITLE
i3status-rust: use mkTarget

### DIFF
--- a/modules/i3status-rust/hm.nix
+++ b/modules/i3status-rust/hm.nix
@@ -1,19 +1,28 @@
-{ config, ... }:
-{
+{ mkTarget, lib, ... }:
+mkTarget {
+  name = "i3status-rust";
+  humanName = "i3status-rust";
+
   # Merge this with your bar's theme's overrides with //config.lib.stylix.i3status-rust.bar
-  config.lib.stylix.i3status-rust.bar =
-    with config.lib.stylix.colors.withHashtag; {
-      idle_bg = base00;
-      idle_fg = base05;
-      info_bg = base09;
-      info_fg = base00;
-      good_bg = base01;
-      good_fg = base05;
-      warning_bg = base0A;
-      warning_fg = base00;
-      critical_bg = base08;
-      critical_fg = base00;
-      separator_bg = base00;
-      separator_fg = base05;
+  generalConfig =
+    { colors }:
+    {
+      lib.stylix.i3status-rust.bar = lib.mkIf (colors != null) (
+        with colors.withHashtag;
+        {
+          idle_bg = base00;
+          idle_fg = base05;
+          info_bg = base09;
+          info_fg = base00;
+          good_bg = base01;
+          good_fg = base05;
+          warning_bg = base0A;
+          warning_fg = base00;
+          critical_bg = base08;
+          critical_fg = base00;
+          separator_bg = base00;
+          separator_fg = base05;
+        }
+      );
     };
 }


### PR DESCRIPTION
can't use `configElements` here to due to inf rec 
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [ ] Tested locally
- [ ] Tested in [testbed](https://nix-community.github.io/stylix/testbeds.html)
- [x] Commit message follows [commit convention](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Fits [style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Respects license of any existing code used

## Notify maintainers

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->
