### PR TITLE
ci: use nix-community cachix

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -49,7 +49,7 @@ jobs:
 
       - uses: cachix/cachix-action@v16
         with:
-          name: stylix
+          name: nix-community
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
         continue-on-error: true
 

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -32,7 +32,7 @@ jobs:
 
       - uses: cachix/cachix-action@v16
         with:
-          name: stylix
+          name: nix-community
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
         continue-on-error: true
 


### PR DESCRIPTION
already discussed with danth on matrix, allows for a bigger cache and reduces the number of things that need to be managed by stylix maintainers.

> [!NOTE]
> `CACHIX_AUTH_TOKEN` must be deleted from [action secrets settings](https://github.com/nix-community/stylix/settings/secrets/actions) when this pr is merged so we will inherit nix-community's auth token.
<!-- Describe your PR above, following Stylix commit conventions. -->

## Submission Checklist

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [x] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [x] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [x] Each commit in this PR is suitable for backport to the current stable branch

## Notify Maintainers

<!---
Consider pinging relevant module maintainers declared in
`modules/<MODULE>/meta.nix`.
-->
