### PR TITLE
anki/meta: fix name capitalization

### DIFF
--- a/modules/anki/meta.nix
+++ b/modules/anki/meta.nix
@@ -1,6 +1,6 @@
 { lib, ... }:
 {
-  name = "anki";
+  name = "Anki";
   homepage = "https://apps.ankiweb.net";
   maintainers = [ lib.maintainers.lomenzel ];
 }


### PR DESCRIPTION
```
Fixes: 1b5e1c5642cf ("anki: init (#1801)")
```

Capitalization based on:

https://github.com/nix-community/stylix/blob/1b5e1c5642cf96e07daf14ae4c5ddd23d7ed5623/modules/anki/hm.nix#L10

<!-- Describe your PR above, following Stylix commit conventions. -->

---

## Submission Checklist

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [X] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [X] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [X] Each commit in this PR is suitable for backport to the current stable branch

## Notify Maintainers

@lomenzel

<!---
Consider pinging relevant module maintainers declared in
`modules/<MODULE>/meta.nix`.
-->
