### PR TITLE
ci: fix generated all-maintainers path

### DIFF
--- a/.github/workflows/update-flake.yml
+++ b/.github/workflows/update-flake.yml
@@ -65,7 +65,7 @@ jobs:
           # in sync
           nix run .#all-maintainers
 
-          git add stylix/generated/all-maintainers.nix
+          git add generated/all-maintainers.nix
           git commit --message "stylix: update all-maintainers list" ||
             echo "generated/all-maintainers.nix has no changes"
 


### PR DESCRIPTION
```
Fixes: f826d3214b ("stylix: add generated all-maintainers file (#1654)")
```
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [ ] Tested [locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Tested in [testbed](https://nix-community.github.io/stylix/testbeds.html)
- [x] Commit message follows [commit convention](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Fits [style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Respects license of any existing code used

## Notify maintainers

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->
