### PR TITLE
stylix: add generated all-maintainers file

### DIFF
--- a/.github/workflows/update-flake.yml
+++ b/.github/workflows/update-flake.yml
@@ -60,6 +60,14 @@ jobs:
             --flake ./flake/dev \
             --option commit-lock-file-summary "flake: update dev inputs"
 
+          # The nixpkgs maintainers may have changed, so keep all-maintainers
+          # in sync
+          nix run .#all-maintainers
+
+          git add stylix/generated/all-maintainers.nix
+          git commit --message "stylix: update all-maintainers list" ||
+            echo "generated/all-maintainers.nix has no changes"
+
       - name: create pull request
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}

--- a/doc/src/modules.md
+++ b/doc/src/modules.md
@@ -245,6 +245,13 @@ number of maintainers:
 The main responsibility of module maintainers is to update and fix their
 modules.
 
+> [!NOTE]
+> If this is the first time you're adding yourself as a maintainer in Stylix,
+> the `/generated/all-maintainers.nix` file will need to be updated by running
++> `nix run .#all-maintainers`
++> ([pre-commit](./development_environment.md#pre-commit) will also automatically
++> regenerate it).
+
 ## Documentation
 
 Documentation for options is automatically generated. To improve the quality of

--- a/flake/dev/all-maintainers.nix
+++ b/flake/dev/all-maintainers.nix
@@ -1,0 +1,52 @@
+{ lib, ... }:
+{
+  perSystem =
+    { pkgs, config, ... }:
+    {
+      apps.all-maintainers = {
+        program = pkgs.writeShellApplication {
+          name = "update-all-maintainers";
+          runtimeInputs = [ pkgs.gitMinimal ];
+          text = ''
+            root="$(git rev-parse --show-toplevel)"
+            cp --force \
+              ${config.packages.all-maintainers} \
+              "$root/generated/all-maintainers.nix"
+          '';
+        };
+        meta.description = "Update generated/all-maintainers.nix.";
+      };
+
+      packages.all-maintainers =
+        pkgs.runCommand "all-maintainers"
+          {
+            passAsFile = [ "allMaintainers" ];
+            allMaintainers = ''
+              # DO NOT EDIT THIS GENERATED FILE.
+              #
+              # This file lists Stylix module maintainers for GitHub review
+              # requests, per NixOS RFC 39.
+              #
+              # To generate this file, run:
+              #
+              #       nix run .#all-maintainers
+              ${lib.pipe ../../stylix/meta.nix [
+                (p: pkgs.callPackage p { })
+                builtins.attrValues
+                (builtins.concatMap (target: target.maintainers or [ ]))
+                (map (maintainer: lib.nameValuePair maintainer.github maintainer))
+                builtins.listToAttrs
+                (lib.generators.toPretty { })
+              ]}
+            '';
+            inherit (config.treefmt) projectRootFile;
+            nativeBuildInputs = [ config.formatter ];
+          }
+          ''
+            touch "$projectRootFile"
+            cp "$allMaintainersPath" all-maintainers.nix
+            treefmt --no-cache all-maintainers.nix
+            install -m 644 -T all-maintainers.nix "$out"
+          '';
+    };
+}

--- a/flake/dev/default.nix
+++ b/flake/dev/default.nix
@@ -1,5 +1,6 @@
 {
   imports = [
+    ./all-maintainers.nix
     ./dev-shell.nix
     ./packages.nix
     ./pre-commit.nix

--- a/flake/dev/pre-commit.nix
+++ b/flake/dev/pre-commit.nix
@@ -12,6 +12,18 @@
 
         settings.hooks = {
           # keep-sorted start block=yes
+          all-maintainers = {
+            enable = true;
+            entry = config.apps.all-maintainers.program;
+            files = "^(${
+              builtins.concatStringsSep "|" [
+                ''flake\.lock''
+                ''generated\/all-maintainers.nix''
+                ''modules\/.*\/meta\.nix''
+                ''stylix\/maintainers\.nix''
+              ]
+            })$";
+          };
           deadnix = {
             enable = true;
             settings.noUnderscore = true;

--- a/flake/propagated-packages.nix
+++ b/flake/propagated-packages.nix
@@ -15,10 +15,22 @@
   perSystem =
     { pkgs, system, ... }:
     lib.optionalAttrs (partitionStack == [ ]) {
-      packages = lib.mkIf pkgs.stdenv.hostPlatform.isLinux (
-        lib.mapAttrs (
-          name: _: config.partitions.dev.module.flake.packages.${system}.${name}
-        ) (import ../stylix/testbed/autoload.nix { inherit lib pkgs; })
-      );
+      apps = {
+        inherit (config.partitions.dev.module.flake.apps.${system})
+          all-maintainers
+          ;
+      };
+      packages = lib.mkMerge [
+        {
+          inherit (config.partitions.dev.module.flake.packages.${system})
+            all-maintainers
+            ;
+        }
+        (lib.mkIf pkgs.stdenv.hostPlatform.isLinux (
+          lib.mapAttrs (
+            name: _: config.partitions.dev.module.flake.packages.${system}.${name}
+          ) (import ../stylix/testbed/autoload.nix { inherit lib pkgs; })
+        ))
+      ];
     };
 }

--- a/generated/all-maintainers.nix
+++ b/generated/all-maintainers.nix
@@ -1,0 +1,187 @@
+# DO NOT EDIT THIS GENERATED FILE.
+#
+# This file lists Stylix module maintainers for GitHub review
+# requests, per NixOS RFC 39.
+#
+# To generate this file, run:
+#
+#       nix run .#all-maintainers
+{
+  "0x5a4" = {
+    email = "bej86nug@hhu.de";
+    github = "0x5a4";
+    githubId = 54070204;
+    name = "0x5a4";
+  };
+  Flameopathic = {
+    email = "flameopathic@gmail.com";
+    github = "Flameopathic";
+    githubId = 64027365;
+    name = "Erin Pletches";
+  };
+  MrSom3body = {
+    email = "nix@sndh.dev";
+    github = "MrSom3body";
+    githubId = 129101708;
+    matrix = "@mrsom3body:matrix.org";
+    name = "Karun Sandhu";
+  };
+  Noodlez1232 = {
+    email = "contact@nathanielbarragan.xyz";
+    github = "Noodlez1232";
+    githubId = 12480453;
+    matrix = "@noodlez1232:matrix.org";
+    name = "Nathaniel Barragan";
+  };
+  TheMaxMur = {
+    email = "muravjev.mak@yandex.ru";
+    github = "TheMaxMur";
+    githubId = 31189199;
+    name = "Maxim Muravev";
+  };
+  ajgon = {
+    email = "igor@rzegocki.pl";
+    github = "ajgon";
+    githubId = 150545;
+    name = "Igor Rzegocki";
+  };
+  awwpotato = {
+    email = "awwpotato@voidq.com";
+    github = "awwpotato";
+    githubId = 153149335;
+    matrix = "@awwpotato:envs.net";
+    name = "awwpotato";
+  };
+  brckd = {
+    email = "hello@bricked.dev";
+    github = "brckd";
+    githubId = 92804487;
+    keys = [
+      {
+        fingerprint = "58A2 81E6 2FBD 6E4E 664C  B603 7B4D 2A02 BB0E C28C";
+      }
+    ];
+    name = "bricked";
+  };
+  butzist = {
+    email = "adam@szalkowski.de";
+    github = "butzist";
+    githubId = 2405792;
+    name = "Adam M. Szalkowski";
+  };
+  cluther = {
+    email = "chet.luther@gmail.com";
+    github = "cluther";
+    githubId = 86579;
+    name = "Chet Luther";
+  };
+  danth = {
+    email = "danth@danth.me";
+    github = "danth";
+    githubId = 28959268;
+    keys = [
+      {
+        fingerprint = "4779 D1D5 3C97 2EAE 34A5  ED3D D8AF C4BF 0567 0F9D";
+      }
+    ];
+    matrix = "@danth:danth.me";
+    name = "Daniel Thwaites";
+  };
+  gideonwolfe = {
+    email = "wolfegideon@gmail.com";
+    github = "gideonwolfe";
+    githubId = 32942052;
+    name = "Gideon Wolfe";
+  };
+  justdeeevin = {
+    email = "devin.droddy@gmail.com";
+    github = "justdeeevin";
+    githubId = 90054389;
+    name = "Devin Droddy";
+  };
+  louis-thevenet = {
+    github = "louis-thevenet";
+    githubId = 55986107;
+    name = "Louis Thevenet";
+  };
+  make-42 = {
+    email = "ontake@ontake.dev";
+    github = "make-42";
+    githubId = 17462236;
+    keys = [
+      {
+        fingerprint = "36BC 916D DD4E B1EE EE82  4BBF DC95 900F 6DA7 9992";
+      }
+    ];
+    matrix = "@ontake:matrix.ontake.dev";
+    name = "Louis Dalibard";
+  };
+  mateusauler = {
+    email = "mateus@auler.dev";
+    github = "mateusauler";
+    githubId = 24767687;
+    keys = [
+      {
+        fingerprint = "A09D C093 3C37 4BFC 2B5A  269F 80A5 D62F 6EB7 D9F0";
+      }
+    ];
+    name = "Mateus Auler";
+  };
+  mightyiam = {
+    email = "mightyiampresence@gmail.com";
+    github = "mightyiam";
+    githubId = 635591;
+    name = "Shahar \"Dawn\" Or";
+  };
+  nukdokplex = {
+    email = "nukdokplex@nukdokplex.ru";
+    github = "nukdokplex";
+    githubId = 25458915;
+    keys = [
+      {
+        fingerprint = "7CE2 4C42 942D 58EA 99F6  F00A A47E 7374 3EF6 FCC4";
+      }
+    ];
+    name = "Viktor Titov";
+  };
+  osipog = {
+    email = "osibluber@protonmail.com";
+    github = "osipog";
+    githubId = 87434959;
+    name = "Osi Bluber";
+  };
+  panchoh = {
+    email = "pancho@pancho.name";
+    github = "panchoh";
+    githubId = 471059;
+    keys = [
+      {
+        fingerprint = "4430 F502 8B19 FAF4 A40E  C4E8 11E0 447D 4ABB A7D0";
+      }
+    ];
+    matrix = "@panchoh:matrix.org";
+    name = "pancho horrillo";
+  };
+  repparw = {
+    email = "ubritos@gmail.com";
+    github = "repparw";
+    githubId = 45952970;
+    name = "repparw";
+  };
+  skoove = {
+    email = "zie@sturges.com.au";
+    github = "skoove";
+    githubId = 53106860;
+    name = "Zie Sturges";
+  };
+  trueNAHO = {
+    github = "trueNAHO";
+    githubId = 90870942;
+    keys = [
+      {
+        fingerprint = "5FC6 088A FB1A 609D 4532  F919 0C1C 177B 3B64 68E0";
+      }
+    ];
+    name = "Noah Pierre Biewesch";
+  };
+}


### PR DESCRIPTION
required for https://github.com/nix-community/stylix/pull/1053, similar to what home-manager and nixvim have done except we don't need a python script or anything because of our project's structure.

cc @MattSturgeon @trueNAHO @danth  
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [ ] Tested [locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Tested in [testbed](https://nix-community.github.io/stylix/testbeds.html)
- [x] Commit message follows [commit convention](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Fits [style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Respects license of any existing code used

## Notify maintainers

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->
