### PR TITLE
ashell: add target

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -203,11 +203,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1748737919,
-        "narHash": "sha256-5kvBbLYdp+n7Ftanjcs6Nv+UO6sBhelp6MIGJ9nWmjQ=",
+        "lastModified": 1751146119,
+        "narHash": "sha256-gvjG95TCnUVJkvQvLMlnC4NqiqFyBdJk3o8/RwuHeaU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5675a9686851d9626560052a032c4e14e533c1fa",
+        "rev": "76d0c31fce2aa0c71409de953e2f9113acd5b656",
         "type": "github"
       },
       "original": {

--- a/modules/ashell/hm.nix
+++ b/modules/ashell/hm.nix
@@ -1,4 +1,4 @@
-{ mkTarget, ... }:
+{ mkTarget, config, ... }:
 mkTarget {
   name = "ashell";
   humanName = "Ashell";
@@ -18,6 +18,9 @@ mkTarget {
           base09
           base0D
         ];
+
+        opacity = config.stylix.opacity.desktop;
+        menu.opacity = config.stylix.opacity.desktop;
       };
     };
 }

--- a/modules/ashell/hm.nix
+++ b/modules/ashell/hm.nix
@@ -1,26 +1,35 @@
-{ mkTarget, config, ... }:
+{ mkTarget, ... }:
 mkTarget {
   name = "ashell";
   humanName = "Ashell";
 
-  configElements =
-    { colors }:
-    {
-      programs.ashell.settings.appearance = with colors.withHashtag; {
-        background_color = base00;
-        primary_color = base0D;
-        secondary_color = base01;
-        success_color = base0B;
-        danger_color = base09;
-        text_color = base05;
+  configElements = [
+    (
+      { colors }:
+      {
+        programs.ashell.settings.appearance = with colors.withHashtag; {
+          background_color = base00;
+          primary_color = base0D;
+          secondary_color = base01;
+          success_color = base0B;
+          danger_color = base09;
+          text_color = base05;
 
-        workspace_colors = [
-          base09
-          base0D
-        ];
-
-        opacity = config.stylix.opacity.desktop;
-        menu.opacity = config.stylix.opacity.desktop;
-      };
-    };
+          workspace_colors = [
+            base09
+            base0D
+          ];
+        };
+      }
+    )
+    (
+      { opacity }:
+      {
+        prrograms.ashell.settings.appearance = {
+          inherit opacity;
+          menu.opacity = opacity;
+        };
+      }
+    )
+  ];
 }

--- a/modules/ashell/hm.nix
+++ b/modules/ashell/hm.nix
@@ -9,14 +9,14 @@ mkTarget {
     { colors }:
     {
       programs.ashell.settings.appearance = with colors.withHashtag; {
-        backgroundColor = base00;
-        primaryColor = base0D;
-        secondaryColor = base01;
-        successColor = base0B;
-        dangerColor = base09;
-        textColor = base05;
+        background_color = base00;
+        primary_color = base0D;
+        secondary_color = base01;
+        success_color = base0B;
+        danger_color = base09;
+        text_color = base05;
 
-        workspaceColors = [
+        workspace_colors = [
           base09
           base0D
         ];

--- a/modules/ashell/hm.nix
+++ b/modules/ashell/hm.nix
@@ -1,0 +1,25 @@
+{
+  mkTarget,
+  ...
+}:
+mkTarget {
+  name = "ashell";
+  humanName = "Ashell";
+  configElements =
+    { colors }:
+    {
+      programs.ashell.settings.appearance = with colors.withHashtag; {
+        backgroundColor = base00;
+        primaryColor = base0D;
+        secondaryColor = base01;
+        successColor = base0B;
+        dangerColor = base09;
+        textColor = base05;
+
+        workspaceColors = [
+          base09
+          base0D
+        ];
+      };
+    };
+}

--- a/modules/ashell/hm.nix
+++ b/modules/ashell/hm.nix
@@ -1,10 +1,8 @@
-{
-  mkTarget,
-  ...
-}:
+{ mkTarget, ... }:
 mkTarget {
   name = "ashell";
   humanName = "Ashell";
+
   configElements =
     { colors }:
     {

--- a/modules/ashell/hm.nix
+++ b/modules/ashell/hm.nix
@@ -25,7 +25,7 @@ mkTarget {
     (
       { opacity }:
       {
-        prrograms.ashell.settings.appearance = {
+        programs.ashell.settings.appearance = {
           inherit opacity;
           menu.opacity = opacity;
         };

--- a/modules/ashell/meta.nix
+++ b/modules/ashell/meta.nix
@@ -1,0 +1,6 @@
+{ lib, ... }:
+{
+  name = "Ashell";
+  homepage = "https://github.com/MalpenZibo/ashell";
+  maintainers = [ lib.maintainers.justdeeevin ];
+}


### PR DESCRIPTION
This adds a target for ashell, a rust-based wayland status bar.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [x] Tested [locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Tested in [testbed](https://nix-community.github.io/stylix/testbeds.html)
- [x] Commit message follows [commit convention](https://nix-community.github.io/stylix/commit_convention.html)
- [x] Fits [style guide](https://nix-community.github.io/stylix/styling.html)
- [x] Respects license of any existing code used

## Notify maintainers

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->
