### PR TITLE
treewide: use config in literalExpressions

### DIFF
--- a/modules/hyprland/hm.nix
+++ b/modules/hyprland/hm.nix
@@ -10,7 +10,7 @@ mkTarget {
   extraOptions.hyprpaper.enable = config.lib.stylix.mkEnableTargetWith {
     name = "Hyprpaper";
     autoEnable = config.stylix.image != null;
-    autoEnableExpr = "stylix.image != null";
+    autoEnableExpr = "config.stylix.image != null";
   };
   configElements = [
     (

--- a/modules/swaylock/hm.nix
+++ b/modules/swaylock/hm.nix
@@ -23,7 +23,7 @@ mkTarget {
     && pkgs.stdenv.hostPlatform.isLinux;
 
   autoEnableExpr = ''
-    lib.versionAtLeast home.stateVersion "23.05" && pkgs.stdenv.hostPlatform.isLinux
+    lib.versionAtLeast config.home.stateVersion "23.05" && pkgs.stdenv.hostPlatform.isLinux
   '';
 
   extraOptions.useWallpaper = config.lib.stylix.mkEnableWallpaper "Swaylock" true;

--- a/stylix/target.nix
+++ b/stylix/target.nix
@@ -95,9 +95,9 @@
           default = cfg.autoEnable && autoEnable;
           defaultText =
             if args ? autoEnableExpr then
-              lib.literalExpression "stylix.autoEnable && ${wrapExpr autoEnableExpr}"
+              lib.literalExpression "config.stylix.autoEnable && ${wrapExpr autoEnableExpr}"
             else if autoEnable then
-              lib.literalExpression "stylix.autoEnable"
+              lib.literalExpression "config.stylix.autoEnable"
             else
               false;
           inherit example;
@@ -109,7 +109,10 @@
           description = "Whether to set the wallpaper for ${humanName}.";
           default = config.stylix.image != null && autoEnable;
           defaultText =
-            if autoEnable then lib.literalExpression "stylix.image != null" else false;
+            if autoEnable then
+              lib.literalExpression "config.stylix.image != null"
+            else
+              false;
           example = config.stylix.image == null;
         };
 


### PR DESCRIPTION
https://github.com/nix-community/stylix/pull/1513#discussion_r2152766280
cc @MattSturgeon
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [ ] Tested [locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Tested in [testbed](https://nix-community.github.io/stylix/testbeds.html)
- [x] Commit message follows [commit convention](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Fits [style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Respects license of any existing code used

## Notify maintainers

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->
