### PR TITLE
nixos-icons: pad hex color values with leading zeros

### DIFF
--- a/modules/nixos-icons/overlay.nix
+++ b/modules/nixos-icons/overlay.nix
@@ -27,6 +27,7 @@
                   pipe
                   toHexString
                   toInt
+                  stringLength
                   ;
 
                 baseColorAdd =
@@ -46,6 +47,8 @@
                     (map (max 0))
                     # convert each to hex string
                     (map toHexString)
+                    # add leading 0 if necessary
+                    (map (hex: if (stringLength hex < 2) then "0" + hex else hex))
                     # to one string
                     concatStrings
                   ];

--- a/modules/nixos-icons/overlay.nix
+++ b/modules/nixos-icons/overlay.nix
@@ -18,6 +18,7 @@
             inherit (oldAttrs) src;
             prePatch =
               let
+                inherit (builtins) stringLength;
                 inherit (config.lib.stylix) colors;
 
                 inherit (lib)
@@ -27,7 +28,6 @@
                   pipe
                   toHexString
                   toInt
-                  stringLength
                   ;
 
                 baseColorAdd =


### PR DESCRIPTION
Fixed a problem where the `nix-snowflake.svg` would contain invalid hex colors

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`

-->

Closes: #1581 

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [x] Tested [locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Tested in [testbed](https://nix-community.github.io/stylix/testbeds.html)
- [x] Commit message follows [commit convention](https://nix-community.github.io/stylix/commit_convention.html)
- [x] Fits [style guide](https://nix-community.github.io/stylix/styling.html)
- [x] Respects license of any existing code used

## Notify maintainers

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->
