### PR TITLE
doc: add link to `PULL_REQUEST_TEMPLATE.md`

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,7 +12,7 @@ Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
 Please check what applies. Note that these are not hard requirements but merely
 serve as information for reviewers.
 -->
-- [ ] Tested locally
+- [ ] Tested [locally](https://nix-community.github.io/stylix/modules.html#development-setup)
 - [ ] Tested in [testbed](https://nix-community.github.io/stylix/testbeds.html)
 - [ ] Commit message follows [commit convention](https://nix-community.github.io/stylix/commit_convention.html)
 - [ ] Fits [style guide](https://nix-community.github.io/stylix/styling.html)


### PR DESCRIPTION
The “Tested locally” entry now has a pointer to the relevant section in the documentation.

(This one almost [fell through the cracks](https://github.com/nix-community/stylix/pull/1261#issuecomment-2881689203); sorry for the delay, @awwpotato!)

This is an interim fix until we tackle having a comprehensive `CONTRIBUTING.md`, as suggested by @MattSturgeon on #1499.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [ ] Tested locally
- [ ] Tested in [testbed](https://nix-community.github.io/stylix/testbeds.html)
- [x] Commit message follows [commit convention](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Fits [style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Respects license of any existing code used

## Notify maintainers

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->

@awwpotato @danth 