### PR TITLE
flake: infer default.nix import path

### DIFF
--- a/flake/dev/packages.nix
+++ b/flake/dev/packages.nix
@@ -10,7 +10,7 @@
       # Testbeds are virtual machines based on NixOS, therefore they are
       # only available for Linux systems.
       packages = lib.mkIf pkgs.stdenv.hostPlatform.isLinux (
-        import ../../stylix/testbed/default.nix {
+        import ../../stylix/testbed {
           inherit pkgs inputs lib;
         }
       );


### PR DESCRIPTION
```
Re-apply commit 0f93e5862859 ("flake: infer default.nix import path
(#1544)") that was accidentally reverted in commit a5c1532ab8bf ("flake:
partition dev inputs (#1289)").
```

## Things done

- [ ] Tested [locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Tested in [testbed](https://nix-community.github.io/stylix/testbeds.html)
- [X] Commit message follows [commit convention](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Fits [style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Respects license of any existing code used

## Notify maintainers
