### PR TITLE
ci: backport: fix "has: port to stable" condition

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -42,6 +42,7 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
 
       - uses: korthout/backport-action@v3.2.1
+        id: backport
         with:
           github_token: ${{ steps.app-token.outputs.token }}
           label_pattern: "^backport: ([^ ]+)$"


### PR DESCRIPTION
the "has: port to stable" label hasn't been applying because it checks to make sure the pr has been created:
https://github.com/nix-community/stylix/blob/57d036d92283fddc6ae080459e72e767144a1cda/.github/workflows/backport.yml#L52
but I forgot to add the id to the pr creation step so it's been looking for a step that doesn't exits.
<!-- Describe your PR above, following Stylix commit conventions. -->

## Submission Checklist

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [x] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [x] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [x] Each commit in this PR is suitable for backport to the current stable branch

## Notify Maintainers

<!---
Consider pinging relevant module maintainers declared in
`modules/<MODULE>/meta.nix`.
-->
@trueNAHO 