### PR TITLE
zen-browser: fix select tags not being readable

### DIFF
--- a/modules/zen-browser/userChrome.css.mustache
+++ b/modules/zen-browser/userChrome.css.mustache
@@ -124,3 +124,9 @@ hbox#titlebar {
 #zen-appcontent-navbar-container {
   background-color: #{{base00-hex}} !important;
 }
+
+#contentAreaContextMenu menu,
+menuitem,
+menupopup {
+  color: #{{base05-hex}} !important;
+}


### PR DESCRIPTION
Improves readability of `<select>` elements by fixing a background/text color contrast issue that made options unreadable.

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->

- [ ] Tested [locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [x] Tested in [testbed](https://nix-community.github.io/stylix/testbeds.html)
- [x] Commit message follows [commit convention](https://nix-community.github.io/stylix/commit_convention.html)
- [x] Fits [style guide](https://nix-community.github.io/stylix/styling.html)
- [x] Respects license of any existing code used
