### PR TITLE
stylix: simplify mkTarget's argument trimming

### DIFF
--- a/stylix/mk-target.nix
+++ b/stylix/mk-target.nix
@@ -206,11 +206,7 @@ let
         lib.genAttrs (functionArgNames fn) (
           arg:
           let
-            trimmedArg =
-              let
-                prefix = "_";
-              in
-              if lib.hasPrefix prefix arg then lib.removePrefix prefix arg else arg;
+            trimmedArg = lib.removePrefix "_" arg;
           in
           if trimmedArg == "cfg" then
             cfg


### PR DESCRIPTION
```
Fixes: 744385eedf23 ("mkTarget: allow _${arg}")
```

This change is a no-op because `lib.removePrefix` already performs the `lib.hasPrefix` check, except that it caches `stringLength prefix`:

- > ```nix
  >   hasPrefix =
  >     pref: str:
  >     # Before 23.05, paths would be copied to the store before converting them
  >     # to strings and comparing. This was surprising and confusing.
  >     warnIf (isPath pref)
  >       ''
  >         lib.strings.hasPrefix: The first argument (${toString pref}) is a path value, but only strings are supported.
  >             There is almost certainly a bug in the calling code, since this function always returns `false` in such a case.
  >             This function also copies the path to the Nix store, which may not be what you want.
  >             This behavior is deprecated and will throw an error in the future.
  >             You might want to use `lib.path.hasPrefix` instead, which correctly supports paths.''
  >       (substring 0 (stringLength pref) str == pref);
  > ```
  >
  > -- [Nixpkgs, `/lib/strings.nix:768`](https://github.com/NixOS/nixpkgs/blob/ee29092a0db3b600ff9d2786cf38427b820e3e75/lib/strings.nix#L738-L779)

- > ```nix
  >   removePrefix =
  >     prefix: str:
  >     # Before 23.05, paths would be copied to the store before converting them
  >     # to strings and comparing. This was surprising and confusing.
  >     warnIf (isPath prefix)
  >       ''
  >         lib.strings.removePrefix: The first argument (${toString prefix}) is a path value, but only strings are supported.
  >             There is almost certainly a bug in the calling code, since this function never removes any prefix in such a case.
  >             This function also copies the path to the Nix store, which may not be what you want.
  >             This behavior is deprecated and will throw an error in the future.''
  >       (
  >         let
  >           preLen = stringLength prefix;
  >         in
  >         if substring 0 preLen str == prefix then
  >           # -1 will take the string until the end
  >           substring preLen (-1) str
  >         else
  >           str
  >       );
  > ```
  >
  > -- [Nixpkgs, `/lib/strings.nix:1808`](https://github.com/NixOS/nixpkgs/blob/ee29092a0db3b600ff9d2786cf38427b820e3e75/lib/strings.nix#L1778-L1827)

## Things done

- [ ] Tested locally
- [ ] Tested in [testbed](https://nix-community.github.io/stylix/testbeds.html)
- [X] Commit message follows [commit convention](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Fits [style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Respects license of any existing code used

## Notify maintainers
