### PR TITLE
ci: add module eval test(s)

### DIFF
--- a/ci/all-modules/hm.nix
+++ b/ci/all-modules/hm.nix
@@ -1,0 +1,14 @@
+{
+  # keep-sorted start block=yes
+  i18n.inputMethod = {
+    enable = false;
+    type = "fcitx5";
+  };
+  programs = {
+
+  };
+  services = {
+
+  };
+  # keep-sorted end
+}

--- a/ci/all-modules/nixos.nix
+++ b/ci/all-modules/nixos.nix
@@ -1,0 +1,10 @@
+{
+  # keep-sorted start block=yes
+  programs = {
+
+  };
+  services = {
+
+  };
+  # keep-sorted end
+}

--- a/ci/default.nix
+++ b/ci/default.nix
@@ -1,0 +1,16 @@
+{ inputs, self, ... }:
+{
+  flake.nixosConfigurations.eval-test = inputs.nixpkgs.lib.nixosSystem {
+    modules = [
+      # keep-sorted start block=yes prefix_order=inputs,self,./,{
+      self.stylix.nixosModules.stylix
+      ./eval-test.nix
+      {
+        home-manager.sharedModules = [
+          inputs.stylix.homeModules.stylix
+        ];
+      }
+      # keep-sorted end
+    ];
+  };
+}

--- a/ci/eval-test.nix
+++ b/ci/eval-test.nix
@@ -1,0 +1,14 @@
+{
+  imports = [
+    ./nixos.nix
+  ];
+
+  home-manager = {
+    useGlobalPkgs = true;
+    useUserPackages = true;
+    backupFileExtension = "backup";
+    users.stylix = {
+      imports = [ ./hm.nix ];
+    };
+  };
+}


### PR DESCRIPTION
depends on https://github.com/nix-community/stylix/pull/1289

evals all modules so would help catch issues like https://github.com/nix-community/stylix/issues/1607.

from a short glance it looks like catppuccin/nix does something similar which is where I got the idea

Issues I've thought of

 - redundant if we can make a testbed for all modules
 - some modules are mutually exclusive

Alternative ideas

  - expend testbeds https://github.com/nix-community/stylix/issues/319
  - run home-manager/nixos tests with stylix enabled (very bad idea)
  - add eval tests for each module similar to hm/nixos

cc @danth @trueNAHO @Flameopathic @MattSturgeon

> [!NOTE]
> This pr is very unfinished and mostly just an RFC
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [ ] Tested [locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Tested in [testbed](https://nix-community.github.io/stylix/testbeds.html)
- [x] Commit message follows [commit convention](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Fits [style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Respects license of any existing code used

## Notify maintainers

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->
