### PR TITLE
feat: add theme modality support for light/dark themes

### DIFF
--- a/doc/src/SUMMARY.md
+++ b/doc/src/SUMMARY.md
@@ -4,6 +4,7 @@
 
 - [Installation](installation.md)
 - [Configuration](configuration.md)
+- [Theme Modality](theme-modality.md)
 - [Tips and tricks](tricks.md)
 
 # Contributing

--- a/doc/src/theme-modality.md
+++ b/doc/src/theme-modality.md
@@ -1,0 +1,106 @@
+# Theme Modality Support
+
+Stylix now supports configuring separate light and dark themes that can be used by applications that support automatic theme switching based on system preferences.
+
+## Basic Configuration
+
+You can configure both light and dark themes:
+
+```nix
+{
+  stylix = {
+    enable = true;
+
+    theme = {
+      light = {
+        base16Scheme = "${pkgs.base16-schemes}/share/themes/solarized-light.yaml";
+        wallpaper = ./wallpaper-light.jpg;
+        icons = {
+          package = pkgs.papirus-icon-theme;
+          name = "Papirus-Light";
+        };
+      };
+
+      dark = {
+        base16Scheme = "${pkgs.base16-schemes}/share/themes/solarized-dark.yaml";
+        wallpaper = ./wallpaper-dark.jpg;
+        icons = {
+          package = pkgs.papirus-icon-theme;
+          name = "Papirus-Dark";
+        };
+      };
+    };
+
+    # For applications that don't support theme switching
+    defaultTheme = "dark"; # or "light"
+  };
+}
+```
+
+## Application Support
+
+Applications are categorized into two groups:
+
+1. **Theme-aware applications** (like Ghostty, GTK, Qt): These will receive both light and dark theme configurations and can switch between them automatically.
+
+2. **Single-theme applications**: These will use the theme specified by `defaultTheme` (or fall back to `polarity` if not set).
+
+## Backward Compatibility
+
+The new theme modality system is fully backward compatible:
+
+- If you don't configure `theme.light` or `theme.dark`, the existing `base16Scheme`, `image`, and other options continue to work as before
+- The `polarity` option is still respected when `defaultTheme` is not set
+- You can configure just one theme modality (e.g., only `theme.dark`) and it will be used for both light and dark modes
+
+## Migration Guide
+
+To migrate from the old configuration to theme modalities:
+
+### Before:
+```nix
+{
+  stylix = {
+    base16Scheme = "${pkgs.base16-schemes}/share/themes/solarized-dark.yaml";
+    image = ./wallpaper.jpg;
+    polarity = "dark";
+  };
+}
+```
+
+### After:
+```nix
+{
+  stylix = {
+    theme.dark = {
+      base16Scheme = "${pkgs.base16-schemes}/share/themes/solarized-dark.yaml";
+      wallpaper = ./wallpaper.jpg;
+    };
+    defaultTheme = "dark";
+  };
+}
+```
+
+Or keep both configurations during transition:
+```nix
+{
+  stylix = {
+    # Legacy configuration (used as fallback)
+    base16Scheme = "${pkgs.base16-schemes}/share/themes/solarized-dark.yaml";
+    image = ./wallpaper.jpg;
+
+    # New theme modality (takes precedence)
+    theme = {
+      light = {
+        base16Scheme = "${pkgs.base16-schemes}/share/themes/solarized-light.yaml";
+        wallpaper = ./wallpaper-light.jpg;
+      };
+      dark = {
+        base16Scheme = "${pkgs.base16-schemes}/share/themes/solarized-dark.yaml";
+        wallpaper = ./wallpaper-dark.jpg;
+      };
+    };
+    defaultTheme = "dark";
+  };
+}
+```

--- a/modules/ghostty/hm.nix
+++ b/modules/ghostty/hm.nix
@@ -1,7 +1,11 @@
 # Documentation is available at:
 # - https://ghostty.org/docs/config/reference
 # - `man 5 ghostty`
-{ mkTarget, ... }:
+{
+  mkTarget,
+  lib,
+  ...
+}:
 mkTarget {
   name = "ghostty";
   humanName = "Ghostty";
@@ -28,37 +32,81 @@ mkTarget {
       }
     )
     (
-      { colors }:
       {
-        programs.ghostty = {
-          settings.theme = "stylix";
-          themes.stylix = {
-            background = colors.base00;
-            foreground = colors.base05;
-            cursor-color = colors.base05;
-            selection-background = colors.base02;
-            selection-foreground = colors.base05;
+        colors,
+        base16,
+        override ? { },
+        _computedThemes ? { },
+      }:
+      let
+        # Helper to create a theme from a color scheme
+        makeTheme = scheme: {
+          background = scheme.base00;
+          foreground = scheme.base05;
+          cursor-color = scheme.base05;
+          selection-background = scheme.base02;
+          selection-foreground = scheme.base05;
 
-            palette = with colors.withHashtag; [
-              "0=${base00}"
-              "1=${base08}"
-              "2=${base0B}"
-              "3=${base0A}"
-              "4=${base0D}"
-              "5=${base0E}"
-              "6=${base0C}"
-              "7=${base05}"
-              "8=${base03}"
-              "9=${base08}"
-              "10=${base0B}"
-              "11=${base0A}"
-              "12=${base0D}"
-              "13=${base0E}"
-              "14=${base0C}"
-              "15=${base07}"
-            ];
-          };
+          palette = with scheme.withHashtag; [
+            "0=${base00}"
+            "1=${base08}"
+            "2=${base0B}"
+            "3=${base0A}"
+            "4=${base0D}"
+            "5=${base0E}"
+            "6=${base0C}"
+            "7=${base05}"
+            "8=${base03}"
+            "9=${base08}"
+            "10=${base0B}"
+            "11=${base0A}"
+            "12=${base0D}"
+            "13=${base0E}"
+            "14=${base0C}"
+            "15=${base07}"
+          ];
         };
+
+        # Check if we have theme modalities configured
+        hasThemeConfig = _computedThemes.hasThemeConfig or false;
+
+        # Get both light and dark color schemes if available
+        lightColors =
+          if hasThemeConfig && _computedThemes.light.base16Scheme != null then
+            (base16.mkSchemeAttrs _computedThemes.light.base16Scheme).override override
+          else
+            colors;
+
+        darkColors =
+          if hasThemeConfig && _computedThemes.dark.base16Scheme != null then
+            (base16.mkSchemeAttrs _computedThemes.dark.base16Scheme).override override
+          else
+            colors;
+
+        # Check if we actually have different light and dark themes
+        hasDifferentThemes =
+          hasThemeConfig
+          && _computedThemes.light.base16Scheme != null
+          && _computedThemes.dark.base16Scheme != null;
+      in
+      {
+        programs.ghostty = lib.mkMerge [
+          # If we have different light and dark themes, configure both
+          # Ghostty supports auto-switching, so we always provide both themes
+          (lib.mkIf hasDifferentThemes {
+            settings.theme = "dark:stylix-dark,light:stylix-light";
+            themes = {
+              stylix-dark = makeTheme darkColors;
+              stylix-light = makeTheme lightColors;
+            };
+          })
+
+          # Single theme configuration (legacy or when only one modality is configured)
+          (lib.mkIf (!hasDifferentThemes) {
+            settings.theme = "stylix";
+            themes.stylix = makeTheme colors;
+          })
+        ];
       }
     )
   ];

--- a/stylix/darwin/default.nix
+++ b/stylix/darwin/default.nix
@@ -16,6 +16,7 @@ in
     ../palette.nix
     ../pixel.nix
     ../target.nix
+    ../theme.nix
     ../release.nix
     ../overlays.nix
     ../ordering.nix

--- a/stylix/droid/default.nix
+++ b/stylix/droid/default.nix
@@ -13,6 +13,7 @@ in
     ../palette.nix
     ../pixel.nix
     ../target.nix
+    ../theme.nix
     ../overlays.nix
     ../ordering.nix
   ]

--- a/stylix/hm/default.nix
+++ b/stylix/hm/default.nix
@@ -19,6 +19,7 @@ in
     ../palette.nix
     ../pixel.nix
     ../target.nix
+    ../theme.nix
     ../release.nix
     ../overlays.nix
     ../ordering.nix

--- a/stylix/nixos/default.nix
+++ b/stylix/nixos/default.nix
@@ -19,6 +19,7 @@ in
     ../icons.nix
     ../pixel.nix
     ../target.nix
+    ../theme.nix
     ../release.nix
     ../overlays.nix
     ../ordering.nix

--- a/stylix/theme.nix
+++ b/stylix/theme.nix
@@ -1,0 +1,208 @@
+{
+  lib,
+  config,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.stylix;
+
+  themeOptions = {
+    wallpaper = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      apply =
+        value: if value == null || lib.isDerivation value then value else "${value}";
+      description = ''
+        Wallpaper image for this theme modality.
+      '';
+    };
+
+    base16Scheme = lib.mkOption {
+      type =
+        with lib.types;
+        nullOr (oneOf [
+          path
+          lines
+          attrs
+        ]);
+      default = null;
+      description = ''
+        A scheme following the base16 standard for this theme modality.
+      '';
+    };
+
+    icons = {
+      package = lib.mkOption {
+        type = lib.types.nullOr lib.types.package;
+        default = null;
+        description = ''
+          Package providing the icon theme for this modality.
+        '';
+      };
+      name = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        description = ''
+          Icon theme name for this modality.
+        '';
+      };
+    };
+
+    cursor = lib.mkOption {
+      type = lib.types.nullOr (
+        lib.types.submodule {
+          options = {
+            name = lib.mkOption {
+              type = lib.types.str;
+              description = "The cursor name within the package.";
+            };
+            package = lib.mkOption {
+              type = lib.types.package;
+              description = "Package providing the cursor theme.";
+            };
+            size = lib.mkOption {
+              type = lib.types.int;
+              description = "The cursor size.";
+            };
+          };
+        }
+      );
+      default = null;
+      description = ''
+        Cursor configuration for this theme modality.
+      '';
+    };
+  };
+
+  # Helper to determine if theme modalities are configured
+  hasThemeConfig = cfg.theme.light != null || cfg.theme.dark != null;
+
+  # Get single theme for apps that don't support switching
+  # Prioritizes: defaultTheme > polarity
+  singleTheme =
+    let
+      preference =
+        if cfg.defaultTheme != null then cfg.defaultTheme else cfg.polarity;
+      # When only one theme is configured, use it regardless of preference
+      fallbackTheme =
+        if cfg.theme.dark != null then cfg.theme.dark else cfg.theme.light;
+    in
+    if preference == "light" then
+      if cfg.theme.light != null then cfg.theme.light else fallbackTheme
+    else if preference == "dark" then
+      if cfg.theme.dark != null then cfg.theme.dark else fallbackTheme
+    else
+      # "either" - no strong preference, default to dark if available
+      fallbackTheme;
+
+  # Computed theme configurations (for modules to access)
+  computedLightTheme =
+    if cfg.theme.light != null then cfg.theme.light else cfg.theme.dark;
+  computedDarkTheme =
+    if cfg.theme.dark != null then cfg.theme.dark else cfg.theme.light;
+in
+{
+  options.stylix = {
+    theme = {
+      light = lib.mkOption {
+        type = lib.types.nullOr (lib.types.submodule { options = themeOptions; });
+        default = null;
+        description = ''
+          Light theme configuration.
+
+          If only this is set (dark is null), these settings will be used for both modalities.
+        '';
+      };
+
+      dark = lib.mkOption {
+        type = lib.types.nullOr (lib.types.submodule { options = themeOptions; });
+        default = null;
+        description = ''
+          Dark theme configuration.
+
+          If only this is set (light is null), these settings will be used for both modalities.
+        '';
+      };
+    };
+
+    defaultTheme = lib.mkOption {
+      type = lib.types.nullOr (
+        lib.types.enum [
+          "light"
+          "dark"
+        ]
+      );
+      default = null;
+      description = ''
+        Which theme to use for applications that don't support automatic theme switching.
+
+        When set, this takes precedence over the polarity setting.
+        Use this instead of polarity when using theme modalities.
+
+        - "light": Use light theme for single-theme applications
+        - "dark": Use dark theme for single-theme applications
+        - null: Fall back to polarity setting
+
+        Note: Applications that support both themes (like GTK, Qt, Ghostty) will always
+        get both themes configured regardless of this setting.
+      '';
+    };
+
+    # Internal options to expose computed themes
+    _computedThemes = lib.mkOption {
+      type = lib.types.attrs;
+      internal = true;
+      readOnly = true;
+      default = {
+        inherit hasThemeConfig singleTheme;
+        light = computedLightTheme;
+        dark = computedDarkTheme;
+      };
+      description = ''
+        The computed theme configurations for both modalities.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    # When theme modalities are configured, map them to the legacy options
+    # For single-theme applications/settings, use singleTheme (defaultTheme > polarity)
+    stylix = lib.mkMerge [
+      # Wallpaper - single selection
+      (lib.mkIf (hasThemeConfig && singleTheme.wallpaper != null) {
+        image = lib.mkForce singleTheme.wallpaper;
+      })
+
+      # Base16 scheme - single selection
+      (lib.mkIf (hasThemeConfig && singleTheme.base16Scheme != null) {
+        base16Scheme = lib.mkForce singleTheme.base16Scheme;
+      })
+
+      # Icons - provide both light and dark when available
+      (lib.mkIf hasThemeConfig {
+        icons = {
+          package = lib.mkForce (
+            if computedLightTheme != null then
+              computedLightTheme.icons.package
+            else if computedDarkTheme != null then
+              computedDarkTheme.icons.package
+            else
+              null
+          );
+          light = lib.mkForce (
+            if computedLightTheme != null then computedLightTheme.icons.name else null
+          );
+          dark = lib.mkForce (
+            if computedDarkTheme != null then computedDarkTheme.icons.name else null
+          );
+        };
+      })
+
+      # Cursor - single selection (most cursor systems don't support dual themes)
+      (lib.mkIf (hasThemeConfig && singleTheme.cursor != null) {
+        cursor = lib.mkForce singleTheme.cursor;
+      })
+    ];
+  };
+}


### PR DESCRIPTION
I don't know if this is something the project is looking to adopt, but I forked and made this work for Ghostty for my own experiment and plan to add support for more modules.

Sharing for feedback and to hopefully upstream.

Related #447 

---

Add support for configuring separate light and dark themes that can be used by applications supporting automatic theme switching. This includes:

- New theme.light and theme.dark configuration options
- defaultTheme option to control fallback for single-theme apps
- Full backward compatibility with existing configurations
- Ghostty integration with automatic light/dark theme switching
- Documentation for theme modality configuration and migration

---

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [x] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [x] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [x] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [x] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [ ] Each commit in this PR is suitable for backport to the current stable branch
