### PR TITLE
ci: public flake instead of root flake

### DIFF
--- a/.github/workflows/update-flake.yml
+++ b/.github/workflows/update-flake.yml
@@ -53,7 +53,7 @@ jobs:
         run: |
           nix flake update \
             --commit-lock-file \
-            --option commit-lock-file-summary "flake: update root inputs"
+            --option commit-lock-file-summary "flake: update public inputs"
 
           nix flake update \
             --commit-lock-file \


### PR DESCRIPTION
got missed in https://github.com/nix-community/stylix/pull/1289
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [ ] Tested [locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Tested in [testbed](https://nix-community.github.io/stylix/testbeds.html)
- [x] Commit message follows [commit convention](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Fits [style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Respects license of any existing code used

## Notify maintainers

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->
