### PR TITLE
stylix: use lib.warn instead of builtins.warn

### DIFF
--- a/flake/deprecation/default.nix
+++ b/flake/deprecation/default.nix
@@ -18,7 +18,10 @@
 
   # Drop this alias after 26.05
   flake = lib.mkIf (!lib.oldestSupportedReleaseIsAtLeast 2605) {
-    homeManagerModules = builtins.warn "stylix: flake output `homeManagerModules` has been renamed to `homeModules` and will be removed after 26.05." self.homeModules;
+    homeManagerModules =
+      lib.warnIf true
+        "stylix: flake output `homeManagerModules` has been renamed to `homeModules` and will be removed after 26.05."
+        self.homeModules;
   };
 
   perSystem.stylix.aliases = [

--- a/flake/deprecation/default.nix
+++ b/flake/deprecation/default.nix
@@ -18,10 +18,7 @@
 
   # Drop this alias after 26.05
   flake = lib.mkIf (!lib.oldestSupportedReleaseIsAtLeast 2605) {
-    homeManagerModules =
-      lib.warn
-        "stylix: flake output `homeManagerModules` has been renamed to `homeModules` and will be removed after 26.05."
-        self.homeModules;
+    homeManagerModules = lib.warn "stylix: flake output `homeManagerModules` has been renamed to `homeModules` and will be removed after 26.05." self.homeModules;
   };
 
   perSystem.stylix.aliases = [

--- a/flake/deprecation/default.nix
+++ b/flake/deprecation/default.nix
@@ -19,7 +19,7 @@
   # Drop this alias after 26.05
   flake = lib.mkIf (!lib.oldestSupportedReleaseIsAtLeast 2605) {
     homeManagerModules =
-      lib.warnIf true
+      lib.warn
         "stylix: flake output `homeManagerModules` has been renamed to `homeModules` and will be removed after 26.05."
         self.homeModules;
   };

--- a/modules/i3/hm.nix
+++ b/modules/i3/hm.nix
@@ -82,7 +82,7 @@ in
       })
 
       {
-        lib.stylix.i3.bar = builtins.warn "stylix: `config.lib.stylix.i3.bar` has been renamed to `config.stylix.targets.i3.exportedBarConfig` and will be removed after 26.11." config.stylix.targets.i3.exportedBarConfig;
+        lib.stylix.i3.bar = lib.warnIf "stylix: `config.lib.stylix.i3.bar` has been renamed to `config.stylix.targets.i3.exportedBarConfig` and will be removed after 26.11." config.stylix.targets.i3.exportedBarConfig;
 
         stylix.targets.i3.exportedBarConfig = {
           inherit fonts;

--- a/modules/i3/hm.nix
+++ b/modules/i3/hm.nix
@@ -82,10 +82,7 @@ in
       })
 
       {
-        lib.stylix.i3.bar =
-          lib.warn
-            "stylix: `config.lib.stylix.i3.bar` has been renamed to `config.stylix.targets.i3.exportedBarConfig` and will be removed after 26.11."
-            config.stylix.targets.i3.exportedBarConfig;
+        lib.stylix.i3.bar = lib.warn "stylix: `config.lib.stylix.i3.bar` has been renamed to `config.stylix.targets.i3.exportedBarConfig` and will be removed after 26.11." config.stylix.targets.i3.exportedBarConfig;
 
         stylix.targets.i3.exportedBarConfig = {
           inherit fonts;

--- a/modules/i3/hm.nix
+++ b/modules/i3/hm.nix
@@ -83,7 +83,7 @@ in
 
       {
         lib.stylix.i3.bar =
-          lib.warnIf true
+          lib.warn
             "stylix: `config.lib.stylix.i3.bar` has been renamed to `config.stylix.targets.i3.exportedBarConfig` and will be removed after 26.11."
             config.stylix.targets.i3.exportedBarConfig;
 

--- a/modules/i3/hm.nix
+++ b/modules/i3/hm.nix
@@ -82,7 +82,10 @@ in
       })
 
       {
-        lib.stylix.i3.bar = lib.warnIf "stylix: `config.lib.stylix.i3.bar` has been renamed to `config.stylix.targets.i3.exportedBarConfig` and will be removed after 26.11." config.stylix.targets.i3.exportedBarConfig;
+        lib.stylix.i3.bar =
+          lib.warnIf true
+            "stylix: `config.lib.stylix.i3.bar` has been renamed to `config.stylix.targets.i3.exportedBarConfig` and will be removed after 26.11."
+            config.stylix.targets.i3.exportedBarConfig;
 
         stylix.targets.i3.exportedBarConfig = {
           inherit fonts;

--- a/modules/sway/hm.nix
+++ b/modules/sway/hm.nix
@@ -87,10 +87,7 @@ in
       })
 
       {
-        lib.stylix.sway.bar =
-          lib.warn
-            "stylix: `config.lib.stylix.sway.bar` has been renamed to `config.stylix.targets.sway.exportedBarConfig` and will be removed after 26.11."
-            config.stylix.targets.sway.exportedBarConfig;
+        lib.stylix.sway.bar = lib.warn "stylix: `config.lib.stylix.sway.bar` has been renamed to `config.stylix.targets.sway.exportedBarConfig` and will be removed after 26.11." config.stylix.targets.sway.exportedBarConfig;
 
         stylix.targets.sway.exportedBarConfig = {
           inherit fonts;

--- a/modules/sway/hm.nix
+++ b/modules/sway/hm.nix
@@ -87,7 +87,10 @@ in
       })
 
       {
-        lib.stylix.sway.bar = builtins.warn "stylix: `config.lib.stylix.sway.bar` has been renamed to `config.stylix.targets.sway.exportedBarConfig` and will be removed after 26.11." config.stylix.targets.sway.exportedBarConfig;
+        lib.stylix.sway.bar =
+          lib.warnIf true
+            "stylix: `config.lib.stylix.sway.bar` has been renamed to `config.stylix.targets.sway.exportedBarConfig` and will be removed after 26.11."
+            config.stylix.targets.sway.exportedBarConfig;
 
         stylix.targets.sway.exportedBarConfig = {
           inherit fonts;

--- a/modules/sway/hm.nix
+++ b/modules/sway/hm.nix
@@ -88,7 +88,7 @@ in
 
       {
         lib.stylix.sway.bar =
-          lib.warnIf true
+          lib.warn
             "stylix: `config.lib.stylix.sway.bar` has been renamed to `config.stylix.targets.sway.exportedBarConfig` and will be removed after 26.11."
             config.stylix.targets.sway.exportedBarConfig;
 


### PR DESCRIPTION
Closes #1669

`lib.warn` can be used across nix and lix, allowing stylix to maintain a larger userbase. 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [x] Tested [locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Tested in [testbed](https://nix-community.github.io/stylix/testbeds.html)
- [x] Commit message follows [commit convention](https://nix-community.github.io/stylix/commit_convention.html)
- [x] Fits [style guide](https://nix-community.github.io/stylix/styling.html)
- [x] Respects license of any existing code used

## Notify maintainers

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->
