### PR TITLE
discord: Fix Nixcord build failure

### DIFF
--- a/modules/discord/nixcord.nix
+++ b/modules/discord/nixcord.nix
@@ -30,7 +30,7 @@ mkTarget {
         inherit (config.programs) nixcord;
       in
       lib.mkIf
-        (cfg.themeBody != (import ./common/theme-header.nix || cfg.extraCss != ""))
+        (cfg.themeBody != (import ./common/theme-header.nix) || cfg.extraCss != "")
         (
           lib.optionalAttrs (builtins.hasAttr "nixcord" options.programs) (
             lib.mkMerge [


### PR DESCRIPTION
Fixes a Nixcord build failure. Closes #1525.


I briefly looked into adding a testbed for Nixcord, but it looks like it would require pulling in the Nixcord Home Manager module.

## Things done

- [x] Tested [locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Tested in [testbed](https://nix-community.github.io/stylix/testbeds.html)
  - Tested via pulling my branch into my HM config instead.
- [x] Commit message follows [commit convention](https://nix-community.github.io/stylix/commit_convention.html)
- [x] Fits [style guide](https://nix-community.github.io/stylix/styling.html)
- [x] Respects license of any existing code used

## Notify maintainers