### PR TITLE
bemenu: add defaultText to fontSize

### DIFF
--- a/modules/bemenu/hm.nix
+++ b/modules/bemenu/hm.nix
@@ -15,6 +15,7 @@ mkTarget {
       '';
       type = with lib.types; nullOr int;
       default = config.stylix.fonts.sizes.popups;
+      defaultText = lib.literalExpression "config.stylix.fonts.sizes.popups";
     }; # optional argument
 
     alternate = lib.mkOption {


### PR DESCRIPTION
https://github.com/nix-community/stylix/pull/1368#discussion_r2148905012
cc @MattSturgeon 
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [ ] Tested [locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Tested in [testbed](https://nix-community.github.io/stylix/testbeds.html)
- [x] Commit message follows [commit convention](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Fits [style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Respects license of any existing code used

## Notify maintainers

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->
