### PR TITLE
treewide: remove redundant stylix.image Nix store copies

### DIFF
--- a/modules/swaylock/hm.nix
+++ b/modules/swaylock/hm.nix
@@ -71,7 +71,7 @@ mkTarget {
     (
       { cfg, image }:
       {
-        programs.swaylock.settings.image = lib.mkIf cfg.useWallpaper "${image}";
+        programs.swaylock.settings.image = lib.mkIf cfg.useWallpaper image;
       }
     )
     (

--- a/modules/wpaperd/hm.nix
+++ b/modules/wpaperd/hm.nix
@@ -25,7 +25,7 @@ mkTarget {
       in
       {
         services.wpaperd.settings.any = {
-          path = "${image}";
+          path = image;
         } // modeAttrs;
       }
     );

--- a/stylix/palette.nix
+++ b/stylix/palette.nix
@@ -84,7 +84,7 @@ in
         default = pkgs.runCommand "palette.json" { } ''
           ${lib.getExe cfg.paletteGenerator} \
             "${cfg.polarity}" \
-            ${lib.escapeShellArg "${cfg.image}"} \
+            ${cfg.image} \
             "$out"
         '';
       };


### PR DESCRIPTION
```
Remove redundant stylix.image Nix store copies, following the
improvements from commit 838df8b8ad7d ("stylix: improve `stylix.image`
type (#1414)").
```

## Things done

- [ ] Tested [locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Tested in [testbed](https://nix-community.github.io/stylix/testbeds.html)
- [X] Commit message follows [commit convention](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Fits [style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Respects license of any existing code used

## Notify maintainers
