### PR TITLE
lazygit: add wildcard author color

### DIFF
--- a/modules/lazygit/hm.nix
+++ b/modules/lazygit/hm.nix
@@ -6,22 +6,27 @@ mkTarget {
   configElements =
     { colors }:
     {
-      programs.lazygit.settings.gui.theme = with colors.withHashtag; {
-        activeBorderColor = [
-          base07
-          "bold"
-        ];
-        inactiveBorderColor = [ base04 ];
-        searchingActiveBorderColor = [
-          base02
-          "bold"
-        ];
-        optionsTextColor = [ base06 ];
-        selectedLineBgColor = [ base03 ];
-        cherryPickedCommitBgColor = [ base02 ];
-        cherryPickedCommitFgColor = [ base03 ];
-        unstagedChangesColor = [ base08 ];
-        defaultFgColor = [ base05 ];
+      programs.lazygit.settings.gui = with colors.withHashtag; {
+        theme = {
+          activeBorderColor = [
+            base07
+            "bold"
+          ];
+          inactiveBorderColor = [ base04 ];
+          searchingActiveBorderColor = [
+            base02
+            "bold"
+          ];
+          optionsTextColor = [ base06 ];
+          selectedLineBgColor = [ base03 ];
+          cherryPickedCommitBgColor = [ base02 ];
+          cherryPickedCommitFgColor = [ base03 ];
+          unstagedChangesColor = [ base08 ];
+          defaultFgColor = [ base05 ];
+        };
+        authorColors = {
+          "*" = base0D;
+        };
       };
     };
 }


### PR DESCRIPTION
If this isn't set, an "ugly" default dark blue color will be used and looks with certain themes out of place. The `base0D` will be used as the new default color for users not specified in the list.



<!-- Describe your PR above, following Stylix commit conventions. -->

---

## Submission Checklist

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [ ] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [ ] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [x] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [x] Each commit in this PR is suitable for backport to the current stable branch
