### PR TITLE
stylix: use enable for cursor instead of null

### DIFF
--- a/stylix/cursor.nix
+++ b/stylix/cursor.nix
@@ -1,5 +1,4 @@
 { lib, config, ... }:
-
 {
   options.stylix.cursor = lib.mkOption {
     description = ''
@@ -9,6 +8,16 @@
     type = lib.types.nullOr (
       lib.types.submodule {
         options = {
+          enable = lib.mkEnableOption "cursor theming with stylix" // {
+            default =
+              lib.versionOlder (config.system.stateVersion or config.home.stateVersion
+              ) "25.05"
+              && builtins.any (x: x != null) (builtins.attrValues config.stylix.cursor);
+            defaultText = lib.literalExpression ''
+              lib.versionOlder (config.system.stateVersion or config.home.stateVersion) "25.05"
+              && builtins.any (x: x != null) (builtins.attrValues config.stylix.cursor)
+            '';
+          };
           name = lib.mkOption {
             description = "The cursor name within the package.";
             type = lib.types.nullOr lib.types.str;
@@ -27,21 +36,44 @@
         };
       }
     );
-    default = null;
-  };
-  config.assertions =
-    let
-      inherit (config.stylix) cursor;
-    in
-    [
+    default = {
+      enable =
+        lib.versionOlder (config.system.stateVersion or config.home.stateVersion
+        ) "25.05"
+        && builtins.any (x: x != null) (builtins.attrValues config.stylix.cursor);
+      name = null;
+      package = null;
+      size = null;
+    };
+    defaultText = lib.literalExpression ''
       {
-        assertion =
-          cursor == null
-          || cursor.name != null && cursor.package != null && cursor.size != null;
-        message = ''
-          stylix: `stylix.cursor` is only partially defined. Set either none or
-          all of the `stylix.cursor` options.
-        '';
+        enable =
+          lib.versionOlder (config.system.stateVersion or config.home.stateVersion) "25.05"
+          && builtins.any (x: x != null) (builtins.attrValues config.stylix.cursor);
+        name = null;
+        package = null;
+        size = null;
       }
-    ];
+    '';
+  };
+  config = {
+    assertions =
+      let
+        inherit (config.stylix) cursor;
+      in
+      [
+        {
+          assertion =
+            (cursor == null && cursor.enable)
+            || cursor.name != null && cursor.package != null && cursor.size != null;
+          message = ''
+            stylix: `stylix.cursor` is only partially defined. Set either none or
+            all of the `stylix.cursor` options.
+          '';
+        }
+      ];
+    warnings =
+      lib.optional (config.stylix.cursor == null)
+        "stylix: setting `stylix.cursor` to null is deprecated, instead set `stylix.cursor.enable` to `false`.";
+  };
 }


### PR DESCRIPTION
as mentioned in https://github.com/nix-community/stylix/pull/1597#issuecomment-3053700908
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [ ] Tested [locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Tested in [testbed](https://nix-community.github.io/stylix/testbeds.html)
- [x] Commit message follows [commit convention](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Fits [style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Respects license of any existing code used

## Notify maintainers

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->
