### PR TITLE
stylix/testbed: add sendNotifications option

### DIFF
--- a/modules/mako/testbeds/mako.nix
+++ b/modules/mako/testbeds/mako.nix
@@ -1,19 +1,8 @@
-{ lib, pkgs, ... }:
+{ lib, ... }:
 {
   stylix.testbed.ui = {
-    # We use Hyprland because Gnome has its own notification daemon
     graphicalEnvironment = "hyprland";
-    command.text =
-      # Run as a single command to ensure the same order between executions
-      lib.concatMapStringsSep " && "
-        (
-          urgency: "${lib.getExe pkgs.libnotify} --urgency ${urgency} ${urgency} urgency"
-        )
-        [
-          "low"
-          "normal"
-          "critical"
-        ];
+    sendNotifications = true;
   };
 
   home-manager.sharedModules = lib.singleton {

--- a/stylix/testbed/modules/application.nix
+++ b/stylix/testbed/modules/application.nix
@@ -84,6 +84,7 @@ in
             );
             default = null;
           };
+          sendNotifications = lib.mkEnableOption "sending notifications of each urgency with libnotify";
         };
       }
     );
@@ -108,6 +109,27 @@ in
               pkgs.writeShellScript "startup" config.stylix.testbed.ui.command.text
             );
             terminal = config.stylix.testbed.ui.command.useTerminal;
+          };
+        }
+      )
+      ++ lib.optional config.stylix.testbed.ui.sendNotifications (
+        pkgs.makeAutostartItem {
+          name = "stylix-notification-check";
+          package = pkgs.makeDesktopItem {
+            name = "stylix-notification-check";
+            desktopName = "stylix-notification-check";
+            terminal = false;
+            exec = pkgs.writeShellScript "stylix-send-notifications" (
+              lib.concatMapStringsSep " && "
+                (
+                  urgency: "${lib.getExe pkgs.libnotify} --urgency ${urgency} ${urgency} urgency"
+                )
+                [
+                  "low"
+                  "normal"
+                  "critical"
+                ]
+            );
           };
         }
       )


### PR DESCRIPTION
we have a few notification daemons which I'd like to add testbeds for and repeating this a bunch seems silly.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

Please also link any relevant issues or pull requests e.g. `Closes: #<ISSUE-ID>`
-->

## Things done

<!--
Please check what applies. Note that these are not hard requirements but merely
serve as information for reviewers.
-->
- [ ] Tested [locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [x] Tested in [testbed](https://nix-community.github.io/stylix/testbeds.html)
- [x] Commit message follows [commit convention](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Fits [style guide](https://nix-community.github.io/stylix/styling.html)
- [x] Respects license of any existing code used

## Notify maintainers

<!---
If you are editing an existing target, consider pinging relevant
module maintainers from `modules/<module>/meta.nix`.
-->
@make-42 @trueNAHO 