### PR TITLE
stylix: make `fonts.packages` mutable

### DIFF
--- a/stylix/fonts.nix
+++ b/stylix/fonts.nix
@@ -110,10 +110,9 @@ in
 
     packages = lib.mkOption {
       description = ''
-        A list of all the font packages that will be installed.
+        A list of font packages to be installed.
       '';
       type = lib.types.listOf lib.types.package;
-      readOnly = true;
     };
   };
 


### PR DESCRIPTION
Related: #1567 

Though having `stylix.fonts.packages` be `readOnly` ensures some level of inability for users to break things, it seems incredibly rare that a user would even bother with this option, and as seen in #1567, there *is* an (albiet rare and soon to be obsolete) use case for being able to change it.

I believe that it would be best to just fix this now, as `stylix.fonts` will not be optional until all targets use `mkTarget`.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [ ] Tested [locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Tested in [testbed](https://nix-community.github.io/stylix/testbeds.html)
- [x] Commit message follows [commit convention](https://nix-community.github.io/stylix/commit_convention.html)
- [x] Fits [style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Respects license of any existing code used

## Notify maintainers

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->
