### PR TITLE
treewide: allow re-running test code and simplify testbeds

### DIFF
--- a/doc/src/testbeds.md
+++ b/doc/src/testbeds.md
@@ -36,13 +36,12 @@ uses.
       graphical environments.
     - `command` takes a command to be run once the graphical environment
       has loaded
-      - `text` takes the string of the command
+      - `packages` are forwarded to `environment.systemPackages`
+      - `text` takes the string of the command, which is deduced from
+        `config.stylix.testbed.ui.command.packages` when it contains one
+        package.
       - `useTerminal` takes a boolean which determines whether the command
         should be run in a terminal, defaulting to `false`
-    - `application` takes a desktop application to be run once the graphical
-      environment has loaded. If one of its suboptions is set, all must be.
-      - `name` takes the string name of the desktop application
-      - `package` takes the package which provides the `.desktop` file
 
 ### Home Manager
 

--- a/doc/src/testbeds.md
+++ b/doc/src/testbeds.md
@@ -37,11 +37,11 @@ uses.
     - `command` takes a command to be run once the graphical environment
       has loaded
       - `packages` are forwarded to `environment.systemPackages`
+      - `terminal` takes a boolean which determines whether the command should
+        be run in a terminal, defaulting to `false`
       - `text` takes the string of the command, which is deduced from
         `config.stylix.testbed.ui.command.packages` when it contains one
         package.
-      - `useTerminal` takes a boolean which determines whether the command
-        should be run in a terminal, defaulting to `false`
 
 ### Home Manager
 

--- a/doc/src/testbeds.md
+++ b/doc/src/testbeds.md
@@ -38,7 +38,7 @@ uses.
       has loaded
       - `text` takes the string of the command
       - `useTerminal` takes a boolean which determines whether the command
-        should be run in a terminal
+        should be run in a terminal, defaulting to `false`
     - `application` takes a desktop application to be run once the graphical
       environment has loaded. If one of its suboptions is set, all must be.
       - `name` takes the string name of the desktop application

--- a/modules/alacritty/testbeds/alacritty.nix
+++ b/modules/alacritty/testbeds/alacritty.nix
@@ -1,17 +1,8 @@
-{ lib, pkgs, ... }:
-let
-  package = pkgs.alacritty;
-in
+{ lib, ... }:
 {
-  stylix.testbed.ui.application = {
-    name = "Alacritty";
-    inherit package;
-  };
+  stylix.testbed.ui.command.text = "alacritty";
 
   home-manager.sharedModules = lib.singleton {
-    programs.alacritty = {
-      enable = true;
-      inherit package;
-    };
+    programs.alacritty.enable = true;
   };
 }

--- a/modules/ashell/testbeds/ashell.nix
+++ b/modules/ashell/testbeds/ashell.nix
@@ -1,8 +1,8 @@
 { lib, ... }:
 {
   stylix.testbed.ui = {
-    graphicalEnvironment = "hyprland";
     command.text = "ashell";
+    graphicalEnvironment = "hyprland";
   };
 
   home-manager.sharedModules = lib.singleton {

--- a/modules/bat/testbeds/bat.nix
+++ b/modules/bat/testbeds/bat.nix
@@ -1,8 +1,8 @@
 { lib, ... }:
 {
   stylix.testbed.ui.command = {
+    terminal = true;
     text = "bat flake-parts/flake.nix";
-    useTerminal = true;
   };
 
   home-manager.sharedModules = lib.singleton {

--- a/modules/bat/testbeds/bat.nix
+++ b/modules/bat/testbeds/bat.nix
@@ -1,10 +1,11 @@
-{ lib, pkgs, ... }:
-let
-  package = pkgs.bat;
-in
+{ lib, ... }:
 {
-  environment = {
-    loginShellInit = "${lib.getExe package} flake-parts/flake.nix";
-    systemPackages = [ package ];
+  stylix.testbed.ui.command = {
+    text = "bat flake-parts/flake.nix";
+    useTerminal = true;
+  };
+
+  home-manager.sharedModules = lib.singleton {
+    programs.bat.enable = true;
   };
 }

--- a/modules/blender/testbeds/blender.nix
+++ b/modules/blender/testbeds/blender.nix
@@ -1,12 +1,4 @@
 { pkgs, ... }:
-let
-  package = pkgs.blender;
-in
 {
-  stylix.testbed.ui.application = {
-    name = "blender";
-    inherit package;
-  };
-
-  environment.systemPackages = [ package ];
+  stylix.testbed.ui.command.packages = [ pkgs.blender ];
 }

--- a/modules/bspwm/testbeds/bspwm.nix
+++ b/modules/bspwm/testbeds/bspwm.nix
@@ -1,12 +1,7 @@
 { pkgs, ... }:
 {
   stylix.testbed.ui = {
+    command.packages = [ pkgs.kitty ];
     graphicalEnvironment = "bspwm";
-
-    # We need something to open a window so that we can check the window borders
-    application = {
-      name = "kitty";
-      package = pkgs.kitty;
-    };
   };
 }

--- a/modules/btop/testbeds/btop.nix
+++ b/modules/btop/testbeds/btop.nix
@@ -1,7 +1,7 @@
-{ lib, pkgs, ... }:
+{ lib, ... }:
 {
   stylix.testbed.ui.command = {
-    text = lib.getExe pkgs.btop;
+    text = "btop";
     useTerminal = true;
   };
 

--- a/modules/btop/testbeds/btop.nix
+++ b/modules/btop/testbeds/btop.nix
@@ -1,8 +1,8 @@
 { lib, ... }:
 {
   stylix.testbed.ui.command = {
+    terminal = true;
     text = "btop";
-    useTerminal = true;
   };
 
   home-manager.sharedModules = lib.singleton {

--- a/modules/cava/testbeds/cava-rainbow.nix
+++ b/modules/cava/testbeds/cava-rainbow.nix
@@ -1,10 +1,8 @@
 { lib, pkgs, ... }:
 {
   stylix.testbed.ui.command = {
-    text = ''
-      ${lib.getExe' pkgs.alsa-utils "aplay"} /dev/urandom &
-      ${lib.getExe pkgs.cava}
-    '';
+    packages = [ pkgs.alsa-utils ];
+    text = "aplay /dev/urandom & cava";
     useTerminal = true;
   };
 

--- a/modules/cava/testbeds/cava-rainbow.nix
+++ b/modules/cava/testbeds/cava-rainbow.nix
@@ -2,8 +2,8 @@
 {
   stylix.testbed.ui.command = {
     packages = [ pkgs.alsa-utils ];
+    terminal = true;
     text = "aplay /dev/urandom & cava";
-    useTerminal = true;
   };
 
   home-manager.sharedModules = lib.singleton {

--- a/modules/cava/testbeds/cava.nix
+++ b/modules/cava/testbeds/cava.nix
@@ -1,10 +1,8 @@
 { lib, pkgs, ... }:
 {
   stylix.testbed.ui.command = {
-    text = ''
-      ${lib.getExe' pkgs.alsa-utils "aplay"} /dev/urandom &
-      ${lib.getExe pkgs.cava}
-    '';
+    packages = [ pkgs.alsa-utils ];
+    text = "aplay /dev/urandom & cava";
     useTerminal = true;
   };
 

--- a/modules/cava/testbeds/cava.nix
+++ b/modules/cava/testbeds/cava.nix
@@ -2,8 +2,8 @@
 {
   stylix.testbed.ui.command = {
     packages = [ pkgs.alsa-utils ];
+    terminal = true;
     text = "aplay /dev/urandom & cava";
-    useTerminal = true;
   };
 
   home-manager.sharedModules = lib.singleton {

--- a/modules/cavalier/testbeds/cavalier.nix
+++ b/modules/cavalier/testbeds/cavalier.nix
@@ -1,17 +1,8 @@
 { lib, pkgs, ... }:
-let
-  package = pkgs.cavalier;
-in
 {
-  stylix.testbed.ui.application = {
-    name = "org.nickvision.cavalier";
-    inherit package;
-  };
+  stylix.testbed.ui.command.text = pkgs.cavalier.meta.mainProgram;
 
   home-manager.sharedModules = lib.singleton {
-    programs.cavalier = {
-      enable = true;
-      inherit package;
-    };
+    programs.cavalier.enable = true;
   };
 }

--- a/modules/chromium/testbeds/chromium.nix
+++ b/modules/chromium/testbeds/chromium.nix
@@ -1,12 +1,8 @@
-{ pkgs, ... }:
-let
-  package = pkgs.chromium;
-in
+{ lib, ... }:
 {
-  stylix.testbed.ui.application = {
-    name = "chromium-browser";
-    inherit package;
-  };
+  stylix.testbed.ui.command.text = "chromium";
 
-  environment.systemPackages = [ package ];
+  home-manager.sharedModules = lib.singleton {
+    programs.chromium.enable = true;
+  };
 }

--- a/modules/discord/testbeds/vencord.nix
+++ b/modules/discord/testbeds/vencord.nix
@@ -1,24 +1,14 @@
 { lib, pkgs, ... }:
-let
-  package = pkgs.discord.override {
-    withVencord = true;
-  };
-in
 {
-  stylix.testbed = {
-    # Discord is not available on arm64.
-    enable = lib.meta.availableOn pkgs.stdenv.hostPlatform package;
-
-    ui.application = {
-      name = "discord";
-      inherit package;
+  stylix.testbed =
+    let
+      package = pkgs.discord.override { withVencord = true; };
+    in
+    {
+      enable = lib.meta.availableOn pkgs.stdenv.hostPlatform package;
+      ui.command.packages = [ package ];
     };
-  };
 
-  environment.systemPackages = [ package ];
   nixpkgs.config.allowUnfreePredicate =
-    pkg:
-    builtins.elem (lib.getName pkg) [
-      "discord"
-    ];
+    pkg: builtins.elem (lib.getName pkg) [ "discord" ];
 }

--- a/modules/discord/testbeds/vesktop.nix
+++ b/modules/discord/testbeds/vesktop.nix
@@ -1,17 +1,8 @@
-{ pkgs, lib, ... }:
-let
-  package = pkgs.vesktop;
-in
+{ lib, ... }:
 {
-  stylix.testbed.ui.application = {
-    name = "vesktop";
-    inherit package;
-  };
+  stylix.testbed.ui.command.text = "vesktop";
 
   home-manager.sharedModules = lib.singleton {
-    programs.vesktop = {
-      enable = true;
-      inherit package;
-    };
+    programs.vesktop.enable = true;
   };
 }

--- a/modules/emacs/testbeds/emacs.nix
+++ b/modules/emacs/testbeds/emacs.nix
@@ -1,11 +1,8 @@
-{ lib, pkgs, ... }:
+{ lib, ... }:
 {
   stylix.testbed.ui.command.text = "emacs flake-parts/flake.nix";
 
   home-manager.sharedModules = lib.singleton {
-    programs.emacs = {
-      enable = true;
-      package = pkgs.emacs;
-    };
+    programs.emacs.enable = true;
   };
 }

--- a/modules/eog/testbeds/eog.nix
+++ b/modules/eog/testbeds/eog.nix
@@ -1,4 +1,4 @@
-{ pkgs, lib, ... }:
+{ pkgs, ... }:
 {
-  stylix.testbed.ui.command.text = lib.getExe pkgs.eog;
+  stylix.testbed.ui.command.packages = [ pkgs.eog ];
 }

--- a/modules/firefox/testbeds/firefox.nix
+++ b/modules/firefox/testbeds/firefox.nix
@@ -1,21 +1,17 @@
-{ lib, pkgs, ... }:
-let
-  package = pkgs.firefox;
-  profileName = "stylix";
-in
+{ lib, ... }:
 {
-  stylix.testbed.ui.application = {
-    name = "firefox";
-    inherit package;
-  };
+  stylix.testbed.ui.command.text = "firefox";
 
-  home-manager.sharedModules = lib.singleton {
-    programs.firefox = {
-      enable = true;
-      inherit package;
-      profiles.${profileName}.isDefault = true;
+  home-manager.sharedModules =
+    let
+      profileName = "stylix";
+    in
+    lib.singleton {
+      programs.firefox = {
+        enable = true;
+        profiles.${profileName}.isDefault = true;
+      };
+
+      stylix.targets.firefox.profileNames = [ profileName ];
     };
-
-    stylix.targets.firefox.profileNames = [ profileName ];
-  };
 }

--- a/modules/fish/testbeds/fish-hm.nix
+++ b/modules/fish/testbeds/fish-hm.nix
@@ -1,8 +1,8 @@
 { lib, ... }:
 {
   stylix.testbed.ui.command = {
+    terminal = true;
     text = "fish";
-    useTerminal = true;
   };
 
   home-manager.sharedModules = lib.singleton {

--- a/modules/fish/testbeds/fish-nixos.nix
+++ b/modules/fish/testbeds/fish-nixos.nix
@@ -1,7 +1,7 @@
 {
   stylix.testbed.ui.command = {
+    terminal = true;
     text = "fish";
-    useTerminal = true;
   };
 
   programs.fish.enable = true;

--- a/modules/foliate/testbeds/foliate.nix
+++ b/modules/foliate/testbeds/foliate.nix
@@ -1,17 +1,8 @@
-{ lib, pkgs, ... }:
-let
-  package = pkgs.foliate;
-in
+{ lib, ... }:
 {
-  stylix.testbed.ui.application = {
-    name = "com.github.johnfactotum.Foliate";
-    inherit package;
-  };
+  stylix.testbed.ui.command.text = "foliate";
 
   home-manager.sharedModules = lib.singleton {
-    programs.foliate = {
-      enable = true;
-      inherit package;
-    };
+    programs.foliate.enable = true;
   };
 }

--- a/modules/foot/testbeds/foot.nix
+++ b/modules/foot/testbeds/foot.nix
@@ -1,17 +1,8 @@
-{ lib, pkgs, ... }:
-let
-  package = pkgs.foot;
-in
+{ lib, ... }:
 {
-  stylix.testbed.ui.application = {
-    name = "foot";
-    inherit package;
-  };
+  stylix.testbed.ui.command.text = "foot";
 
   home-manager.sharedModules = lib.singleton {
-    programs.foot = {
-      enable = true;
-      inherit package;
-    };
+    programs.foot.enable = true;
   };
 }

--- a/modules/fuzzel/testbeds/fuzzel.nix
+++ b/modules/fuzzel/testbeds/fuzzel.nix
@@ -1,8 +1,8 @@
 { lib, ... }:
 {
   stylix.testbed.ui = {
-    graphicalEnvironment = "hyprland";
     command.text = "fuzzel";
+    graphicalEnvironment = "hyprland";
   };
 
   home-manager.sharedModules = lib.singleton {

--- a/modules/fzf/testbeds/fzf.nix
+++ b/modules/fzf/testbeds/fzf.nix
@@ -1,7 +1,7 @@
-{ lib, pkgs, ... }:
+{ lib, ... }:
 {
   stylix.testbed.ui.command = {
-    text = lib.getExe pkgs.fzf;
+    text = "fzf";
     useTerminal = true;
   };
 

--- a/modules/fzf/testbeds/fzf.nix
+++ b/modules/fzf/testbeds/fzf.nix
@@ -1,8 +1,8 @@
 { lib, ... }:
 {
   stylix.testbed.ui.command = {
+    terminal = true;
     text = "fzf";
-    useTerminal = true;
   };
 
   home-manager.sharedModules = lib.singleton {

--- a/modules/gdu/testbeds/gdu.nix
+++ b/modules/gdu/testbeds/gdu.nix
@@ -1,8 +1,8 @@
 { lib, pkgs, ... }:
 {
   stylix.testbed.ui.command = {
+    terminal = true;
     text = "gdu";
-    useTerminal = true;
   };
 
   home-manager.sharedModules = lib.singleton {

--- a/modules/gedit/testbeds/gedit.nix
+++ b/modules/gedit/testbeds/gedit.nix
@@ -1,5 +1,7 @@
 { pkgs, ... }:
 {
-  stylix.testbed.ui.command.text = "gedit flake-parts/flake.nix";
-  environment.systemPackages = [ pkgs.gedit ];
+  stylix.testbed.ui.command = {
+    packages = [ pkgs.gedit ];
+    text = "gedit flake-parts/flake.nix";
+  };
 }

--- a/modules/ghostty/testbeds/ghostty.nix
+++ b/modules/ghostty/testbeds/ghostty.nix
@@ -1,17 +1,8 @@
-{ lib, pkgs, ... }:
-let
-  package = pkgs.ghostty;
-in
+{ lib, ... }:
 {
-  stylix.testbed.ui.application = {
-    name = "com.mitchellh.ghostty";
-    inherit package;
-  };
+  stylix.testbed.ui.command.text = "ghostty";
 
   home-manager.sharedModules = lib.singleton {
-    programs.ghostty = {
-      enable = true;
-      inherit package;
-    };
+    programs.ghostty.enable = true;
   };
 }

--- a/modules/glance/testbeds/glance-hm.nix
+++ b/modules/glance/testbeds/glance-hm.nix
@@ -1,24 +1,17 @@
 { lib, pkgs, ... }:
 let
   host = "127.0.0.1";
-
-  package = pkgs.wrapFirefox pkgs.firefox-unwrapped {
-    extraPolicies.OverrideFirstRunPage = "http://${host}:${toString port}";
-  };
-
   port = 1234;
 in
 {
-  stylix.testbed.ui.application = {
-    name = "firefox";
-    inherit package;
-  };
+  stylix.testbed.ui.command.packages = lib.singleton (
+    pkgs.wrapFirefox pkgs.firefox-unwrapped {
+      extraPolicies.OverrideFirstRunPage = "http://${host}:${toString port}";
+    }
+  );
 
   home-manager.sharedModules = lib.singleton {
-    programs.firefox = {
-      enable = true;
-      inherit package;
-    };
+    programs.firefox.enable = true;
 
     services.glance = {
       enable = true;

--- a/modules/glance/testbeds/glance-nixos.nix
+++ b/modules/glance/testbeds/glance-nixos.nix
@@ -1,23 +1,16 @@
 { lib, pkgs, ... }:
 let
   host = "127.0.0.1";
-
-  package = pkgs.wrapFirefox pkgs.firefox-unwrapped {
-    extraPolicies.OverrideFirstRunPage = "http://${host}:${toString port}";
-  };
-
   port = 1234;
 in
 {
-  stylix.testbed.ui.application = {
-    name = "firefox";
-    inherit package;
-  };
+  stylix.testbed.ui.command.packages = lib.singleton (
+    pkgs.wrapFirefox pkgs.firefox-unwrapped {
+      extraPolicies.OverrideFirstRunPage = "http://${host}:${toString port}";
+    }
+  );
 
-  programs.firefox = {
-    enable = true;
-    inherit package;
-  };
+  programs.firefox.enable = true;
 
   services.glance = {
     enable = true;

--- a/modules/gnome-text-editor/testbeds/gnome-text-editor.nix
+++ b/modules/gnome-text-editor/testbeds/gnome-text-editor.nix
@@ -1,5 +1,7 @@
 { pkgs, ... }:
 {
-  stylix.testbed.ui.command.text = "gnome-text-editor flake-parts/flake.nix";
-  environment.systemPackages = [ pkgs.gnome-text-editor ];
+  stylix.testbed.ui.command = {
+    packages = [ pkgs.gnome-text-editor ];
+    text = "gnome-text-editor flake-parts/flake.nix";
+  };
 }

--- a/modules/halloy/testbeds/halloy.nix
+++ b/modules/halloy/testbeds/halloy.nix
@@ -1,23 +1,15 @@
-{ pkgs, lib, ... }:
-let
-  package = pkgs.halloy;
-in
+{ lib, ... }:
 {
-  stylix.testbed.ui.application = {
-    name = "org.squidowl.halloy";
-    inherit package;
-  };
+  stylix.testbed.ui.command.text = "halloy";
 
   home-manager.sharedModules = lib.singleton {
     programs.halloy = {
       enable = true;
-      inherit package;
-      settings = {
-        servers.liberachat = {
-          nickname = "stylix-testbed";
-          server = "irc.libera.chat";
-          channels = [ "#halloy" ];
-        };
+
+      settings.servers.liberachat = {
+        channels = [ "#halloy" ];
+        nickname = "stylix-testbed";
+        server = "irc.libera.chat";
       };
     };
   };

--- a/modules/helix/testbeds/helix.nix
+++ b/modules/helix/testbeds/helix.nix
@@ -1,8 +1,8 @@
 { lib, ... }:
 {
   stylix.testbed.ui.command = {
+    terminal = true;
     text = "hx flake-parts/flake.nix";
-    useTerminal = true;
   };
 
   home-manager.sharedModules = lib.singleton {

--- a/modules/hyprland/testbeds/hyprland.nix
+++ b/modules/hyprland/testbeds/hyprland.nix
@@ -1,12 +1,7 @@
 { pkgs, ... }:
 {
   stylix.testbed.ui = {
+    command.packages = [ pkgs.kitty ];
     graphicalEnvironment = "hyprland";
-
-    # We need something to open a window so that we can check the window borders
-    application = {
-      name = "kitty";
-      package = pkgs.kitty;
-    };
   };
 }

--- a/modules/hyprpanel/testbeds/hyprpanel.nix
+++ b/modules/hyprpanel/testbeds/hyprpanel.nix
@@ -11,6 +11,7 @@
       name = "FiraMono NF";
       package = pkgs.nerd-fonts.fira-mono;
     };
+
     programs.hyprpanel.enable = true;
   };
 }

--- a/modules/kde/testbeds/kde.nix
+++ b/modules/kde/testbeds/kde.nix
@@ -1,10 +1,9 @@
+{ lib, pkgs, ... }:
 {
-  lib,
-  ...
-}:
-{
-  config = {
-    stylix.testbed.ui.graphicalEnvironment = "kde";
-    services.displayManager.autoLogin.enable = lib.mkForce false;
+  stylix.testbed.ui = {
+    command.packages = [ pkgs.kitty ];
+    graphicalEnvironment = "kde";
   };
+
+  services.displayManager.autoLogin.enable = lib.mkForce false;
 }

--- a/modules/kitty/testbeds/kitty.nix
+++ b/modules/kitty/testbeds/kitty.nix
@@ -1,17 +1,8 @@
-{ lib, pkgs, ... }:
-let
-  package = pkgs.kitty;
-in
+{ lib, ... }:
 {
-  stylix.testbed.ui.application = {
-    name = "kitty";
-    inherit package;
-  };
+  stylix.testbed.ui.command.text = "kitty";
 
   home-manager.sharedModules = lib.singleton {
-    programs.kitty = {
-      enable = true;
-      inherit package;
-    };
+    programs.kitty.enable = true;
   };
 }

--- a/modules/lazygit/testbeds/lazygit.nix
+++ b/modules/lazygit/testbeds/lazygit.nix
@@ -1,10 +1,7 @@
-{ lib, pkgs, ... }:
+{ lib, ... }:
 {
   stylix.testbed.ui.command = {
-    text = ''
-      ${lib.getExe pkgs.git} init
-      ${lib.getExe pkgs.lazygit}
-    '';
+    text = "git init && lazygit";
     useTerminal = true;
   };
 

--- a/modules/lazygit/testbeds/lazygit.nix
+++ b/modules/lazygit/testbeds/lazygit.nix
@@ -1,8 +1,8 @@
 { lib, ... }:
 {
   stylix.testbed.ui.command = {
+    terminal = true;
     text = "git init && lazygit";
-    useTerminal = true;
   };
 
   home-manager.sharedModules = lib.singleton {

--- a/modules/micro/testbeds/micro.nix
+++ b/modules/micro/testbeds/micro.nix
@@ -1,8 +1,8 @@
 { lib, ... }:
 {
   stylix.testbed.ui.command = {
+    terminal = true;
     text = "micro flake-parts/flake.nix";
-    useTerminal = true;
   };
 
   home-manager.sharedModules = lib.singleton {

--- a/modules/micro/testbeds/micro.nix
+++ b/modules/micro/testbeds/micro.nix
@@ -1,7 +1,7 @@
-{ lib, pkgs, ... }:
+{ lib, ... }:
 {
   stylix.testbed.ui.command = {
-    text = "${lib.getExe pkgs.micro} flake-parts/flake.nix";
+    text = "micro flake-parts/flake.nix";
     useTerminal = true;
   };
 

--- a/modules/mpv/testbeds/mpv-modernz.nix
+++ b/modules/mpv/testbeds/mpv-modernz.nix
@@ -1,17 +1,10 @@
 { lib, pkgs, ... }:
-let
-  package = pkgs.mpv;
-in
 {
-  stylix.testbed.ui.application = {
-    name = "mpv";
-    inherit package;
-  };
+  stylix.testbed.ui.command.text = "mpv";
 
   home-manager.sharedModules = lib.singleton {
     programs.mpv = {
       enable = true;
-      inherit package;
       scripts = [ pkgs.mpvScripts.modernz ];
     };
   };

--- a/modules/mpv/testbeds/mpv-uosc.nix
+++ b/modules/mpv/testbeds/mpv-uosc.nix
@@ -1,17 +1,10 @@
 { lib, pkgs, ... }:
-let
-  package = pkgs.mpv;
-in
 {
-  stylix.testbed.ui.application = {
-    name = "mpv";
-    inherit package;
-  };
+  stylix.testbed.ui.command.text = "mpv";
 
   home-manager.sharedModules = lib.singleton {
     programs.mpv = {
       enable = true;
-      inherit package;
       scripts = [ pkgs.mpvScripts.uosc ];
     };
   };

--- a/modules/mpv/testbeds/mpv.nix
+++ b/modules/mpv/testbeds/mpv.nix
@@ -1,17 +1,8 @@
-{ lib, pkgs, ... }:
-let
-  package = pkgs.mpv;
-in
+{ lib, ... }:
 {
-  stylix.testbed.ui.application = {
-    name = "mpv";
-    inherit package;
-  };
+  stylix.testbed.ui.command.text = "mpv";
 
   home-manager.sharedModules = lib.singleton {
-    programs.mpv = {
-      enable = true;
-      inherit package;
-    };
+    programs.mpv.enable = true;
   };
 }

--- a/modules/ncspot/testbeds/ncspot.nix
+++ b/modules/ncspot/testbeds/ncspot.nix
@@ -1,9 +1,10 @@
-{ pkgs, lib, ... }:
+{ lib, ... }:
 {
   stylix.testbed.ui.command = {
-    text = lib.getExe pkgs.ncspot;
+    text = "ncspot";
     useTerminal = true;
   };
+
   home-manager.sharedModules = lib.singleton {
     programs.ncspot.enable = true;
   };

--- a/modules/ncspot/testbeds/ncspot.nix
+++ b/modules/ncspot/testbeds/ncspot.nix
@@ -1,8 +1,8 @@
 { lib, ... }:
 {
   stylix.testbed.ui.command = {
+    terminal = true;
     text = "ncspot";
-    useTerminal = true;
   };
 
   home-manager.sharedModules = lib.singleton {

--- a/modules/neovim/testbeds/neovide.nix
+++ b/modules/neovim/testbeds/neovide.nix
@@ -1,13 +1,10 @@
-{ lib, pkgs, ... }:
+{ lib, ... }:
 {
   stylix.testbed.ui.command.text = "neovide flake-parts/flake.nix";
 
   home-manager.sharedModules = lib.singleton {
     programs = {
-      neovide = {
-        enable = true;
-        package = pkgs.neovide;
-      };
+      neovide.enable = true;
       neovim.enable = true;
     };
   };

--- a/modules/neovim/testbeds/neovim.nix
+++ b/modules/neovim/testbeds/neovim.nix
@@ -1,8 +1,8 @@
 { lib, ... }:
 {
   stylix.testbed.ui.command = {
+    terminal = true;
     text = "nvim flake-parts/flake.nix";
-    useTerminal = true;
   };
 
   home-manager.sharedModules = lib.singleton {

--- a/modules/neovim/testbeds/nixvim-integrated.nix
+++ b/modules/neovim/testbeds/nixvim-integrated.nix
@@ -1,7 +1,7 @@
 {
   stylix.testbed.ui.command = {
+    terminal = true;
     text = "nvim flake-parts/flake.nix";
-    useTerminal = true;
   };
 
   programs.nixvim.enable = true;

--- a/modules/neovim/testbeds/nixvim-standalone.nix
+++ b/modules/neovim/testbeds/nixvim-standalone.nix
@@ -1,8 +1,8 @@
 { config, lib, ... }:
 {
   stylix.testbed.ui.command = {
+    terminal = true;
     text = "nvim flake-parts/flake.nix";
-    useTerminal = true;
   };
 
   environment.systemPackages = lib.singleton (

--- a/modules/neovim/testbeds/nvf.nix
+++ b/modules/neovim/testbeds/nvf.nix
@@ -1,7 +1,7 @@
 {
   stylix.testbed.ui.command = {
+    terminal = true;
     text = "nvim flake-parts/flake.nix";
-    useTerminal = true;
   };
 
   programs.nvf.enable = true;

--- a/modules/neovim/testbeds/vim.nix
+++ b/modules/neovim/testbeds/vim.nix
@@ -1,8 +1,8 @@
 { lib, ... }:
 {
   stylix.testbed.ui.command = {
+    terminal = true;
     text = "vim flake-parts/flake.nix";
-    useTerminal = true;
   };
 
   home-manager.sharedModules = lib.singleton {

--- a/modules/neovim/testbeds/vim.nix
+++ b/modules/neovim/testbeds/vim.nix
@@ -1,7 +1,7 @@
-{ lib, pkgs, ... }:
+{ lib, ... }:
 {
   stylix.testbed.ui.command = {
-    text = "${lib.getExe pkgs.vim} flake-parts/flake.nix";
+    text = "vim flake-parts/flake.nix";
     useTerminal = true;
   };
 

--- a/modules/nushell/testbeds/nushell.nix
+++ b/modules/nushell/testbeds/nushell.nix
@@ -1,8 +1,8 @@
 { lib, ... }:
 {
   stylix.testbed.ui.command = {
+    terminal = true;
     text = "nu";
-    useTerminal = true;
   };
 
   home-manager.sharedModules = lib.singleton {

--- a/modules/obsidian/testbeds/obsidian.nix
+++ b/modules/obsidian/testbeds/obsidian.nix
@@ -1,29 +1,20 @@
-{ lib, pkgs, ... }:
-let
-  package = pkgs.obsidian;
-in
+{ lib, ... }:
 {
-  nixpkgs.config.allowUnfreePredicate =
-    pkg:
-    builtins.elem (lib.getName pkg) [
-      "obsidian"
-    ];
+  stylix.testbed.ui.text = "obsidian";
 
-  stylix.testbed.ui.application = {
-    name = "obsidian";
-    inherit package;
-  };
+  nixpkgs.config.allowUnfreePredicate =
+    pkg: builtins.elem (lib.getName pkg) [ "obsidian" ];
 
   home-manager.sharedModules =
     let
       vault = "stylix";
     in
     lib.singleton {
+      stylix.targets.obsidian.vaultNames = [ vault ];
+
       programs.obsidian = {
         enable = true;
         vaults.${vault}.enable = true;
-        inherit package;
       };
-      stylix.targets.obsidian.vaultNames = [ vault ];
     };
 }

--- a/modules/opencode/testbeds/opencode.nix
+++ b/modules/opencode/testbeds/opencode.nix
@@ -1,8 +1,8 @@
 { lib, ... }:
 {
   stylix.testbed.ui.command = {
+    terminal = true;
     text = "opencode";
-    useTerminal = true;
   };
 
   home-manager.sharedModules = lib.singleton {

--- a/modules/opencode/testbeds/opencode.nix
+++ b/modules/opencode/testbeds/opencode.nix
@@ -1,7 +1,7 @@
-{ lib, pkgs, ... }:
+{ lib, ... }:
 {
   stylix.testbed.ui.command = {
-    text = lib.getExe pkgs.opencode;
+    text = "opencode";
     useTerminal = true;
   };
 

--- a/modules/qutebrowser/testbeds/qutebrowser.nix
+++ b/modules/qutebrowser/testbeds/qutebrowser.nix
@@ -1,17 +1,8 @@
-{ lib, pkgs, ... }:
-let
-  package = pkgs.qutebrowser;
-in
+{ lib, ... }:
 {
-  stylix.testbed.ui.application = {
-    name = "org.qutebrowser.qutebrowser";
-    inherit package;
-  };
+  stylix.testbed.ui.command.text = "qutebrowser";
 
   home-manager.sharedModules = lib.singleton {
-    programs.qutebrowser = {
-      enable = true;
-      inherit package;
-    };
+    programs.qutebrowser.enable = true;
   };
 }

--- a/modules/rio/testbeds/rio.nix
+++ b/modules/rio/testbeds/rio.nix
@@ -1,17 +1,8 @@
-{ lib, pkgs, ... }:
-let
-  package = pkgs.rio;
-in
+{ lib, ... }:
 {
-  stylix.testbed.ui.application = {
-    name = "rio";
-    inherit package;
-  };
+  stylix.testbed.ui.command.text = "rio";
 
   home-manager.sharedModules = lib.singleton {
-    programs.rio = {
-      enable = true;
-      inherit package;
-    };
+    programs.rio.enable = true;
   };
 }

--- a/modules/spicetify/testbeds/spicetify.nix
+++ b/modules/spicetify/testbeds/spicetify.nix
@@ -1,24 +1,12 @@
-{
-  lib,
-  pkgs,
-  config,
-  ...
-}:
+{ lib, pkgs, ... }:
 {
   stylix.testbed = {
-    # Spotify is not available on arm64.
     enable = lib.meta.availableOn pkgs.stdenv.hostPlatform pkgs.spotify;
-
-    ui.command = {
-      text = lib.getExe config.programs.spicetify.spicedSpotify;
-    };
+    ui.command.text = "spotify";
   };
 
-  programs.spicetify.enable = true;
-
   nixpkgs.config.allowUnfreePredicate =
-    pkg:
-    builtins.elem (lib.getName pkg) [
-      "spotify"
-    ];
+    pkg: builtins.elem (lib.getName pkg) [ "spotify" ];
+
+  programs.spicetify.enable = true;
 }

--- a/modules/starship/testbeds/starship.nix
+++ b/modules/starship/testbeds/starship.nix
@@ -1,8 +1,8 @@
 { lib, ... }:
 {
   stylix.testbed.ui.command = {
+    terminal = true;
     text = "bash";
-    useTerminal = true;
   };
 
   home-manager.sharedModules = lib.singleton {

--- a/modules/starship/testbeds/starship.nix
+++ b/modules/starship/testbeds/starship.nix
@@ -1,20 +1,17 @@
-{ lib, pkgs, ... }:
+{ lib, ... }:
 {
   stylix.testbed.ui.command = {
-    text = lib.getExe pkgs.bashInteractive;
+    text = "bash";
     useTerminal = true;
   };
 
   home-manager.sharedModules = lib.singleton {
     programs = {
+      bash.enable = true;
+
       starship = {
         enable = true;
-        package = pkgs.starship;
         enableBashIntegration = true;
-      };
-      bash = {
-        enable = true;
-        package = pkgs.bashInteractive;
       };
     };
   };

--- a/modules/sxiv/testbeds/sxiv.nix
+++ b/modules/sxiv/testbeds/sxiv.nix
@@ -8,7 +8,7 @@ in
     ${lib.getExe pkgs.xorg.xrdb} ~/.Xresources
 
     ${lib.getExe package} \
-      "${pkgs.nixos-icons}/share/icons/hicolor/scalable/apps/nix-snowflake.svg";
+      "${pkgs.nixos-icons}/share/icons/hicolor/scalable/apps/nix-snowflake.svg"
   '';
 
   home-manager.sharedModules = lib.singleton {

--- a/modules/sxiv/testbeds/sxiv.nix
+++ b/modules/sxiv/testbeds/sxiv.nix
@@ -1,17 +1,17 @@
-{ lib, pkgs, ... }:
-let
-  package = pkgs.nsxiv;
-in
+{ pkgs, ... }:
 {
-  stylix.testbed.ui.command.text = ''
-    # Xresources isn't loaded by default, so we force it
-    ${lib.getExe pkgs.xorg.xrdb} ~/.Xresources
+  stylix.testbed.ui.command = {
+    packages = with pkgs; [
+      nsxiv
+      xorg.xrdb
+    ];
 
-    ${lib.getExe package} \
-      "${pkgs.nixos-icons}/share/icons/hicolor/scalable/apps/nix-snowflake.svg"
-  '';
+    text = ''
+      # Xresources isn't loaded by default, so we force it
+      xrdb ~/.Xresources
 
-  home-manager.sharedModules = lib.singleton {
-    home.packages = [ package ];
+      nsxiv \
+        "${pkgs.nixos-icons}/share/icons/hicolor/scalable/apps/nix-snowflake.svg"
+    '';
   };
 }

--- a/modules/tmux/testbeds/tmux.nix
+++ b/modules/tmux/testbeds/tmux.nix
@@ -1,9 +1,10 @@
-{ pkgs, lib, ... }:
+{ lib, ... }:
 {
   stylix.testbed.ui.command = {
-    text = lib.getExe pkgs.tmux;
+    text = "tmux";
     useTerminal = true;
   };
+
   home-manager.sharedModules = lib.singleton {
     programs.tmux.enable = true;
   };

--- a/modules/tmux/testbeds/tmux.nix
+++ b/modules/tmux/testbeds/tmux.nix
@@ -1,8 +1,8 @@
 { lib, ... }:
 {
   stylix.testbed.ui.command = {
+    terminal = true;
     text = "tmux";
-    useTerminal = true;
   };
 
   home-manager.sharedModules = lib.singleton {

--- a/modules/vicinae/testbeds/vicinae.nix
+++ b/modules/vicinae/testbeds/vicinae.nix
@@ -1,8 +1,8 @@
 { lib, ... }:
 {
   stylix.testbed.ui = {
-    graphicalEnvironment = "hyprland";
     command.text = "sleep 5 && vicinae open";
+    graphicalEnvironment = "hyprland";
   };
 
   home-manager.sharedModules = lib.singleton {

--- a/modules/waybar/testbeds/waybar.nix
+++ b/modules/waybar/testbeds/waybar.nix
@@ -1,22 +1,25 @@
 { lib, ... }:
 {
   stylix.testbed.ui = {
-    graphicalEnvironment = "hyprland";
     command.text = "waybar";
+    graphicalEnvironment = "hyprland";
   };
 
   home-manager.sharedModules = lib.singleton {
     programs.waybar = {
       enable = true;
+
       settings = lib.singleton {
         modules-left = [
           "hyprland/workspaces"
           "hyprland/submap"
           "custom/media"
         ];
+
         modules-center = [
           "hyprland/window"
         ];
+
         modules-right = [
           "mpd"
           "idle_inhibitor"

--- a/modules/wayprompt/testbeds/wayprompt.nix
+++ b/modules/wayprompt/testbeds/wayprompt.nix
@@ -1,8 +1,7 @@
 { lib, ... }:
 {
-  stylix.testbed = {
-    ui.graphicalEnvironment = "hyprland";
-    ui.command.text = ''
+  stylix.testbed.ui = {
+    command.text = ''
       wayprompt \
         --get-pin \
         --title "Wayprompt stylix test" \
@@ -11,6 +10,8 @@
         --button-not-ok "Not okay" \
         --button-cancel "Cancel"
     '';
+
+    graphicalEnvironment = "hyprland";
   };
 
   home-manager.sharedModules = lib.singleton {

--- a/modules/wezterm/testbeds/wezterm.nix
+++ b/modules/wezterm/testbeds/wezterm.nix
@@ -1,17 +1,8 @@
-{ lib, pkgs, ... }:
-let
-  package = pkgs.wezterm;
-in
+{ lib, ... }:
 {
-  stylix.testbed.ui.application = {
-    name = "org.wezfurlong.wezterm";
-    inherit package;
-  };
+  stylix.testbed.ui.command.text = "wezterm";
 
   home-manager.sharedModules = lib.singleton {
-    programs.wezterm = {
-      enable = true;
-      inherit package;
-    };
+    programs.wezterm.enable = true;
   };
 }

--- a/modules/wofi/testbeds/wofi.nix
+++ b/modules/wofi/testbeds/wofi.nix
@@ -1,15 +1,8 @@
-{ lib, pkgs, ... }:
-let
-  package = pkgs.wofi;
-in
+{ lib, ... }:
 {
-  stylix.testbed.ui.command.text =
-    "${lib.getExe package} --allow-images --show drun";
+  stylix.testbed.ui.command.text = "wofi --allow-images --show drun";
 
   home-manager.sharedModules = lib.singleton {
-    programs.wofi = {
-      enable = true;
-      inherit package;
-    };
+    programs.wofi.enable = true;
   };
 }

--- a/modules/yazi/testbeds/yazi.nix
+++ b/modules/yazi/testbeds/yazi.nix
@@ -1,21 +1,8 @@
-{ lib, pkgs, ... }:
-let
-  package = pkgs.yazi;
-in
+{ lib, ... }:
 {
-  stylix.testbed.ui.application = {
-    name = "yazi";
-    inherit package;
-  };
+  stylix.testbed.ui.command.text = "yazi";
 
   home-manager.sharedModules = lib.singleton {
-    programs.yazi = {
-      enable = true;
-      inherit package;
-    };
-
-    home.packages = [
-      pkgs.nerd-fonts.fira-mono
-    ];
+    programs.yazi.enable = true;
   };
 }

--- a/modules/zathura/testbeds/zathura.nix
+++ b/modules/zathura/testbeds/zathura.nix
@@ -1,17 +1,8 @@
-{ lib, pkgs, ... }:
-let
-  package = pkgs.zathura;
-in
+{ lib, ... }:
 {
-  stylix.testbed.ui.application = {
-    name = "org.pwmt.zathura";
-    inherit package;
-  };
+  stylix.testbed.ui.command.text = "zathura";
 
   home-manager.sharedModules = lib.singleton {
-    programs.zathura = {
-      enable = true;
-      inherit package;
-    };
+    programs.zathura.enable = true;
   };
 }

--- a/modules/zed/testbeds/zed.nix
+++ b/modules/zed/testbeds/zed.nix
@@ -1,8 +1,6 @@
-{ lib, pkgs, ... }:
+{ lib, ... }:
 {
-  stylix.testbed.ui.command = {
-    text = "${lib.getExe pkgs.zed-editor} flake-parts/flake.nix";
-  };
+  stylix.testbed.ui.command.text = "zeditor flake-parts/flake.nix";
 
   home-manager.sharedModules = lib.singleton {
     programs.zed-editor.enable = true;

--- a/modules/zellij/testbeds/zellij.nix
+++ b/modules/zellij/testbeds/zellij.nix
@@ -1,8 +1,8 @@
 { lib, ... }:
 {
   stylix.testbed.ui.command = {
+    terminal = true;
     text = "zellij";
-    useTerminal = true;
   };
 
   home-manager.sharedModules = lib.singleton {

--- a/modules/zen-browser/testbeds/zen-browser.nix
+++ b/modules/zen-browser/testbeds/zen-browser.nix
@@ -8,8 +8,10 @@ in
   home-manager.sharedModules = lib.singleton {
     programs.zen-browser = {
       enable = true;
+
       profiles.${profileName} = {
         isDefault = true;
+
         settings = {
           "app.normandy.first_run" = false;
           "zen.welcome-screen.seen" = true;

--- a/stylix/testbed/modules/application.nix
+++ b/stylix/testbed/modules/application.nix
@@ -45,6 +45,14 @@ in
                     '';
                     default = [ ];
                   };
+                  terminal = lib.mkOption {
+                    type = lib.types.bool;
+                    description = ''
+                      Whether to spawn a terminal when running the command.
+                    '';
+                    default = false;
+                    example = true;
+                  };
                   text = lib.mkOption {
                     type = lib.types.str;
                     description = ''
@@ -54,14 +62,6 @@ in
                       contains one package.
                     '';
                     default = "";
-                  };
-                  useTerminal = lib.mkOption {
-                    type = lib.types.bool;
-                    description = ''
-                      Whether to spawn a terminal when running the command.
-                    '';
-                    default = false;
-                    example = true;
                   };
                 };
               }
@@ -133,11 +133,10 @@ in
         )
         [
           {
-            inherit (config.stylix.testbed.ui.command) packages text;
+            inherit (config.stylix.testbed.ui.command) packages terminal text;
 
             condition = config.stylix.testbed.ui.command != null;
             name = "";
-            terminal = config.stylix.testbed.ui.command.useTerminal;
           }
           {
             condition = config.stylix.testbed.ui.sendNotifications;

--- a/stylix/testbed/modules/application.nix
+++ b/stylix/testbed/modules/application.nix
@@ -132,11 +132,14 @@ in
 
             name' = "stylix-testbed-${name}";
           in
-          lib.optionals condition [
-            application
-            autostartItem
-            desktopItem
-          ]
+          lib.optionals condition (
+            [
+              application
+              autostartItem
+              desktopItem
+            ]
+            ++ packages
+          )
         )
         [
           {

--- a/stylix/testbed/modules/application.nix
+++ b/stylix/testbed/modules/application.nix
@@ -20,11 +20,11 @@ in
               Whether to enable a standard configuration for testing graphical
               applications.
 
-              This will automatically log in as the `${user.username}` user and launch
-              an application or command.
+              This will automatically log in as the `${user.username}` user and
+              launch an application or command.
 
-              This is currently based on GNOME, but the specific desktop environment
-              used may change in the future.
+              This is currently based on GNOME, but the specific desktop
+              environment used may change in the future.
             '';
           };
           graphicalEnvironment = lib.mkOption {
@@ -45,8 +45,8 @@ in
                   name = lib.mkOption {
                     type = lib.types.str;
                     description = ''
-                      The name of the desktop entry for the application, without the
-                      `.desktop` extension.
+                      The name of the desktop entry for the application, without
+                      the `.desktop` extension.
                     '';
                   };
 
@@ -69,8 +69,8 @@ in
                   text = lib.mkOption {
                     type = lib.types.str;
                     description = ''
-                      The command which will be run once the graphical environment has
-                      loaded.
+                      The command which will be run once the graphical
+                      environment has loaded.
                     '';
                   };
                   useTerminal = lib.mkOption {

--- a/stylix/testbed/modules/application.nix
+++ b/stylix/testbed/modules/application.nix
@@ -15,6 +15,7 @@ in
           enable = lib.mkOption {
             type = lib.types.bool;
             default = false;
+            example = true;
             description = ''
               Whether to enable a standard configuration for testing graphical
               applications.
@@ -78,6 +79,7 @@ in
                       Whether or not to spawn a terminal when running the command.
                     '';
                     default = false;
+                    example = true;
                   };
                 };
               }

--- a/stylix/testbed/modules/application.nix
+++ b/stylix/testbed/modules/application.nix
@@ -76,7 +76,7 @@ in
                   useTerminal = lib.mkOption {
                     type = lib.types.bool;
                     description = ''
-                      Whether or not to spawn a terminal when running the command.
+                      Whether to spawn a terminal when running the command.
                     '';
                     default = false;
                     example = true;


### PR DESCRIPTION
```
commit d9ed64e692940886678ebb8d7e839c42d332961b
Author: NAHO <90870942+trueNAHO@users.noreply.github.com>
Date:   2025-07-30 12:10:25 +0200

    sxiv/testbed: remove trailing Bash semicolon

    Fixes: 8b898ca041a3 ("sxiv: avoid downloading custom file in testbed (#1641)")

 modules/sxiv/testbeds/sxiv.nix | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

commit 34217434704711819d78f8feef038d71075b758c
Author: NAHO <90870942+trueNAHO@users.noreply.github.com>
Date:   2025-07-09 18:38:21 +0200

    stylix/testbed/modules/application: add examples to boolean options

 stylix/testbed/modules/application.nix | 2 ++
 1 file changed, 2 insertions(+)

commit b6022cb3a5aeba3d00433fa42bb0fff08a3cd1a7
Author: NAHO <90870942+trueNAHO@users.noreply.github.com>
Date:   2025-07-09 18:38:59 +0200

    stylix/testbed/modules/application: match mkEnableOption's description

 stylix/testbed/modules/application.nix | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

commit e458b09827b2f989860196428f4d0ccb83ae5705
Author: NAHO <90870942+trueNAHO@users.noreply.github.com>
Date:   2025-08-26 20:57:25 +0200

    doc/src/testbeds: mention stylix.testbed.ui.command.useTerminal default

    Co-authored-by: awwpotato <awwpotato@voidq.com>

 doc/src/testbeds.md | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

commit 47ad279bd90c37d0198d7677cd7ccd1aef299b51
Author: NAHO <90870942+trueNAHO@users.noreply.github.com>
Date:   2025-07-09 18:39:58 +0200

    stylix/testbed/modules/application: wrap documentation to 80 characters

 stylix/testbed/modules/application.nix | 16 ++++++++--------
 1 file changed, 8 insertions(+), 8 deletions(-)

commit e1b7fdedc2653aa199648b2a6f08298e94ae6caa
Author: NAHO <90870942+trueNAHO@users.noreply.github.com>
Date:   2025-07-29 16:04:48 +0200

    stylix/testbed/modules/application: allow re-running test code

    Allow re-running test code via deskop items and stylix-testbed-${name}
    CLIs.

 stylix/testbed/modules/application.nix | 94 ++++++++++++++++++++++------------
 1 file changed, 60 insertions(+), 34 deletions(-)

commit 72931352f091caa0c946cb59f24f871d231380e0
Author: NAHO <90870942+trueNAHO@users.noreply.github.com>
Date:   2025-07-29 16:23:57 +0200

    stylix/testbed/modules/application: conveniently install dependencies

 stylix/testbed/modules/application.nix | 13 ++++++++-----
 1 file changed, 8 insertions(+), 5 deletions(-)

commit be30a1a880852632f5db88a0808077b724565b58
Author: NAHO <90870942+trueNAHO@users.noreply.github.com>
Date:   2025-07-30 11:49:44 +0200

    treewide: simplify and standardize testbeds

    Simplify and standardize testbeds by replacing
    config.stylix.testbed.ui.application declarations with
    config.stylix.testbed.ui.command, and replacing

        stylix.testbed.ui.command = {
          packages = [ package ];
          text = package.meta.mainProgram;
        };

    with

        stylix.testbed.ui.command.packages = [ package ];

    by trivially deducing config.stylix.testbed.ui.command.text from
    config.stylix.testbed.ui.command.packages.

    Leverage the default programs."<PACKAGE>".package value to simplify

        let
          package = pkgs."<PACKAGE>";
        in
        {
          stylix.testbed.ui.command.packages = [ package ];

          home-manager.sharedModules = lib.singleton {
            programs."<PACKAGE>" = {
              inherit package;
              enable = true;
            };
          };
        }

    to

        {
          stylix.testbed.ui.command.text = "<PACKAGE_META_MAIN_PROGRAM>";

          home-manager.sharedModules = lib.singleton {
            programs."<PACKAGE>".enable = true;
          };
        }

    Minor stylistic changes are made to standardize testbed declarations.

 doc/src/testbeds.md                                |  9 ++--
 modules/alacritty/testbeds/alacritty.nix           | 15 ++----
 modules/ashell/testbeds/ashell.nix                 |  2 +-
 modules/bat/testbeds/bat.nix                       | 15 +++---
 modules/blender/testbeds/blender.nix               | 10 +---
 modules/bspwm/testbeds/bspwm.nix                   |  7 +--
 modules/btop/testbeds/btop.nix                     |  4 +-
 modules/cava/testbeds/cava-rainbow.nix             |  6 +--
 modules/cava/testbeds/cava.nix                     |  6 +--
 modules/cavalier/testbeds/cavalier.nix             | 13 +----
 modules/chromium/testbeds/chromium.nix             | 14 ++----
 modules/discord/testbeds/vencord.nix               | 26 +++-------
 modules/discord/testbeds/vesktop.nix               | 15 ++----
 modules/emacs/testbeds/emacs.nix                   |  7 +--
 modules/eog/testbeds/eog.nix                       |  4 +-
 modules/firefox/testbeds/firefox.nix               | 30 +++++-------
 modules/foliate/testbeds/foliate.nix               | 15 ++----
 modules/foot/testbeds/foot.nix                     | 15 ++----
 modules/fuzzel/testbeds/fuzzel.nix                 |  2 +-
 modules/fzf/testbeds/fzf.nix                       |  4 +-
 modules/gedit/testbeds/gedit.nix                   |  6 ++-
 modules/ghostty/testbeds/ghostty.nix               | 15 ++----
 modules/glance/testbeds/glance-hm.nix              | 19 +++-----
 modules/glance/testbeds/glance-nixos.nix           | 19 +++-----
 .../testbeds/gnome-text-editor.nix                 |  6 ++-
 modules/halloy/testbeds/halloy.nix                 | 22 +++------
 modules/hyprland/testbeds/hyprland.nix             |  7 +--
 modules/hyprpanel/testbeds/hyprpanel.nix           |  1 +
 modules/kde/testbeds/kde.nix                       | 13 +++--
 modules/kitty/testbeds/kitty.nix                   | 15 ++----
 modules/lazygit/testbeds/lazygit.nix               |  7 +--
 modules/micro/testbeds/micro.nix                   |  4 +-
 modules/mpv/testbeds/mpv-modernz.nix               |  9 +---
 modules/mpv/testbeds/mpv-uosc.nix                  |  9 +---
 modules/mpv/testbeds/mpv.nix                       | 15 ++----
 modules/ncspot/testbeds/ncspot.nix                 |  5 +-
 modules/neovim/testbeds/neovide.nix                |  7 +--
 modules/neovim/testbeds/vim.nix                    |  4 +-
 modules/obsidian/testbeds/obsidian.nix             | 21 +++-----
 modules/opencode/testbeds/opencode.nix             |  4 +-
 modules/qutebrowser/testbeds/qutebrowser.nix       | 15 ++----
 modules/rio/testbeds/rio.nix                       | 15 ++----
 modules/spicetify/testbeds/spicetify.nix           | 22 ++-------
 modules/starship/testbeds/starship.nix             | 11 ++---
 modules/sxiv/testbeds/sxiv.nix                     | 24 ++++-----
 modules/tmux/testbeds/tmux.nix                     |  5 +-
 modules/vicinae/testbeds/vicinae.nix               |  2 +-
 modules/waybar/testbeds/waybar.nix                 |  5 +-
 modules/wayprompt/testbeds/wayprompt.nix           |  7 +--
 modules/wezterm/testbeds/wezterm.nix               | 15 ++----
 modules/wofi/testbeds/wofi.nix                     | 13 ++---
 modules/yazi/testbeds/yazi.nix                     | 19 ++------
 modules/zathura/testbeds/zathura.nix               | 15 ++----
 modules/zed/testbeds/zed.nix                       |  6 +--
 modules/zen-browser/testbeds/zen-browser.nix       |  2 +
 stylix/testbed/modules/application.nix             | 57 ++++++++--------------
 56 files changed, 209 insertions(+), 451 deletions(-)

commit 85a5792c0528dd1bdb5169fe094435c253a4b54a
Author: NAHO <90870942+trueNAHO@users.noreply.github.com>
Date:   2025-07-30 12:39:19 +0200

    treewide: rename stylix.testbed.ui.command.{useTerminal => terminal}

    Simplify the testbed interface by renaming
    stylix.testbed.ui.command.useTerminal to
    stylix.testbed.ui.command.terminal.

 doc/src/testbeds.md                           |  4 ++--
 modules/bat/testbeds/bat.nix                  |  2 +-
 modules/btop/testbeds/btop.nix                |  2 +-
 modules/cava/testbeds/cava-rainbow.nix        |  2 +-
 modules/cava/testbeds/cava.nix                |  2 +-
 modules/fish/testbeds/fish-hm.nix             |  2 +-
 modules/fish/testbeds/fish-nixos.nix          |  2 +-
 modules/fzf/testbeds/fzf.nix                  |  2 +-
 modules/gdu/testbeds/gdu.nix                  |  2 +-
 modules/helix/testbeds/helix.nix              |  2 +-
 modules/lazygit/testbeds/lazygit.nix          |  2 +-
 modules/micro/testbeds/micro.nix              |  2 +-
 modules/ncspot/testbeds/ncspot.nix            |  2 +-
 modules/neovim/testbeds/neovim.nix            |  2 +-
 modules/neovim/testbeds/nixvim-integrated.nix |  2 +-
 modules/neovim/testbeds/nixvim-standalone.nix |  2 +-
 modules/neovim/testbeds/nvf.nix               |  2 +-
 modules/neovim/testbeds/vim.nix               |  2 +-
 modules/nushell/testbeds/nushell.nix          |  2 +-
 modules/opencode/testbeds/opencode.nix        |  2 +-
 modules/starship/testbeds/starship.nix        |  2 +-
 modules/tmux/testbeds/tmux.nix                |  2 +-
 modules/zellij/testbeds/zellij.nix            |  2 +-
 stylix/testbed/modules/application.nix        | 19 +++++++++----------
 24 files changed, 33 insertions(+), 34 deletions(-)
```

# Changelog

## v9: https://github.com/nix-community/stylix/commit/85a5792c0528dd1bdb5169fe094435c253a4b54a

- Rebase on top of commit 89f99bfeb8b6 ("vicinae: init (#1994)").

## v8: https://github.com/nix-community/stylix/commit/92ee46f4c602751df3eada1b0c667b2853f8c204

- Rebase on top of commit f47c0edcf71e ("treewide: remove Plasma 5 support dropped upstream (#1860)").
- Add patch ["[PATCH 4/9] doc/src/testbeds: mention stylix.testbed.ui.command.useTerminal default"](https://github.com/nix-community/stylix/pull/1662/commits/41d66fd0e7eeb65c4bf0f70b03f9020dd7fbfb66), as suggested in https://github.com/nix-community/stylix/pull/1662#discussion_r2287040438.

## v7: https://github.com/nix-community/stylix/commit/0042265c132ff8823e8d76b95b3a9272d690577c

- Rebase on top of commit 1b5e1c5642cf ("anki: init (#1801)").
- `treewide: simplify and standardize testbeds`
    - Fix `programs."<PACKAGE">.package` typo in commit message with `programs."<PACKAGE>".package`.
    - Polish `/modules/spicetify/testbeds/spicetify.nix` formatting, as suggested in https://github.com/nix-community/stylix/pull/1662#discussion_r2245866637.

## v6: https://github.com/nix-community/stylix/commit/a5a8c4159aaff856864397f0b455adb5906932dd

- Rebase on top of commit e544f6ec6cab ("ci: visually distinguish user description from PR template content (#1802)").
- `treewide: simplify and standardize testbeds`
    - Fix `stylix.testbed.ui.command.text` usage in `/modules/spicetify/testbeds/spicetify.nix`.

## v5: https://github.com/nix-community/stylix/commit/b9e3c7495c01d8689541ee1807f1d9ca751742db

- `treewide: simplify and standardize testbeds`
    - Remove `stylix.testbed.ui.command.packages = [ pkgs.kitty ];` in `/modules/kde/testbeds/plasma5.nix` to avoid enabling GNOME.

## v4: https://github.com/nix-community/stylix/commit/2b4754f319dab23af350df757a3a56c3a063e7a2

- `treewide: simplify and standardize testbeds`
    - Use local `packages` variable in `throw`.

## v3: https://github.com/nix-community/stylix/commit/303cef833017d75de88c5ce735008a20831b8408

- `treewide: simplify and standardize testbeds`
    - Add missing `throw` call.
    - Remove `multiline = false;` because we are `throw`ing and no longer curating assertion errors.

## v2: https://github.com/nix-community/stylix/commit/1a8885e94e9a2e006211c8fbcb13d33c528b7281

- `treewide: simplify and standardize testbeds`
    - Fix `null` access by inlining assertion and using local variables.

## v1: https://github.com/nix-community/stylix/commit/0a8661c4be856805db99bcad5dc2a44f784888b9

- Rebase on top of commit 57d036d92283 ("doc: commit_convention: overhaul and formalize unspoken rules (#1717)").
- Remove commit `treewide: optionally apply lib.getExe to stylix.testbed.ui.command.gnome-text-editor` in favor of the new commit `treewide: simplify and standardize testbeds`.
- Add the following commits:
    - `sxiv/testbed: remove trailing Bash semicolon`
    - `stylix/testbed/modules/application: allow re-running test code`
    - `stylix/testbed/modules/application: conveniently install dependencies`
    - `treewide: rename stylix.testbed.ui.command.{useTerminal => terminal}`

## v0: https://github.com/nix-community/stylix/commit/1e3df8be7b0bcd1b948d21b0588bd5b7eeccebfe

---

- [X]  I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [X] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
    - Commit `treewide: simplify and standardize testbeds` has only been partially tested.
- [X] Each commit in this PR is suitable for backport to the current stable branch

## Notify Maintainers
