### PR TITLE
[release-25.05] ci: add more top-level labels to provide better overview

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -3,6 +3,10 @@
 # remove the label
 ---
 # keep-sorted start newline_separated=yes
+"topic: ci":
+  - changed-files:
+      - any-glob-to-any-file: ".github/**"
+
 "topic: darwin":
   - changed-files:
       - any-glob-to-any-file:
@@ -25,11 +29,22 @@
           - "stylix/droid/**"
           - "modules/*/droid.nix"
 
+"topic: flake":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "flake.lock"
+          - "flake.nix"
+          - "flake/**"
+
 "topic: home-manager":
   - changed-files:
       - any-glob-to-any-file:
           - "stylix/hm/**"
           - "modules/*/hm.nix"
+
+"topic: modules":
+  - changed-files:
+      - any-glob-to-any-file: "modules/**"
 
 "topic: nixos":
   - changed-files:
@@ -42,6 +57,10 @@
       - any-glob-to-any-file:
           - "stylix/overlays.nix"
           - "modules/*/overlay.nix"
+
+"topic: stylix":
+  - changed-files:
+      - any-glob-to-any-file: "stylix/**"
 
 "topic: testbed":
   - changed-files:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -2,6 +2,13 @@
 # This version uses `sync-labels: false`, meaning that a non-match will NOT
 # remove the label
 ---
+# keep-sorted start newline_separated=yes
+"topic: darwin":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "stylix/darwin/**"
+          - "modules/*/darwin.nix"
+
 "topic: dependencies":
   - changed-files:
       - any-glob-to-any-file: "flake.lock"
@@ -12,11 +19,11 @@
           - "doc/**"
           - "README.md"
 
-"topic: nixos":
+"topic: droid":
   - changed-files:
       - any-glob-to-any-file:
-          - "stylix/nixos/*"
-          - "modules/*/nixos.nix"
+          - "stylix/droid/**"
+          - "modules/*/droid.nix"
 
 "topic: home-manager":
   - changed-files:
@@ -24,17 +31,11 @@
           - "stylix/hm/**"
           - "modules/*/hm.nix"
 
-"topic: darwin":
+"topic: nixos":
   - changed-files:
       - any-glob-to-any-file:
-          - "stylix/darwin/**"
-          - "modules/*/darwin.nix"
-
-"topic: droid":
-  - changed-files:
-      - any-glob-to-any-file:
-          - "stylix/droid/**"
-          - "modules/*/droid.nix"
+          - "stylix/nixos/*"
+          - "modules/*/nixos.nix"
 
 "topic: overlay":
   - changed-files:
@@ -47,3 +48,4 @@
       - any-glob-to-any-file:
           - "stylix/testbed/**"
           - "modules/*/testbeds/**"
+# keep-sorted end


### PR DESCRIPTION
manual backport of https://github.com/nix-community/stylix/pull/1755
`ci: consistently format singleton list` isn't being backported because it doesn't apply to the stable branch.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [ ] Tested [locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Tested in [testbed](https://nix-community.github.io/stylix/testbeds.html)
- [x] Commit message follows [commit convention](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Fits [style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Respects license of any existing code used

## Notify maintainers

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->
