### PR TITLE
waybar: support specifying font families

### DIFF
--- a/modules/waybar/hm.nix
+++ b/modules/waybar/hm.nix
@@ -14,16 +14,11 @@ in
 {
   options.stylix.targets.waybar = {
     enable = config.lib.stylix.mkEnableTarget "Waybar" true;
-    font = lib.mkOption {
-      type = lib.types.enum [
-        "serif"
-        "sansSerif"
-        "monospace"
-        "emoji"
-      ];
-      default = "monospace";
-      example = "sansSerif";
-      description = "The font for waybar to use";
+    fontFamilies = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ config.stylix.fonts.monospace.name ];
+      example = [ "Cascadia Code" ];
+      description = "The font families for waybar to use";
     };
     addCss = lib.mkOption {
       type = lib.types.bool;
@@ -58,7 +53,9 @@ in
         @define-color base0C ${base0C}; @define-color base0D ${base0D}; @define-color base0E ${base0E}; @define-color base0F ${base0F};
 
         * {
-            font-family: "${config.stylix.fonts.${cfg.font}.name}";
+            font-family: ${
+              builtins.concatStringsSep ", " (map (x: "\"" + x + "\"") cfg.fontFamilies)
+            };
             font-size: ${builtins.toString config.stylix.fonts.sizes.desktop}pt;
         }
       ''


### PR DESCRIPTION
Change option `font` to `fontFamilies`, so that waybar can use a font list.

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [x] Tested locally
- [ ] Tested in [testbed](https://nix-community.github.io/stylix/testbeds.html)

  waybar module doesn't provide testbed.

- [x] Commit message follows [commit convention](https://nix-community.github.io/stylix/commit_convention.html)
- [x] Fits [style guide](https://nix-community.github.io/stylix/styling.html)
- [x] Respects license of any existing code used

## Notify maintainers

@awwpotato 
