### PR TITLE
ci: commit as stylix-automation in updates

### DIFF
--- a/.github/workflows/update-flake.yml
+++ b/.github/workflows/update-flake.yml
@@ -27,9 +27,27 @@ jobs:
           permission-contents: write
           permission-pull-requests: write
 
+      - id: user-info
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          slug: ${{ steps.generate-token.outputs.app-slug }}
+        run: |
+          name="$slug[bot]"
+          id="$(gh api "/users/$name" --jq .id)"
+          printf \
+            '%s=%s\n' \
+            id "$id" \
+            name "$name" \
+            email "$id+$name@users.noreply.github.com" \
+            >>"$GITHUB_OUTPUT"
+
       - uses: DeterminateSystems/update-flake-lock@v25
         with:
           token: ${{ steps.generate-token.outputs.token }}
+          git-committer-name: ${{ steps.user-info.outputs.name }}
+          git-committer-email: ${{ steps.user-info.outputs.email }}
+          git-author-name: ${{ steps.user-info.outputs.name }}
+          git-author-email: ${{ steps.user-info.outputs.email }}
           branch: update_flake_lock_action_${{ matrix.branch }}
           commit-msg: "flake: update all inputs"
           pr-title: "${{ startsWith(matrix.branch, 'release') && format('[{0}] ', matrix.branch) || '' }}stylix: update all flake inputs"   # yamllint disable-line rule:line-length


### PR DESCRIPTION
Follow up to https://github.com/nix-community/stylix/pull/1289#discussion_r2148894496, get the app's slug and user-id and use them to construct its "name" and "email".

This matches the implementation in home-manager and nixvim:
- https://github.com/nix-community/nixvim/blob/95957f306bf6d8e40f62fd0062cf326436bf011d/.github/workflows/update.yml#L53-L67
- https://github.com/nix-community/home-manager/blob/66523b0efe93ce5b0ba96dcddcda15d36673c1f0/.github/workflows/update-flake.yml#L19-L31

I won't be offended if you reject this PR; perhaps you prefer your updates committed by github-actions[bot]? But I felt it best to open a separate PR so we don't end up having this debate on the unrelated PR (https://github.com/nix-community/stylix/pull/1289#discussion_r2148894496).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [ ] Tested [locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Tested in [testbed](https://nix-community.github.io/stylix/testbeds.html)
- [x] Commit message follows [commit convention](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Fits [style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Respects license of any existing code used

## Notify maintainers

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->
