### PR TITLE
stylix/droid: fix import droid modules

### DIFF
--- a/stylix/droid/default.nix
+++ b/stylix/droid/default.nix
@@ -4,10 +4,10 @@ let
 in
 {
   imports = [
-    ../fonts.nix
+    ./fonts.nix
+    ./palette.nix
     ../home-manager-integration.nix
     ../opacity.nix
-    ../palette.nix
     ../pixel.nix
     ../target.nix
     ../overlays.nix

--- a/stylix/droid/default.nix
+++ b/stylix/droid/default.nix
@@ -6,8 +6,10 @@ in
   imports = [
     ./fonts.nix
     ./palette.nix
+    ../fonts.nix
     ../home-manager-integration.nix
     ../opacity.nix
+    ../palette.nix
     ../pixel.nix
     ../target.nix
     ../overlays.nix

--- a/stylix/droid/fonts.nix
+++ b/stylix/droid/fonts.nix
@@ -23,7 +23,5 @@ let
   terminalFont = mkFont config.stylix.fonts.monospace;
 in
 {
-  imports = [ ../fonts.nix ];
-
   config.terminal.font = lib.mkIf config.stylix.enable terminalFont;
 }

--- a/stylix/droid/palette.nix
+++ b/stylix/droid/palette.nix
@@ -1,8 +1,5 @@
-args:
 { config, lib, ... }:
 {
-  imports = [ (lib.modules.importApply ../palette.nix args) ];
-
   config = lib.mkIf config.stylix.enable {
     environment.etc = config.stylix.generated.fileTree;
   };


### PR DESCRIPTION
<!-- Describe your PR above, following Stylix commit conventions. -->
Fixed the lack of import of specific settings files for the `nix-on-droid` module,
and removed a duplicate and broken import of the universal styles configuration.
This made it possible to export color palette files and set fonts for this system.

---

### Submission Checklist
<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->

- [X] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [X] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [X] Each commit in this PR is suitable for backport to the current stable branch

<!---
### Notify Maintainers

Consider pinging relevant module maintainers declared in
`modules/<MODULE>/meta.nix`.
-->
