### PR TITLE
treewide: properly quote `stylix.image` when used as a shell argument

### DIFF
--- a/modules/grub/nixos.nix
+++ b/modules/grub/nixos.nix
@@ -134,7 +134,11 @@ in
                 cfg.useWallpaper
               # Make sure the background image is .png by asking to convert it
               then
-                "${lib.getExe' pkgs.imagemagick "convert"} ${config.stylix.image} png32:$out/background.png"
+                ''
+                  ${lib.getExe' pkgs.imagemagick "convert"} \
+                    ${lib.escapeShellArg config.stylix.image} \
+                    "png32:$out/background.png"
+                ''
               else
                 "cp ${pixel "base00"} $out/background.png"
             }

--- a/stylix/palette.nix
+++ b/stylix/palette.nix
@@ -83,7 +83,7 @@ in
         default = pkgs.runCommand "palette.json" { } ''
           ${lib.getExe cfg.paletteGenerator} \
             "${cfg.polarity}" \
-            ${cfg.image} \
+            ${lib.escapeShellArg cfg.image} \
             "$out"
         '';
       };

--- a/stylix/testbed/images.nix
+++ b/stylix/testbed/images.nix
@@ -9,7 +9,9 @@
   };
 
   light = fetchurl {
-    name = "three-bicycles.jpg";
+    # Includes a space to make sure the path is properly quoted via
+    # `lib.escapeShellArg` when used as a shell argument.
+    name = "three bicycles.jpg";
     url = "https://unsplash.com/photos/hwLAI5lRhdM/download?ixid=M3wxMjA3fDB8MXxhbGx8fHx8fHx8fHwxNzE2MzYxNDcwfA&force=true";
     hash = "sha256-S0MumuBGJulUekoGI2oZfUa/50Jw0ZzkqDDu1nRkFUA=";
   };

--- a/stylix/testbed/images.nix
+++ b/stylix/testbed/images.nix
@@ -1,5 +1,6 @@
 {
   fetchurl,
+  runCommandLocal,
 }:
 {
   dark = fetchurl {
@@ -8,11 +9,22 @@
     hash = "sha256-Dm/0nKiTFOzNtSiARnVg7zM0J1o+EuIdUQ3OAuasM58=";
   };
 
-  light = fetchurl {
-    # Includes a space to make sure the path is properly quoted via
-    # `lib.escapeShellArg` when used as a shell argument.
-    name = "three bicycles.jpg";
-    url = "https://unsplash.com/photos/hwLAI5lRhdM/download?ixid=M3wxMjA3fDB8MXxhbGx8fHx8fHx8fHwxNzE2MzYxNDcwfA&force=true";
-    hash = "sha256-S0MumuBGJulUekoGI2oZfUa/50Jw0ZzkqDDu1nRkFUA=";
-  };
+  light =
+    let
+      image = fetchurl {
+        name = "three-bicycles.jpg";
+        url = "https://unsplash.com/photos/hwLAI5lRhdM/download?ixid=M3wxMjA3fDB8MXxhbGx8fHx8fHx8fHwxNzE2MzYxNDcwfA&force=true";
+        hash = "sha256-S0MumuBGJulUekoGI2oZfUa/50Jw0ZzkqDDu1nRkFUA=";
+      };
+
+      # Create a path containing a space to test that `stylix.image` is
+      # correctly quoted when used as a shell argument. We have to use a
+      # directory as the parent because derivation names themselves cannot
+      # contain spaces.
+      directory = runCommandLocal "three-bicycles" { } ''
+        mkdir "$out"
+        ln --symbolic ${image} "$out/three bicycles.jpg"
+      '';
+    in
+    "${directory}/three bicycles.jpg";
 }

--- a/stylix/testbed/images.nix
+++ b/stylix/testbed/images.nix
@@ -23,7 +23,7 @@
       # contain spaces.
       directory = runCommandLocal "three-bicycles" { } ''
         mkdir "$out"
-        ln --symbolic ${image} "$out/three bicycles.jpg"
+        cp ${image} "$out/three bicycles.jpg"
       '';
     in
     "${directory}/three bicycles.jpg";

--- a/stylix/testbed/themes/schemeless.nix
+++ b/stylix/testbed/themes/schemeless.nix
@@ -5,8 +5,8 @@ in
 {
   stylix = {
     enable = true;
-    image = images.dark;
-    polarity = "dark";
+    image = images.light;
+    polarity = "light";
     cursor = {
       name = "Vanilla-DMZ";
       package = pkgs.vanilla-dmz;


### PR DESCRIPTION
Fixes #1720

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [ ] Tested [locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Tested in [testbed](https://nix-community.github.io/stylix/testbeds.html)
- [x] Commit message follows [commit convention](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Fits [style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Respects license of any existing code used

## Notify maintainers

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->

@awwpotato @trueNAHO 