### PR TITLE
flake: add Flake Parts tree into testbed environment

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -34,6 +34,17 @@ jobs:
         with:
           persist-credentials: false
 
+      # TODO: Lock this Action to a release tag once commit [1] ("fix: relocate
+      # TMPDIR to /mnt to improve Nix installer compatibility") is part of a
+      # release, resolving [2] ("does not work with cachix install nix action").
+      #
+      # [1]: https://github.com/wimpysworld/nothing-but-nix/pull/25
+      # [2]: https://github.com/wimpysworld/nothing-but-nix/issues/24
+      - uses: wimpysworld/nothing-but-nix@10c936d9e46521bf923f75458e0cbd4fa309300d  # yamllint disable-line rule:line-length
+        if: runner.os == 'Linux'
+        with:
+          hatchet-protocol: holster
+
       - uses: cachix/install-nix-action@v31
 
       - uses: cachix/cachix-action@v16

--- a/modules/bat/testbeds/bat.nix
+++ b/modules/bat/testbeds/bat.nix
@@ -4,17 +4,7 @@ let
 in
 {
   environment = {
-    loginShellInit = "${lib.getExe package} example.md";
+    loginShellInit = "${lib.getExe package} flake-parts/flake.nix";
     systemPackages = [ package ];
   };
-  home-manager.sharedModules = [
-    {
-      home.file."example.md" = {
-        source = pkgs.fetchurl {
-          url = "https://raw.githubusercontent.com/sharkdp/bat/refs/heads/master/tests/syntax-tests/source/Markdown/example.md";
-          hash = "sha256-VYYwgRFY1c2DPY7yGM8oF3zG4rtEpBWyqfPwmGZIkcA=";
-        };
-      };
-    }
-  ];
 }

--- a/modules/emacs/testbeds/emacs.nix
+++ b/modules/emacs/testbeds/emacs.nix
@@ -1,17 +1,11 @@
 { lib, pkgs, ... }:
-let
-  package = pkgs.emacs;
-in
 {
-  stylix.testbed.ui.application = {
-    name = "emacs";
-    inherit package;
-  };
+  stylix.testbed.ui.command.text = "emacs flake-parts/flake.nix";
 
   home-manager.sharedModules = lib.singleton {
     programs.emacs = {
       enable = true;
-      inherit package;
+      package = pkgs.emacs;
     };
   };
 }

--- a/modules/gedit/testbeds/gedit.nix
+++ b/modules/gedit/testbeds/gedit.nix
@@ -1,12 +1,5 @@
 { pkgs, ... }:
-let
-  package = pkgs.gedit;
-in
 {
-  stylix.testbed.ui.application = {
-    name = "org.gnome.gedit";
-    inherit package;
-  };
-
-  environment.systemPackages = [ package ];
+  stylix.testbed.ui.command.text = "gedit flake-parts/flake.nix";
+  environment.systemPackages = [ pkgs.gedit ];
 }

--- a/modules/gnome-text-editor/testbeds/gnome-text-editor.nix
+++ b/modules/gnome-text-editor/testbeds/gnome-text-editor.nix
@@ -1,12 +1,5 @@
 { pkgs, ... }:
-let
-  package = pkgs.gnome-text-editor;
-in
 {
-  stylix.testbed.ui.application = {
-    name = "org.gnome.TextEditor";
-    inherit package;
-  };
-
-  environment.systemPackages = [ package ];
+  stylix.testbed.ui.command.text = "gnome-text-editor flake-parts/flake.nix";
+  environment.systemPackages = [ pkgs.gnome-text-editor ];
 }

--- a/modules/micro/testbeds/micro.nix
+++ b/modules/micro/testbeds/micro.nix
@@ -1,17 +1,11 @@
 { lib, pkgs, ... }:
 {
   stylix.testbed.ui.command = {
-    text = "${lib.getExe pkgs.micro} example.md";
+    text = "${lib.getExe pkgs.micro} flake-parts/flake.nix";
     useTerminal = true;
   };
 
   home-manager.sharedModules = lib.singleton {
     programs.micro.enable = true;
-    home.file."example.md" = {
-      source = pkgs.fetchurl {
-        url = "https://raw.githubusercontent.com/sharkdp/bat/e2aa4bc33cca785cab8bdadffc58a4a30b245854/tests/syntax-tests/source/Markdown/example.md";
-        hash = "sha256-VYYwgRFY1c2DPY7yGM8oF3zG4rtEpBWyqfPwmGZIkcA=";
-      };
-    };
   };
 }

--- a/modules/neovim/testbeds/neovide.nix
+++ b/modules/neovim/testbeds/neovide.nix
@@ -1,18 +1,12 @@
 { lib, pkgs, ... }:
-let
-  package = pkgs.neovide;
-in
 {
-  stylix.testbed.ui.application = {
-    name = "neovide";
-    inherit package;
-  };
+  stylix.testbed.ui.command.text = "neovide flake-parts/flake.nix";
 
   home-manager.sharedModules = lib.singleton {
     programs = {
       neovide = {
         enable = true;
-        inherit package;
+        package = pkgs.neovide;
       };
       neovim.enable = true;
     };

--- a/modules/neovim/testbeds/neovim.nix
+++ b/modules/neovim/testbeds/neovim.nix
@@ -1,17 +1,11 @@
-{ lib, pkgs, ... }:
+{ lib, ... }:
 {
   stylix.testbed.ui.command = {
-    text = "nvim example.md";
+    text = "nvim flake-parts/flake.nix";
     useTerminal = true;
   };
 
   home-manager.sharedModules = lib.singleton {
     programs.neovim.enable = true;
-    home.file."example.md" = {
-      source = pkgs.fetchurl {
-        url = "https://raw.githubusercontent.com/sharkdp/bat/e2aa4bc33cca785cab8bdadffc58a4a30b245854/tests/syntax-tests/source/Markdown/example.md";
-        hash = "sha256-VYYwgRFY1c2DPY7yGM8oF3zG4rtEpBWyqfPwmGZIkcA=";
-      };
-    };
   };
 }

--- a/modules/neovim/testbeds/nixvim.nix
+++ b/modules/neovim/testbeds/nixvim.nix
@@ -1,18 +1,8 @@
-{ lib, pkgs, ... }:
 {
   stylix.testbed.ui.command = {
-    text = "nvim example.md";
+    text = "nvim flake-parts/flake.nix";
     useTerminal = true;
   };
 
   programs.nixvim.enable = true;
-
-  home-manager.sharedModules = lib.singleton {
-    home.file."example.md" = {
-      source = pkgs.fetchurl {
-        url = "https://raw.githubusercontent.com/sharkdp/bat/refs/heads/master/tests/syntax-tests/source/Markdown/example.md";
-        hash = "sha256-VYYwgRFY1c2DPY7yGM8oF3zG4rtEpBWyqfPwmGZIkcA=";
-      };
-    };
-  };
 }

--- a/modules/neovim/testbeds/nvf.nix
+++ b/modules/neovim/testbeds/nvf.nix
@@ -1,18 +1,8 @@
-{ lib, pkgs, ... }:
 {
   stylix.testbed.ui.command = {
-    text = "nvim example.md";
+    text = "nvim flake-parts/flake.nix";
     useTerminal = true;
   };
 
   programs.nvf.enable = true;
-
-  home-manager.sharedModules = lib.singleton {
-    home.file."example.md" = {
-      source = pkgs.fetchurl {
-        url = "https://raw.githubusercontent.com/sharkdp/bat/refs/heads/master/tests/syntax-tests/source/Markdown/example.md";
-        hash = "sha256-VYYwgRFY1c2DPY7yGM8oF3zG4rtEpBWyqfPwmGZIkcA=";
-      };
-    };
-  };
 }

--- a/modules/neovim/testbeds/vim.nix
+++ b/modules/neovim/testbeds/vim.nix
@@ -1,17 +1,11 @@
 { lib, pkgs, ... }:
 {
   stylix.testbed.ui.command = {
-    text = "${lib.getExe pkgs.vim} example.md";
+    text = "${lib.getExe pkgs.vim} flake-parts/flake.nix";
     useTerminal = true;
   };
 
   home-manager.sharedModules = lib.singleton {
     programs.vim.enable = true;
-    home.file."example.md" = {
-      source = pkgs.fetchurl {
-        url = "https://raw.githubusercontent.com/sharkdp/bat/e2aa4bc33cca785cab8bdadffc58a4a30b245854/tests/syntax-tests/source/Markdown/example.md";
-        hash = "sha256-VYYwgRFY1c2DPY7yGM8oF3zG4rtEpBWyqfPwmGZIkcA=";
-      };
-    };
   };
 }

--- a/modules/vscode/testbeds/vscode.nix
+++ b/modules/vscode/testbeds/vscode.nix
@@ -1,18 +1,13 @@
 { lib, pkgs, ... }:
-# We are using VSCodium because VSCode is an unfree package
-let
-  package = pkgs.vscodium;
-in
 {
-  stylix.testbed.ui.application = {
-    name = "codium";
-    inherit package;
-  };
+  stylix.testbed.ui.command.text = "codium flake-parts/flake.nix";
 
   home-manager.sharedModules = lib.singleton {
     programs.vscode = {
       enable = true;
-      inherit package;
+
+      # We are using VSCodium because VSCode is an unfree package
+      package = pkgs.vscodium;
     };
   };
 }

--- a/modules/zed/testbeds/zed.nix
+++ b/modules/zed/testbeds/zed.nix
@@ -1,16 +1,10 @@
 { lib, pkgs, ... }:
 {
   stylix.testbed.ui.command = {
-    text = "${lib.getExe pkgs.zed-editor} example.md";
+    text = "${lib.getExe pkgs.zed-editor} flake-parts/flake.nix";
   };
 
   home-manager.sharedModules = lib.singleton {
     programs.zed-editor.enable = true;
-    home.file."example.md" = {
-      source = pkgs.fetchurl {
-        url = "https://raw.githubusercontent.com/sharkdp/bat/e2aa4bc33cca785cab8bdadffc58a4a30b245854/tests/syntax-tests/source/Rust/output.rs";
-        hash = "sha256-vpUndD6H1oJfYVDai4LpVpsW6SSGbK466t3IKENZ1ow=";
-      };
-    };
   };
 }

--- a/stylix/testbed/default.nix
+++ b/stylix/testbed/default.nix
@@ -14,6 +14,7 @@ let
 
         modules =
           [
+            (lib.modules.importApply ./modules/flake-parts.nix inputs)
             ./modules/common.nix
             ./modules/enable.nix
             ./modules/application.nix

--- a/stylix/testbed/modules/flake-parts.nix
+++ b/stylix/testbed/modules/flake-parts.nix
@@ -1,0 +1,7 @@
+inputs:
+{ lib, ... }:
+{
+  home-manager.sharedModules = lib.singleton {
+    home.file.flake-parts.source = inputs.flake-parts;
+  };
+}


### PR DESCRIPTION
```
commit e334b3019e72212289729c753873ad2a897370ca
Author: NAHO <90870942+trueNAHO@users.noreply.github.com>
Date:   2025-07-21 19:36:53 +0200

    ci: check: add wimpysworld/nothing-but-nix Action for larger Nix store

    Co-authored-by: awwpotato <awwpotato@voidq.com>

 .github/workflows/check.yml | 11 +++++++++++
 1 file changed, 11 insertions(+)

commit 1adb93fcbcfb1ffeef23cdf0ab4f7d17e7af0a6e
Author: NAHO <90870942+trueNAHO@users.noreply.github.com>
Date:   2025-07-08 19:38:21 +0200

    flake: add Flake Parts tree into testbed environment

    Add the Flake Parts tree into the testbed environment, enabling
    realistic testing interactions.

    Flake Parts is chosen over Stylix to reduce cache invalidations, and
    over other flake inputs as the smallest tree.

 stylix/testbed/default.nix             | 1 +
 stylix/testbed/modules/flake-parts.nix | 7 +++++++
 2 files changed, 8 insertions(+)

commit 79fab36b0f92cfca17c74871558a48640cf0eac1
Author: NAHO <90870942+trueNAHO@users.noreply.github.com>
Date:   2025-07-08 19:41:02 +0200

    treewide: replace custom testbed test files with Flake Parts tree

 modules/bat/testbeds/bat.nix       | 12 +-----------
 modules/micro/testbeds/micro.nix   |  8 +-------
 modules/neovim/testbeds/neovim.nix | 10 ++--------
 modules/neovim/testbeds/nixvim.nix | 12 +-----------
 modules/neovim/testbeds/nvf.nix    | 12 +-----------
 modules/neovim/testbeds/vim.nix    |  8 +-------
 modules/zed/testbeds/zed.nix       |  8 +-------
 7 files changed, 8 insertions(+), 62 deletions(-)

commit 62c9ec3e0eebe2d8e9b49c9976cf1f5138c85ab2
Author: NAHO <90870942+trueNAHO@users.noreply.github.com>
Date:   2025-07-11 15:19:21 +0200

    treewide: expand testbed interactions with Flake Parts tree

 modules/emacs/testbeds/emacs.nix                         | 10 ++--------
 modules/gedit/testbeds/gedit.nix                         | 11 ++---------
 modules/gnome-text-editor/testbeds/gnome-text-editor.nix | 11 ++---------
 modules/neovim/testbeds/neovide.nix                      | 10 ++--------
 modules/vscode/testbeds/vscode.nix                       | 13 ++++---------
 5 files changed, 12 insertions(+), 43 deletions(-)
```

## Things done

- [ ] Tested [locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [X] Tested in [testbed](https://nix-community.github.io/stylix/testbeds.html)
- [X] Commit message follows [commit convention](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Fits [style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Respects license of any existing code used

## Notify maintainers
