### PR TITLE
doc/src/modules: fix admonition formatting

### DIFF
--- a/doc/src/modules.md
+++ b/doc/src/modules.md
@@ -248,9 +248,9 @@ modules.
 > [!NOTE]
 > If this is the first time you're adding yourself as a maintainer in Stylix,
 > the `/generated/all-maintainers.nix` file will need to be updated by running
-+> `nix run .#all-maintainers`
-+> ([pre-commit](./development_environment.md#pre-commit) will also automatically
-+> regenerate it).
+> `nix run .#all-maintainers`
+> ([pre-commit](./development_environment.md#pre-commit) will also automatically
+> regenerate it).
 
 ## Documentation
 


### PR DESCRIPTION
```
Fixes: f826d3214b8a ("stylix: add generated all-maintainers file (#1654)")
```



<!-- Describe your PR above, following Stylix commit conventions. -->

---

## Submission Checklist

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [X] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [X] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [X] Each commit in this PR is suitable for backport to the current stable branch

## Notify Maintainers

<!---
Consider pinging relevant module maintainers declared in
`modules/<MODULE>/meta.nix`.
-->
