### PR TITLE
wayfire: mixup between wayfire and wf-shell settings

### DIFF
--- a/modules/wayfire/hm.nix
+++ b/modules/wayfire/hm.nix
@@ -31,12 +31,15 @@ mkTarget {
         '';
       in
       {
-        wayland.windowManager.wayfire.wf-shell.settings = {
-          background.image = lib.mkIf cfg.useWallpaper (toString wayfireBackground);
+        wayland.windowManager.wayfire.settings = {
           cube = {
             cubemap_image = lib.mkIf cfg.useWallpaper (toString wayfireBackground);
             skydome_texture = lib.mkIf cfg.useWallpaper (toString wayfireBackground);
           };
+        };
+
+        wayland.windowManager.wayfire.wf-shell.settings = {
+          background.image = lib.mkIf cfg.useWallpaper (toString wayfireBackground);
           background.fill_mode =
             if imageScalingMode == "stretch" then
               "stretch"
@@ -44,7 +47,6 @@ mkTarget {
               "preserve_aspect"
             else
               "fill_and_crop";
-
         };
       }
     )


### PR DESCRIPTION
It appears that while migrating to `mkTarget` some of the options to wayfire itself have become mixed up into the wf-shell ones.

~While at it, I've implemented #1658, because I feel like that would have been a merge conflict.~

~Superceeds/Closes~ Might conflict with #1658
## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [x] Tested [locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Tested in [testbed](https://nix-community.github.io/stylix/testbeds.html)
- [x] Commit message follows [commit convention](https://nix-community.github.io/stylix/commit_convention.html)
- [x] Fits [style guide](https://nix-community.github.io/stylix/styling.html)
- [x] Respects license of any existing code used

## Notify maintainers

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->
