### PR TITLE
stylix: add missing trailing period in mkEnableTargetWith's description

### DIFF
--- a/stylix/target.nix
+++ b/stylix/target.nix
@@ -91,7 +91,7 @@
           };
         in
         self.mkEnableIf {
-          description = "Whether to enable theming for ${name}";
+          description = "Whether to enable theming for ${name}.";
           default = cfg.autoEnable && autoEnable;
           defaultText =
             if args ? autoEnableExpr then


### PR DESCRIPTION
```
Fixes: 0449dae6d4b3 ("stylix: allow specifying `autoEnableExpr` in `mkEnableTargetWith`")
```

## Things done

- [ ] Tested [locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [X] Tested in [testbed](https://nix-community.github.io/stylix/testbeds.html)
- [X] Commit message follows [commit convention](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Fits [style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Respects license of any existing code used

## Notify maintainers
