### PR TITLE
zed: fix homepage URL

### DIFF
--- a/modules/zed/meta.nix
+++ b/modules/zed/meta.nix
@@ -1,5 +1,5 @@
 {
   name = "Zed";
-  homepage = "https://zed.brimdata.io/";
+  homepage = "https://zed.dev/";
   maintainers = [ ];
 }


### PR DESCRIPTION
Fix the homepage URL of zed, which currently points to ZED the data model.

## Things done

- [ ] Tested [locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Tested in [testbed](https://nix-community.github.io/stylix/testbeds.html)
- [x] Commit message follows [commit convention](https://nix-community.github.io/stylix/commit_convention.html)
- [x] Fits [style guide](https://nix-community.github.io/stylix/styling.html)
- [x] Respects license of any existing code used
