### PR TITLE
ci: request-reviewers: do not request PR author

### DIFF
--- a/.github/workflows/request-reviewers.yml
+++ b/.github/workflows/request-reviewers.yml
@@ -39,6 +39,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MAX_REVIEWERS: 5
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           printf \
@@ -46,6 +47,7 @@ jobs:
             "$(
               gh pr diff --name-only "$PR_NUMBER" |
                 jq \
+                  --arg pr_author "$PR_AUTHOR" \
                   --argjson max_reviewers "$MAX_REVIEWERS" \
                   --raw-input \
                   --raw-output \
@@ -67,6 +69,7 @@ jobs:
                       )[]
                     ] |
                     unique |
+                    map(select(. != $pr_author)) |
                     if length <= $max_reviewers then
                       . | join(",")
                     else


### PR DESCRIPTION
```
Closes: https://github.com/nix-community/stylix/issues/1867
```

I suggest optimistically closing https://github.com/nix-community/stylix/issues/1867 with this PR. We can re-open it, if the issue is still not resolved.

This PR_AUTHOR filtering was accidentally removed in the following patch:

> ```patch
> From c81f587ce7a796b4bbfb7792ae42b12e1446fb29 Mon Sep 17 00:00:00 2001
> From: NAHO <90870942+trueNAHO@users.noreply.github.com>
> Date: Thu, 24 Jul 2025 20:24:55 +0200
> Subject: [PATCH 3/5] ci: ping-maintainers: overhaul implementation
>
> ---
>  .github/workflows/ping-maintainers.yml | 79 +++++++++++++-------------
>  1 file changed, 39 insertions(+), 40 deletions(-)
>
> diff --git a/.github/workflows/ping-maintainers.yml b/.github/workflows/ping-maintainers.yml
> index f986010..fab3d6c 100644
> --- a/.github/workflows/ping-maintainers.yml
> +++ b/.github/workflows/ping-maintainers.yml
> [...]
>          env:
> -          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
> [...]
> -              # Do not request the original author or already requested
> -              # reviewers.
> -              if [[
> -                "$gh_id" == "$PR_AUTHOR" || \
> -                jq "index(\"$gh_id\") != null" <<<"$existing_reviewers"
> -              ]]; then
> -                  continue
> -              fi
> ```
>
> -- https://github.com/nix-community/stylix/pull/1053#pullrequestreview-3052768383

<!-- Describe your PR above, following Stylix commit conventions. -->

---

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [X] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [X] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [X] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
    - Non-exhaustively tested the `jq` command with dummy input.
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [X] Each commit in this PR is suitable for backport to the current stable branch
