### PR TITLE
flake: infer default.nix import path

### DIFF
--- a/flake/packages.nix
+++ b/flake/packages.nix
@@ -15,7 +15,7 @@
         # Testbeds are virtual machines based on NixOS, therefore they are
         # only available for Linux systems.
         (lib.mkIf pkgs.stdenv.hostPlatform.isLinux (
-          import ../stylix/testbed/default.nix {
+          import ../stylix/testbed {
             inherit pkgs inputs lib;
           }
         ))


### PR DESCRIPTION
```
Fixes: c765b15fc394 ("stylix: move testbed to a dedicated directory")
```




## Things done

- [ ] Tested [locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Tested in [testbed](https://nix-community.github.io/stylix/testbeds.html)
- [X] Commit message follows [commit convention](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Fits [style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Respects license of any existing code used

## Notify maintainers
