### PR TITLE
zellij: Updated module to reflect new theme config

### DIFF
--- a/modules/zellij/hm.nix
+++ b/modules/zellij/hm.nix
@@ -1,27 +1,130 @@
-{ mkTarget, ... }:
+{mkTarget, ...}:
 mkTarget {
   name = "zellij";
   humanName = "zellij";
 
-  configElements =
-    { colors }:
-    {
-      programs.zellij.themes.stylix = {
-        themes = with colors.withHashtag; {
-          default = {
-            bg = base03;
-            fg = base05;
-            red = base01;
-            green = base0B;
-            blue = base0D;
-            yellow = base0A;
-            magenta = base0E;
-            orange = base09;
-            cyan = base0C;
-            black = base00;
-            white = base07;
+  configElements = {colors}: {
+    programs.zellij.themes.stylix = {
+      themes = with colors.withHashtag; {
+        default = {
+          text_unselected = {
+            base = base05;
+            background = base01;
+            emphasis_0 = base09;
+            emphasis_1 = base0C;
+            emphasis_2 = base0B;
+            emphasis_3 = base0F;
+          };
+          text_selected = {
+            base = base05;
+            background = base04;
+            emphasis_0 = base09;
+            emphasis_1 = base0C;
+            emphasis_2 = base0B;
+            emphasis_3 = base0F;
+          };
+          ribbon_selected = {
+            base = base01;
+            background = base0E;
+            emphasis_0 = base08;
+            emphasis_1 = base09;
+            emphasis_2 = base0F;
+            emphasis_3 = base0D;
+          };
+          ribbon_unselected = {
+            base = base01;
+            background = base05;
+            emphasis_0 = base08;
+            emphasis_1 = base05;
+            emphasis_2 = base0D;
+            emphasis_3 = base0F;
+          };
+          table_title = {
+            base = base0E;
+            background = base00;
+            emphasis_0 = base09;
+            emphasis_1 = base0C;
+            emphasis_2 = base0B;
+            emphasis_3 = base0F;
+          };
+          table_cell_selected = {
+            base = base05;
+            background = base04;
+            emphasis_0 = base09;
+            emphasis_1 = base0C;
+            emphasis_2 = base0B;
+            emphasis_3 = base0F;
+          };
+          table_cell_unselected = {
+            base = base05;
+            background = base01;
+            emphasis_0 = base09;
+            emphasis_1 = base0C;
+            emphasis_2 = base0B;
+            emphasis_3 = base0F;
+          };
+          list_selected = {
+            base = base05;
+            background = base04;
+            emphasis_0 = base09;
+            emphasis_1 = base0C;
+            emphasis_2 = base0B;
+            emphasis_3 = base0F;
+          };
+          list_unselected = {
+            base = base05;
+            background = base01;
+            emphasis_0 = base09;
+            emphasis_1 = base0C;
+            emphasis_2 = base0B;
+            emphasis_3 = base0F;
+          };
+          frame_selected = {
+            base = base0E;
+            background = base00;
+            emphasis_0 = base09;
+            emphasis_1 = base0C;
+            emphasis_2 = base0F;
+            emphasis_3 = base00;
+          };
+          frame_highlight = {
+            base = base08;
+            background = base00;
+            emphasis_0 = base0F;
+            emphasis_1 = base09;
+            emphasis_2 = base09;
+            emphasis_3 = base09;
+          };
+          exit_code_success = {
+            base = base0B;
+            background = base00;
+            emphasis_0 = base0C;
+            emphasis_1 = base01;
+            emphasis_2 = base0F;
+            emphasis_3 = base0D;
+          };
+          exit_code_error = {
+            base = base08;
+            background = base00;
+            emphasis_0 = base0A;
+            emphasis_1 = base00;
+            emphasis_2 = base00;
+            emphasis_3 = base00;
+          };
+          multiplayer_user_colors = {
+            player_1 = base0F;
+            player_2 = base0D;
+            player_3 = base00;
+            player_4 = base0A;
+            player_5 = base0C;
+            player_6 = base00;
+            player_7 = base08;
+            player_8 = base00;
+            player_9 = base00;
+            player_10 = base00;
           };
         };
       };
     };
+  };
 }

--- a/modules/zellij/hm.nix
+++ b/modules/zellij/hm.nix
@@ -1,130 +1,132 @@
-{mkTarget, ...}:
+{ mkTarget, ... }:
 mkTarget {
   name = "zellij";
   humanName = "zellij";
 
-  configElements = {colors}: {
-    programs.zellij.themes.stylix = {
-      themes = with colors.withHashtag; {
-        default = {
-          text_unselected = {
-            base = base05;
-            background = base01;
-            emphasis_0 = base09;
-            emphasis_1 = base0C;
-            emphasis_2 = base0B;
-            emphasis_3 = base0F;
-          };
-          text_selected = {
-            base = base05;
-            background = base04;
-            emphasis_0 = base09;
-            emphasis_1 = base0C;
-            emphasis_2 = base0B;
-            emphasis_3 = base0F;
-          };
-          ribbon_selected = {
-            base = base01;
-            background = base0E;
-            emphasis_0 = base08;
-            emphasis_1 = base09;
-            emphasis_2 = base0F;
-            emphasis_3 = base0D;
-          };
-          ribbon_unselected = {
-            base = base01;
-            background = base05;
-            emphasis_0 = base08;
-            emphasis_1 = base05;
-            emphasis_2 = base0D;
-            emphasis_3 = base0F;
-          };
-          table_title = {
-            base = base0E;
-            background = base00;
-            emphasis_0 = base09;
-            emphasis_1 = base0C;
-            emphasis_2 = base0B;
-            emphasis_3 = base0F;
-          };
-          table_cell_selected = {
-            base = base05;
-            background = base04;
-            emphasis_0 = base09;
-            emphasis_1 = base0C;
-            emphasis_2 = base0B;
-            emphasis_3 = base0F;
-          };
-          table_cell_unselected = {
-            base = base05;
-            background = base01;
-            emphasis_0 = base09;
-            emphasis_1 = base0C;
-            emphasis_2 = base0B;
-            emphasis_3 = base0F;
-          };
-          list_selected = {
-            base = base05;
-            background = base04;
-            emphasis_0 = base09;
-            emphasis_1 = base0C;
-            emphasis_2 = base0B;
-            emphasis_3 = base0F;
-          };
-          list_unselected = {
-            base = base05;
-            background = base01;
-            emphasis_0 = base09;
-            emphasis_1 = base0C;
-            emphasis_2 = base0B;
-            emphasis_3 = base0F;
-          };
-          frame_selected = {
-            base = base0E;
-            background = base00;
-            emphasis_0 = base09;
-            emphasis_1 = base0C;
-            emphasis_2 = base0F;
-            emphasis_3 = base00;
-          };
-          frame_highlight = {
-            base = base08;
-            background = base00;
-            emphasis_0 = base0F;
-            emphasis_1 = base09;
-            emphasis_2 = base09;
-            emphasis_3 = base09;
-          };
-          exit_code_success = {
-            base = base0B;
-            background = base00;
-            emphasis_0 = base0C;
-            emphasis_1 = base01;
-            emphasis_2 = base0F;
-            emphasis_3 = base0D;
-          };
-          exit_code_error = {
-            base = base08;
-            background = base00;
-            emphasis_0 = base0A;
-            emphasis_1 = base00;
-            emphasis_2 = base00;
-            emphasis_3 = base00;
-          };
-          multiplayer_user_colors = {
-            player_1 = base0F;
-            player_2 = base0D;
-            player_3 = base00;
-            player_4 = base0A;
-            player_5 = base0C;
-            player_6 = base00;
-            player_7 = base08;
-            player_8 = base00;
-            player_9 = base00;
-            player_10 = base00;
+  configElements =
+    { colors }:
+    {
+      programs.zellij.themes.stylix = {
+        themes = with colors.withHashtag; {
+          default = {
+            text_unselected = {
+              base = base05;
+              background = base01;
+              emphasis_0 = base09;
+              emphasis_1 = base0C;
+              emphasis_2 = base0B;
+              emphasis_3 = base0F;
+            };
+            text_selected = {
+              base = base05;
+              background = base04;
+              emphasis_0 = base09;
+              emphasis_1 = base0C;
+              emphasis_2 = base0B;
+              emphasis_3 = base0F;
+            };
+            ribbon_selected = {
+              base = base01;
+              background = base0E;
+              emphasis_0 = base08;
+              emphasis_1 = base09;
+              emphasis_2 = base0F;
+              emphasis_3 = base0D;
+            };
+            ribbon_unselected = {
+              base = base01;
+              background = base05;
+              emphasis_0 = base08;
+              emphasis_1 = base05;
+              emphasis_2 = base0D;
+              emphasis_3 = base0F;
+            };
+            table_title = {
+              base = base0E;
+              background = base00;
+              emphasis_0 = base09;
+              emphasis_1 = base0C;
+              emphasis_2 = base0B;
+              emphasis_3 = base0F;
+            };
+            table_cell_selected = {
+              base = base05;
+              background = base04;
+              emphasis_0 = base09;
+              emphasis_1 = base0C;
+              emphasis_2 = base0B;
+              emphasis_3 = base0F;
+            };
+            table_cell_unselected = {
+              base = base05;
+              background = base01;
+              emphasis_0 = base09;
+              emphasis_1 = base0C;
+              emphasis_2 = base0B;
+              emphasis_3 = base0F;
+            };
+            list_selected = {
+              base = base05;
+              background = base04;
+              emphasis_0 = base09;
+              emphasis_1 = base0C;
+              emphasis_2 = base0B;
+              emphasis_3 = base0F;
+            };
+            list_unselected = {
+              base = base05;
+              background = base01;
+              emphasis_0 = base09;
+              emphasis_1 = base0C;
+              emphasis_2 = base0B;
+              emphasis_3 = base0F;
+            };
+            frame_selected = {
+              base = base0E;
+              background = base00;
+              emphasis_0 = base09;
+              emphasis_1 = base0C;
+              emphasis_2 = base0F;
+              emphasis_3 = base00;
+            };
+            frame_highlight = {
+              base = base08;
+              background = base00;
+              emphasis_0 = base0F;
+              emphasis_1 = base09;
+              emphasis_2 = base09;
+              emphasis_3 = base09;
+            };
+            exit_code_success = {
+              base = base0B;
+              background = base00;
+              emphasis_0 = base0C;
+              emphasis_1 = base01;
+              emphasis_2 = base0F;
+              emphasis_3 = base0D;
+            };
+            exit_code_error = {
+              base = base08;
+              background = base00;
+              emphasis_0 = base0A;
+              emphasis_1 = base00;
+              emphasis_2 = base00;
+              emphasis_3 = base00;
+            };
+            multiplayer_user_colors = {
+              player_1 = base0F;
+              player_2 = base0D;
+              player_3 = base00;
+              player_4 = base0A;
+              player_5 = base0C;
+              player_6 = base00;
+              player_7 = base08;
+              player_8 = base00;
+              player_9 = base00;
+              player_10 = base00;
+            };
           };
         };
       };
     };
-  };
 }


### PR DESCRIPTION
The current Stylix module for zellij seems to be outdated, so I updated it to match the current options. The theming is based on Zellij's built-in catppuccin-mocha theme, which I then replaced with Stylix's base color variables.


## Things done

Copied Zellij's built-in `catppuccin-mocha` theme, transcribed the KDL to Nix, then replaced all colors with their respective Stylix variable counterparts. This should keep styling mostly consistent across different themes, which I tested with `ayu-dark` and `grayscale-dark` myself.

- [x] Tested [locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Tested in [testbed](https://nix-community.github.io/stylix/testbeds.html)
- [x] Commit message follows [commit convention](https://nix-community.github.io/stylix/commit_convention.html)
- [x] Fits [style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Respects license of any existing code used

## Notify maintainers
Listed Nix module maintainers: @trueNAHO 
