### PR TITLE
waybar: fix attribute 'default' missing

### DIFF
--- a/modules/waybar/hm.nix
+++ b/modules/waybar/hm.nix
@@ -88,7 +88,7 @@ mkTarget {
         '';
       in
       {
-        stylix.targets.waybar.background = lib.default "@base00";
+        stylix.targets.waybar.background = lib.mkDefault "@base00";
         programs.waybar.style =
           with colors.withHashtag;
           ''


### PR DESCRIPTION
Fix build failure `attribute 'default' missing`. Closes: #1538

## Things done

- [x] Tested [locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Tested in [testbed](https://nix-community.github.io/stylix/testbeds.html)
- [x] Commit message follows [commit convention](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Fits [style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Respects license of any existing code used

## Notify maintainers

@awwpotato 
