### PR TITLE
stylix/testbed: respect xserver rename for gnome

### DIFF
--- a/stylix/testbed/graphical-environments/gnome.nix
+++ b/stylix/testbed/graphical-environments/gnome.nix
@@ -8,8 +8,7 @@
   config =
     lib.mkIf (config.stylix.testbed.ui.graphicalEnvironment or null == "gnome")
       {
-        services.xserver = {
-          enable = true;
+        services = {
           displayManager.gdm.enable = true;
           desktopManager.gnome.enable = true;
         };


### PR DESCRIPTION
```
Fixes: 8c854fe383 ("stylix: allow choosing testbed desktop (#1222)")
```
was originally done in https://github.com/nix-community/stylix/pull/1429
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [ ] Tested [locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Tested in [testbed](https://nix-community.github.io/stylix/testbeds.html)
- [x] Commit message follows [commit convention](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Fits [style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Respects license of any existing code used

## Notify maintainers

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->
