### PR TITLE
gtksourceview: don't overlay all of gnome2

### DIFF
--- a/modules/gtksourceview/overlay.nix
+++ b/modules/gtksourceview/overlay.nix
@@ -27,9 +27,9 @@ in
         && config.stylix.targets.gtksourceview.enable
       )
       {
-        gnome2.gtksourceview = prev.gnome2.gtksourceview.overrideAttrs (
-          attrsOverride "2.0"
-        );
+        gnome2 = prev.gnome2 // {
+          gtksourceview = prev.gnome2.gtksourceview.overrideAttrs (attrsOverride "2.0");
+        };
         gtksourceview = prev.gtksourceview.overrideAttrs (attrsOverride "3.0");
         gtksourceview4 = prev.gtksourceview4.overrideAttrs (attrsOverride "4");
         gtksourceview5 = prev.gtksourceview5.overrideAttrs (attrsOverride "5");


### PR DESCRIPTION
The overlay would reduce the gnome2 attribute set to contain just
gtksourceview. This preserves the old entries of gnome2 and only
overrides gtksourceview.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

The problem was introduced in #958

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [x] Tested [locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [x] Tested in [testbed](https://nix-community.github.io/stylix/testbeds.html)
- [x] Commit message follows [commit convention](https://nix-community.github.io/stylix/commit_convention.html)
- [x] Fits [style guide](https://nix-community.github.io/stylix/styling.html)
- [x] Respects license of any existing code used

## Notify maintainers

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->
@brckd 