### PR TITLE
discord: use mkTarget

### DIFF
--- a/modules/discord/common/color-theme.nix
+++ b/modules/discord/common/color-theme.nix
@@ -1,58 +1,47 @@
-{ colors, fonts }:
-''
-    /**
-    * @name Stylix
-    * @author Stylix
-    * @version 0.0.0
-    * @description Theme configured via NixOS or Home Manager.
-    **/
+colors: ''
+  :root {
+      --base00: #${colors.base00}; /* Black */
+      --base01: #${colors.base01}; /* Bright Black */
+      --base02: #${colors.base02}; /* Grey */
+      --base03: #${colors.base03}; /* Brighter Grey */
+      --base04: #${colors.base04}; /* Bright Grey */
+      --base05: #${colors.base05}; /* White */
+      --base06: #${colors.base06}; /* Brighter White */
+      --base07: #${colors.base07}; /* Bright White */
+      --base08: #${colors.base08}; /* Red */
+      --base09: #${colors.base09}; /* Orange */
+      --base0A: #${colors.base0A}; /* Yellow */
+      --base0B: #${colors.base0B}; /* Green */
+      --base0C: #${colors.base0C}; /* Cyan */
+      --base0D: #${colors.base0D}; /* Blue */
+      --base0E: #${colors.base0E}; /* Purple */
+      --base0F: #${colors.base0F}; /* Magenta */
 
-    :root {
-        --font-primary: ${fonts.sansSerif.name};
-        --font-display: ${fonts.sansSerif.name};
-        --font-code: ${fonts.monospace.name};
-        --base00: #${colors.base00}; /* Black */
-        --base01: #${colors.base01}; /* Bright Black */
-        --base02: #${colors.base02}; /* Grey */
-        --base03: #${colors.base03}; /* Brighter Grey */
-        --base04: #${colors.base04}; /* Bright Grey */
-        --base05: #${colors.base05}; /* White */
-        --base06: #${colors.base06}; /* Brighter White */
-        --base07: #${colors.base07}; /* Bright White */
-        --base08: #${colors.base08}; /* Red */
-        --base09: #${colors.base09}; /* Orange */
-        --base0A: #${colors.base0A}; /* Yellow */
-        --base0B: #${colors.base0B}; /* Green */
-        --base0C: #${colors.base0C}; /* Cyan */
-        --base0D: #${colors.base0D}; /* Blue */
-        --base0E: #${colors.base0E}; /* Purple */
-        --base0F: #${colors.base0F}; /* Magenta */
+      --primary-630: var(--base00); /* Autocomplete background */
+      --primary-660: var(--base00); /* Search input background */
+  }
 
-        --primary-630: var(--base00); /* Autocomplete background */
-        --primary-660: var(--base00); /* Search input background */
-    }
+    /* Copyright (c) 2025 Cole Schaefer
 
-      /* Copyright (c) 2025 Cole Schaefer
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
 
-      Permission is hereby granted, free of charge, to any person obtaining a copy
-      of this software and associated documentation files (the "Software"), to deal
-      in the Software without restriction, including without limitation the rights
-      to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-      copies of the Software, and to permit persons to whom the Software is
-      furnished to do so, subject to the following conditions:
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
 
-      The above copyright notice and this permission notice shall be included in all
-      copies or substantial portions of the Software.
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE. */
 
-      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-      IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-      FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-      AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-      LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-      OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-      SOFTWARE. */
-
-      .theme-light,
+  .theme-light,
   .theme-dark,
   .theme-darker,
   .theme-midnight,

--- a/modules/discord/common/font-theme.nix
+++ b/modules/discord/common/font-theme.nix
@@ -1,0 +1,7 @@
+fonts: ''
+  :root {
+      --font-primary: ${fonts.sansSerif.name};
+      --font-display: ${fonts.sansSerif.name};
+      --font-code: ${fonts.monospace.name};
+  }
+''

--- a/modules/discord/common/theme-elements.nix
+++ b/modules/discord/common/theme-elements.nix
@@ -1,0 +1,17 @@
+name: [
+  {
+    stylix.targets.${name}.themeBody = import ./theme-header.nix;
+  }
+  (
+    { fonts }:
+    {
+      stylix.targets.${name}.themeBody = import ./font-theme.nix fonts;
+    }
+  )
+  (
+    { colors }:
+    {
+      stylix.targets.${name}.themeBody = import ./color-theme.nix colors;
+    }
+  )
+]

--- a/modules/discord/common/theme-header.nix
+++ b/modules/discord/common/theme-header.nix
@@ -1,0 +1,8 @@
+''
+  /**
+  * @name Stylix
+  * @author Stylix
+  * @version 0.0.0
+  * @description Theme configured via NixOS or Home Manager.
+  **/
+''

--- a/modules/discord/hm.nix
+++ b/modules/discord/hm.nix
@@ -1,94 +1,12 @@
 {
-  config,
+  mkTarget,
   lib,
-  pkgs,
-  options,
   ...
 }:
-let
-  template = import ./template.nix {
-    inherit (config.lib.stylix) colors;
-    inherit (config.stylix) fonts;
-  };
-in
 {
-  imports = lib.singleton (
-    lib.mkRemovedOptionModule [ "stylix" "targets" "vesktop" "extraCss" ]
-      "CSS can be added to by declaring 'programs.vesktop.vencord.themes.stylix = lib.mkAfter \"YOUR EXTRA CSS\";"
-  );
-  options.stylix.targets = {
-    vesktop.enable = config.lib.stylix.mkEnableTarget "Vesktop" true;
-    vencord = {
-      enable = config.lib.stylix.mkEnableTarget "Vencord" true;
-      extraCss = lib.mkOption {
-        description = "Extra CSS to added to Vencord's theme";
-        type = lib.types.lines;
-        default = "";
-      };
-    };
-    nixcord = {
-      enable = config.lib.stylix.mkEnableTarget "Nixcord" true;
-      extraCss = lib.mkOption {
-        description = "Extra CSS to added to Nixcord's theme";
-        type = lib.types.lines;
-        default = "";
-      };
-    };
-  };
-
-  config =
-    let
-      inherit (config.programs) nixcord;
-    in
-    lib.mkIf config.stylix.enable (
-      lib.mkMerge [
-        (lib.mkIf config.stylix.targets.vencord.enable {
-          xdg.configFile."Vencord/themes/stylix.theme.css".text =
-            template + config.stylix.targets.vencord.extraCss;
-        })
-
-        (lib.mkIf config.stylix.targets.vesktop.enable {
-          programs.vesktop.vencord = {
-            themes.stylix = template;
-            settings.enabledThemes = [ "stylix.css" ];
-          };
-        })
-
-        (lib.mkIf config.stylix.targets.nixcord.enable (
-          lib.optionalAttrs (builtins.hasAttr "nixcord" options.programs) (
-            lib.mkMerge [
-              (lib.mkIf nixcord.discord.enable (
-                lib.mkMerge [
-                  (lib.mkIf (!pkgs.stdenv.hostPlatform.isDarwin || config.xdg.enable) {
-                    xdg.configFile."Vencord/themes/stylix.theme.css".text =
-                      template + config.stylix.targets.nixcord.extraCss;
-                  })
-
-                  (lib.mkIf (pkgs.stdenv.hostPlatform.isDarwin && !config.xdg.enable) {
-                    home.file."Library/Application Support/Vencord/themes/stylix.theme.css".text =
-                      template + config.stylix.targets.nixcord.extraCss;
-                  })
-                ]
-              ))
-              (lib.mkIf nixcord.vesktop.enable (
-                lib.mkMerge [
-                  (lib.mkIf (!pkgs.stdenv.hostPlatform.isDarwin || config.xdg.enable) {
-                    xdg.configFile."vesktop/themes/stylix.theme.css".text =
-                      template + config.stylix.targets.nixcord.extraCss;
-                  })
-
-                  (lib.mkIf (pkgs.stdenv.hostPlatform.isDarwin && !config.xdg.enable) {
-                    home.file."Library/Application Support/vesktop/themes/stylix.theme.css".text =
-                      template + config.stylix.targets.nixcord.extraCss;
-                  })
-                ]
-              ))
-              {
-                programs.nixcord.config.enabledThemes = [ "stylix.theme.css" ];
-              }
-            ]
-          )
-        ))
-      ]
-    );
+  imports = map (module: lib.modules.importApply module mkTarget) [
+    ./nixcord.nix
+    ./vencord.nix
+    ./vesktop.nix
+  ];
 }

--- a/modules/discord/nixcord.nix
+++ b/modules/discord/nixcord.nix
@@ -1,0 +1,71 @@
+mkTarget:
+{
+  lib,
+  config,
+  pkgs,
+  options,
+  ...
+}:
+mkTarget {
+  name = "nixcord";
+  humanName = "Nixcord";
+
+  extraOptions = {
+    themeBody = lib.mkOption {
+      type = lib.types.lines;
+      default = "";
+      internal = true;
+    };
+    extraCss = lib.mkOption {
+      description = "Extra CSS to added to Nixcord's theme";
+      type = lib.types.lines;
+      default = "";
+    };
+  };
+
+  configElements = (import ./common/theme-elements.nix "nixcord") ++ [
+    (
+      { cfg }:
+      let
+        inherit (config.programs) nixcord;
+      in
+      lib.mkIf
+        (cfg.themeBody != (import ./common/theme-header.nix || cfg.extraCss != ""))
+        (
+          lib.optionalAttrs (builtins.hasAttr "nixcord" options.programs) (
+            lib.mkMerge [
+              (lib.mkIf nixcord.discord.enable (
+                lib.mkMerge [
+                  (lib.mkIf (!pkgs.stdenv.hostPlatform.isDarwin || config.xdg.enable) {
+                    xdg.configFile."Vencord/themes/stylix.theme.css".text =
+                      cfg.themeBody + cfg.extraCss;
+                  })
+
+                  (lib.mkIf (pkgs.stdenv.hostPlatform.isDarwin && !config.xdg.enable) {
+                    home.file."Library/Application Support/Vencord/themes/stylix.theme.css".text =
+                      cfg.themeBody + cfg.extraCss;
+                  })
+                ]
+              ))
+              (lib.mkIf nixcord.vesktop.enable (
+                lib.mkMerge [
+                  (lib.mkIf (!pkgs.stdenv.hostPlatform.isDarwin || config.xdg.enable) {
+                    xdg.configFile."vesktop/themes/stylix.theme.css".text =
+                      cfg.themeBody + cfg.extraCss;
+                  })
+
+                  (lib.mkIf (pkgs.stdenv.hostPlatform.isDarwin && !config.xdg.enable) {
+                    home.file."Library/Application Support/vesktop/themes/stylix.theme.css".text =
+                      cfg.themeBody + cfg.extraCss;
+                  })
+                ]
+              ))
+              {
+                programs.nixcord.config.enabledThemes = [ "stylix.theme.css" ];
+              }
+            ]
+          )
+        )
+    )
+  ];
+}

--- a/modules/discord/vencord.nix
+++ b/modules/discord/vencord.nix
@@ -1,0 +1,31 @@
+mkTarget:
+{ lib, ... }:
+mkTarget {
+  name = "vencord";
+  humanName = "Vencord";
+
+  extraOptions = {
+    themeBody = lib.mkOption {
+      type = lib.types.lines;
+      default = "";
+      internal = true;
+    };
+    extraCss = lib.mkOption {
+      description = "Extra CSS to added to Vencord's theme";
+      type = lib.types.lines;
+      default = "";
+    };
+  };
+
+  configElements = (import ./common/theme-elements.nix "vencord") ++ [
+    (
+      { cfg }:
+      lib.mkIf
+        (cfg.themeBody != (import ./common/theme-header.nix) || cfg.extraCss != "")
+        {
+          xdg.configFile."Vencord/themes/stylix.theme.css".text =
+            cfg.themeBody + cfg.extraCss;
+        }
+    )
+  ];
+}

--- a/modules/discord/vesktop.nix
+++ b/modules/discord/vesktop.nix
@@ -1,0 +1,29 @@
+mkTarget:
+{ lib, ... }:
+mkTarget {
+  name = "vesktop";
+  humanName = "Vesktop";
+
+  extraOptions.themeBody = lib.mkOption {
+    type = lib.types.lines;
+    default = "";
+    internal = true;
+  };
+
+  configElements = (import ./common/theme-elements.nix "vesktop") ++ [
+    (
+      { cfg }:
+      lib.mkIf (cfg.themeBody != (import ./common/theme-header.nix)) {
+        programs.vesktop.vencord = {
+          themes.stylix = cfg.themeBody;
+          settings.enabledThemes = [ "stylix.css" ];
+        };
+      }
+    )
+  ];
+
+  imports = lib.singleton (
+    lib.mkRemovedOptionModule [ "stylix" "targets" "vesktop" "extraCss" ]
+      "CSS can be added to by declaring 'programs.vesktop.vencord.themes.stylix = lib.mkAfter \"YOUR EXTRA CSS\";"
+  );
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

## Things done
- `template.nix` split into three files under `common`
    - Some (technically out of scope) whitespace changes in `common/color-theme.nix`
- Individual files made for each target
- `common/theme-elements.nix` stores the three elements which assemble the full theme file

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [ ] Tested [locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [x] Tested in [testbed](https://nix-community.github.io/stylix/testbeds.html) 
- [x] Commit message follows [commit convention](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Fits [style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Respects license of any existing code used

## Notify maintainers
@Flameopathic
<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->
