### PR TITLE
stylix: don't check lambda pattern names with deadnix

### DIFF
--- a/flake/dev/pre-commit.nix
+++ b/flake/dev/pre-commit.nix
@@ -14,7 +14,7 @@
           # keep-sorted start block=yes
           deadnix = {
             enable = true;
-            settings.noUnderscore = true;
+            settings.noLambdaPatternNames = true;
           };
           editorconfig-checker.enable = true;
           hlint.enable = true;

--- a/modules/waybar/hm.nix
+++ b/modules/waybar/hm.nix
@@ -55,7 +55,7 @@ mkTarget {
       }
     )
     (
-      { opacity, _colors }:
+      { opacity, colors }:
       {
         stylix.targets.waybar.background = "alpha(@base00, ${builtins.toString opacity.desktop})";
       }

--- a/stylix/mk-target.nix
+++ b/stylix/mk-target.nix
@@ -125,11 +125,6 @@
       )
       ```
 
-      Arguments prefixed with an underscore (`_`) resolve to their non-prefixed
-      counterparts. For example, the `_colors` argument resolves to `colors`.
-      Underscored arguments are considered unused and should never be accessed.
-      Their sole purpose is satisfying `deadnix` in complex configurations.
-
     `generalConfig` (Attribute set or function or path)
     : This argument mirrors the `configElements` argument but intentionally
       lacks automatic safeguarding and should only be used for complex
@@ -205,20 +200,17 @@ let
         fn:
         lib.genAttrs (functionArgNames fn) (
           arg:
-          let
-            trimmedArg = lib.removePrefix "_" arg;
-          in
-          if trimmedArg == "cfg" then
+          if arg == "cfg" then
             cfg
-          else if trimmedArg == "colors" then
+          else if arg == "colors" then
             config.lib.stylix.colors
           else
-            config.stylix.${trimmedArg}
+            config.stylix.${arg}
               or (throw "stylix: mkTarget expected one of `cfg`, `colors`, ${
                 lib.concatMapStringsSep ", " (name: "`${name}`") (
                   builtins.attrNames config.stylix
                 )
-              }, but got: ${trimmedArg}")
+              }, but got: ${arg}")
         );
 
       # Call the configuration function with its required Stylix arguments.


### PR DESCRIPTION
originally proposed in https://github.com/nix-community/stylix/pull/1340#discussion_r2198135569

cc @trueNAHO @Flameopathic @danth @MattSturgeon 

reverts #1473
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [ ] Tested [locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Tested in [testbed](https://nix-community.github.io/stylix/testbeds.html)
- [x] Commit message follows [commit convention](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Fits [style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Respects license of any existing code used

## Notify maintainers

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->
