### PR TITLE
gnome: get extension UUID from package metadata

### DIFF
--- a/modules/gnome/hm.nix
+++ b/modules/gnome/hm.nix
@@ -70,6 +70,8 @@ mkTarget {
     (
       { inputs, colors }:
       let
+        extension = pkgs.gnomeExtensions.user-themes;
+
         activator = pkgs.writeShellApplication {
           name = "stylix-activate-gnome";
           text = ''
@@ -85,7 +87,7 @@ mkTarget {
             }
 
             if gnome_extensions="$(get_exe gnome-extensions)"; then
-              extension='user-theme@gnome-shell-extensions.gcampax.github.com'
+              extension=${lib.escapeShellArg extension.passthru.extensionUuid}
 
               case "$1" in
                 reload)
@@ -101,7 +103,7 @@ mkTarget {
         };
       in
       {
-        home.packages = [ pkgs.gnomeExtensions.user-themes ];
+        home.packages = [ extension ];
 
         dconf.settings = {
           "org/gnome/shell/extensions/user-theme".name = "Stylix";


### PR DESCRIPTION
Just a small change to get the UUID from a single source of truth, rather than hardcoding it. The generated script is exactly the same as before.

<!-- Describe your PR above, following Stylix commit conventions. -->

---

## Submission Checklist

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [x] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [x] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [x] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [x] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [x] Each commit in this PR is suitable for backport to the current stable branch
