### PR TITLE
qt: guard nixosConfig instead of isLinux and osConfig

### DIFF
--- a/modules/qt/hm.nix
+++ b/modules/qt/hm.nix
@@ -2,21 +2,20 @@
   pkgs,
   config,
   lib,
-  osConfig ? null,
+  nixosConfig ? null,
   ...
 }:
 {
   options.stylix.targets.qt = {
-    # TODO: Remove the osConfig workaround [1] ("qt: puts NixOS systemd on
-    # non-NixOS distro path") once [2] ("bug: setting qt.style.name = kvantum
-    # makes host systemd unusable") is resolved.
+    # TODO: Replace `nixosConfig != null` with
+    # `pkgs.stdenv.hostPlatform.isLinux` once [1] ("bug: setting qt.style.name
+    # = kvantum makes host systemd unusable") is resolved.
     #
-    # [1]: https://github.com/nix-community/stylix/issues/933
-    # [2]: https://github.com/nix-community/home-manager/issues/6565
+    # [1]: https://github.com/nix-community/home-manager/issues/6565
     enable = config.lib.stylix.mkEnableTargetWith {
       name = "QT";
-      autoEnable = pkgs.stdenv.hostPlatform.isLinux && osConfig != null;
-      autoEnableExpr = "pkgs.stdenv.hostPlatform.isLinux && osConfig != null";
+      autoEnable = nixosConfig != null;
+      autoEnableExpr = "nixosConfig != null";
     };
 
     platform = lib.mkOption {


### PR DESCRIPTION
nixosConfig is declared [here](https://github.com/nix-community/home-manager/blob/d0300c8808e41da81d6edfc202f3d3833c157daf/modules/misc/submodule-support.nix#L41) and set [here](https://github.com/nix-community/home-manager/blob/d0300c8808e41da81d6edfc202f3d3833c157daf/nixos/default.nix#L26) for reference.

cc @Mikilio @trueNAHO @Flameopathic 
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [ ] Tested [locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Tested in [testbed](https://nix-community.github.io/stylix/testbeds.html)
- [x] Commit message follows [commit convention](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Fits [style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Respects license of any existing code used

## Notify maintainers

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->
