### PR TITLE
stylix: apply stylix.iconTheme option rename to all sub-options

### DIFF
--- a/stylix/icons.nix
+++ b/stylix/icons.nix
@@ -5,11 +5,52 @@
       from = [
         "stylix"
         "iconTheme"
+        "dark"
       ];
       sinceRelease = 2511;
       to = [
         "stylix"
         "icons"
+        "dark"
+      ];
+    })
+    (lib.mkRenamedOptionModuleWith {
+      from = [
+        "stylix"
+        "iconTheme"
+        "enable"
+      ];
+      sinceRelease = 2511;
+      to = [
+        "stylix"
+        "icons"
+        "enable"
+      ];
+    })
+    (lib.mkRenamedOptionModuleWith {
+      from = [
+        "stylix"
+        "iconTheme"
+        "light"
+      ];
+      sinceRelease = 2511;
+      to = [
+        "stylix"
+        "icons"
+        "light"
+      ];
+    })
+    (lib.mkRenamedOptionModuleWith {
+      from = [
+        "stylix"
+        "iconTheme"
+        "package"
+      ];
+      sinceRelease = 2511;
+      to = [
+        "stylix"
+        "icons"
+        "package"
       ];
     })
   ];


### PR DESCRIPTION
```
Fixes: 1021b7d7322c ("stylix: simplify API by renaming stylix.iconTheme option to stylix.icons")
```

CC: @awwpotato, @khaneliman

## Things done

- [x] Tested [locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Tested in [testbed](https://nix-community.github.io/stylix/testbeds.html)
- [X] Commit message follows [commit convention](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Fits [style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Respects license of any existing code used

## Notify maintainers
