### PR TITLE
rofi: fix mkTarget usage

### DIFF
--- a/modules/rofi/hm.nix
+++ b/modules/rofi/hm.nix
@@ -1,9 +1,4 @@
-{
-  mkTarget,
-  lib,
-  config,
-  ...
-}:
+{ mkTarget, config, ... }:
 mkTarget {
   name = "rofi";
   humanName = "Rofi";
@@ -20,18 +15,16 @@ mkTarget {
       let
         inherit (config.lib.formats.rasi) mkLiteral;
         mkRgba =
-          opacity: color:
+          opacity': color:
           let
-            c = config.lib.stylix.colors;
+            c = colors;
             r = c."${color}-rgb-r";
             g = c."${color}-rgb-g";
             b = c."${color}-rgb-b";
           in
-          mkLiteral "rgba ( ${r}, ${g}, ${b}, ${opacity} % )";
+          mkLiteral "rgba ( ${r}, ${g}, ${b}, ${opacity'} % )";
         mkRgb = mkRgba "100";
-        rofiOpacity = builtins.toString (
-          builtins.ceil (config.stylix.opacity.popups * 100)
-        );
+        rofiOpacity = builtins.toString (builtins.ceil (opacity.popups * 100));
       in
       {
         programs.rofi.theme = {


### PR DESCRIPTION
```
       … while evaluating the option `home-manager.users.azalea.programs.rofi.theme.*.active-text.value':

       … while evaluating definitions from `/nix/store/y0v88m35c78ih1mbkrcdnlnfmb4pbgw6-source/modules/rofi/hm.nix':

       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error: stylix: unguareded `config.lib.stylix.colors` accessed while using mkTarget
```
```
Fixes: dea0337e0b ("stylix: restrict access to config while using mkTarget (#1368)")
Fixes: 713f8dae31 ("rofi: use mkTarget (#1550)")
```
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [ ] Tested [locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Tested in [testbed](https://nix-community.github.io/stylix/testbeds.html)
- [x] Commit message follows [commit convention](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Fits [style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Respects license of any existing code used

## Notify maintainers

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->
