### PR TITLE
stylix: conditionally load external modules in testbeds

### DIFF
--- a/stylix/testbed/default.nix
+++ b/stylix/testbed/default.nix
@@ -3,6 +3,7 @@
   inputs,
   lib,
   modules ? import ./autoload.nix { inherit pkgs lib; },
+  testbedFieldSeparator ? ":",
 }:
 
 let
@@ -21,15 +22,24 @@ let
             inputs.self.nixosModules.stylix
             inputs.home-manager.nixosModules.home-manager
             testbed
-
-            # modules for external targets
-            inputs.nvf.nixosModules.default
-            inputs.nixvim.nixosModules.nixvim
-            inputs.spicetify-nix.nixosModules.spicetify
           ]
           ++ map (name: import ./graphical-environments/${name}.nix) (
             import ./available-graphical-environments.nix { inherit lib; }
-          );
+          )
+          ++
+            lib.mapAttrsToList
+              (
+                target:
+                lib.optionalAttrs (
+                  lib.hasPrefix "testbed${testbedFieldSeparator}${target}" name
+                )
+              )
+              {
+                inherit (inputs.nixvim.nixosModules) nixvim;
+                inherit (inputs.spicetify-nix.nixosModules) spicetify;
+
+                nvf = inputs.nvf.nixosModules.default;
+              };
       };
     in
     pkgs.writeShellApplication {


### PR DESCRIPTION
```
Conditionally load external modules in testbeds to preserve testbed
integrity by preventing unrelated code from running and potentially
invalidating its meaning.

Any performance benefit is merely a side effect of this more targeted
module loading.
```

Here is a friendly reminder to include the original commit message in the merged commit:

> remember to include the original commit message (or a reworded version) in the final squash commit message when appropriate. For example, this seems to have been missed in this PR and https://github.com/nix-community/stylix/pull/1659.
>
> -- https://github.com/nix-community/stylix/pull/1673#issuecomment-3070372774

## Things done

- [ ] Tested [locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [X] Tested in [testbed](https://nix-community.github.io/stylix/testbeds.html)
  - The following testbeds evaluate:

    ```console
    nix build .#testbed:{alacritty,nixvim,nvf,spicetify}:dark
    ```

- [X] Commit message follows [commit convention](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Fits [style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Respects license of any existing code used

## Notify maintainers

@Flameopathic @awwpotato
