### PR TITLE
treewide: leverage lib.singleton in imports

### DIFF
--- a/modules/fontconfig/hm.nix
+++ b/modules/fontconfig/hm.nix
@@ -1,6 +1,6 @@
 { lib, mkTarget, ... }:
 {
-  imports = [
-    (lib.modules.importApply ./fontconfig.nix { inherit mkTarget; })
-  ];
+  imports = lib.singleton (
+    lib.modules.importApply ./fontconfig.nix { inherit mkTarget; }
+  );
 }

--- a/modules/fontconfig/nixos.nix
+++ b/modules/fontconfig/nixos.nix
@@ -1,6 +1,6 @@
 { lib, mkTarget, ... }:
 {
-  imports = [
-    (lib.modules.importApply ./fontconfig.nix { inherit mkTarget; })
-  ];
+  imports = lib.singleton (
+    lib.modules.importApply ./fontconfig.nix { inherit mkTarget; }
+  );
 }

--- a/modules/grub/nixos.nix
+++ b/modules/grub/nixos.nix
@@ -41,8 +41,8 @@ let
       "crop";
 in
 {
-  imports = [
-    (lib.mkRenamedOptionModuleWith {
+  imports = lib.singleton (
+    lib.mkRenamedOptionModuleWith {
       from = [
         "stylix"
         "targets"
@@ -56,8 +56,9 @@ in
         "grub"
         "useWallpaper"
       ];
-    })
-  ];
+    }
+  );
+
   options.stylix.targets.grub = {
     enable = mkEnableTarget "GRUB" true;
     useWallpaper = mkEnableWallpaper "GRUB" false;

--- a/modules/plymouth/nixos.nix
+++ b/modules/plymouth/nixos.nix
@@ -29,11 +29,10 @@ mkTarget {
     };
   };
 
-  imports = [
-    (lib.mkRemovedOptionModule [ "stylix" "targets" "plymouth" "blackBackground" ]
+  imports = lib.singleton (
+    lib.mkRemovedOptionModule [ "stylix" "targets" "plymouth" "blackBackground" ]
       "This was removed since it goes against the chosen color scheme. If you want this, consider disabling the target and configuring Plymouth by hand."
-    )
-  ];
+  );
 
   configElements =
     { cfg, colors }:

--- a/modules/swaylock/hm.nix
+++ b/modules/swaylock/hm.nix
@@ -81,8 +81,8 @@ mkTarget {
       }
     )
   ];
-  imports = [
-    (lib.mkRenamedOptionModuleWith {
+  imports = lib.singleton (
+    lib.mkRenamedOptionModuleWith {
       from = [
         "stylix"
         "targets"
@@ -96,6 +96,6 @@ mkTarget {
         "swaylock"
         "useWallpaper"
       ];
-    })
-  ];
+    }
+  );
 }

--- a/stylix/autoload.nix
+++ b/stylix/autoload.nix
@@ -42,8 +42,8 @@ builtins.concatLists (
         {
           key = file;
           _file = file;
-          imports = [
-            (module (
+          imports = lib.singleton (
+            module (
               args
               // extraArgs
               // {
@@ -53,8 +53,8 @@ builtins.concatLists (
                   lib.stylix.colors = throw "stylix: unguarded `config.lib.stylix.colors` accessed while using mkTarget";
                 };
               }
-            ))
-          ];
+            )
+          );
         }
       else
         file


### PR DESCRIPTION
```
Leverage lib.singleton in imports to reduce visual clutter, following
commits 039e938b29ce ("doc: promote lib.singleton in testbeds (#1148)")
and 6d9867604efd ("treewide: reduce indentation level with lib.singleton
(#754)").
```

## Things done

- [ ] Tested [locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Tested in [testbed](https://nix-community.github.io/stylix/testbeds.html)
- [X] Commit message follows [commit convention](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Fits [style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Respects license of any existing code used

## Notify maintainers
