### PR TITLE
fuzzel: apply iconTheme

### DIFF
--- a/modules/fuzzel/hm.nix
+++ b/modules/fuzzel/hm.nix
@@ -32,5 +32,12 @@ mkTarget {
         };
       }
     )
+    (
+      { polarity, iconTheme }:
+      {
+        programs.fuzzel.settings.main."icon-theme" =
+          if (polarity == "dark") then iconTheme.dark else iconTheme.light;
+      }
+    )
   ];
 }


### PR DESCRIPTION




<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

## Things done

Applies the iconTheme to fuzzel, if one is set.

Fuzzel otherwise always defaults to `hicolor`.

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [x] Tested locally
- [ ] Tested in [testbed](https://nix-community.github.io/stylix/testbeds.html)
- [x] Commit message follows [commit convention](https://nix-community.github.io/stylix/commit_convention.html)
- [x] Fits [style guide](https://nix-community.github.io/stylix/styling.html)
- [x] Respects license of any existing code used

## Notify maintainers

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->
