### PR TITLE
fnott: switch progress color option to non deprecated option

### DIFF
--- a/modules/fnott/hm.nix
+++ b/modules/fnott/hm.nix
@@ -38,7 +38,7 @@ mkTarget {
               title-color = fg base05;
               summary-color = fg base05;
               body-color = fg base05;
-              progress-bar-color = fg base02;
+              progress-color = fg base02;
               background = bg base00;
             };
 


### PR DESCRIPTION
switch progress color option to non deprecated option
see https://codeberg.org/dnkl/fnott/commit/f78cf9887eef99ff6398d11dc41b0f14ca750b4f

---

## Submission Checklist

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->

- [x] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [x] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [x] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [x] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [ ] Each commit in this PR is suitable for backport to the current stable branch
