### PR TITLE
stylix: fix 'unguarded' typo

### DIFF
--- a/stylix/autoload.nix
+++ b/stylix/autoload.nix
@@ -49,8 +49,8 @@ builtins.concatLists (
               // {
                 inherit mkTarget;
                 config = lib.recursiveUpdate config {
-                  stylix = throw "stylix: unguareded `config.stylix` accessed while using mkTarget";
-                  lib.stylix.colors = throw "stylix: unguareded `config.lib.stylix.colors` accessed while using mkTarget";
+                  stylix = throw "stylix: unguarded `config.stylix` accessed while using mkTarget";
+                  lib.stylix.colors = throw "stylix: unguarded `config.lib.stylix.colors` accessed while using mkTarget";
                 };
               }
             ))


### PR DESCRIPTION
```
Fixes: dea0337e0bff ("stylix: restrict access to config while using mkTarget (#1368)")
```

## Things done

- [ ] Tested [locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Tested in [testbed](https://nix-community.github.io/stylix/testbeds.html)
- [X] Commit message follows [commit convention](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Fits [style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Respects license of any existing code used

## Notify maintainers
