### PR TITLE
modules: replace static builtins.hasAttrs instances with '?' operator

### DIFF
--- a/modules/discord/nixcord.nix
+++ b/modules/discord/nixcord.nix
@@ -32,7 +32,7 @@ mkTarget {
       lib.mkIf
         (cfg.themeBody != (import ./common/theme-header.nix) || cfg.extraCss != "")
         (
-          lib.optionalAttrs (builtins.hasAttr "nixcord" options.programs) (
+          lib.optionalAttrs (options.programs ? nixcord) (
             lib.mkMerge [
               (lib.mkIf nixcord.discord.enable (
                 lib.mkMerge [

--- a/modules/zen-browser/hm.nix
+++ b/modules/zen-browser/hm.nix
@@ -19,48 +19,46 @@ mkTarget {
     };
   };
 
-  configElements =
-    lib.optionals (builtins.hasAttr "zen-browser" options.programs)
-      [
-        (
-          { cfg }:
-          {
-            warnings =
-              lib.optional (config.programs.zen-browser.enable && cfg.profileNames == [ ])
-                ''stylix: zen-browser: `config.stylix.targets.zen-browser.profileNames` is not set. Declare profile names with 'config.stylix.targets.zen-browser.profileNames = [ "<PROFILE_NAME>" ];'.'';
-          }
-        )
-        (
-          {
-            cfg,
-            fonts,
-          }:
-          {
-            programs.zen-browser.profiles = lib.genAttrs cfg.profileNames (_: {
-              settings = {
-                "font.name.monospace.x-western" = fonts.monospace.name;
-                "font.name.sans-serif.x-western" = fonts.sansSerif.name;
-                "font.name.serif.x-western" = fonts.serif.name;
-              };
-            });
-          }
-        )
-        (
-          {
-            cfg,
-            colors,
-          }:
-          {
-            programs.zen-browser.profiles = lib.genAttrs cfg.profileNames (_: {
-              settings = {
-                "toolkit.legacyUserProfileCustomizations.stylesheets" = true;
-              };
+  configElements = lib.optionals (options.programs ? zen-browser) [
+    (
+      { cfg }:
+      {
+        warnings =
+          lib.optional (config.programs.zen-browser.enable && cfg.profileNames == [ ])
+            ''stylix: zen-browser: `config.stylix.targets.zen-browser.profileNames` is not set. Declare profile names with 'config.stylix.targets.zen-browser.profileNames = [ "<PROFILE_NAME>" ];'.'';
+      }
+    )
+    (
+      {
+        cfg,
+        fonts,
+      }:
+      {
+        programs.zen-browser.profiles = lib.genAttrs cfg.profileNames (_: {
+          settings = {
+            "font.name.monospace.x-western" = fonts.monospace.name;
+            "font.name.sans-serif.x-western" = fonts.sansSerif.name;
+            "font.name.serif.x-western" = fonts.serif.name;
+          };
+        });
+      }
+    )
+    (
+      {
+        cfg,
+        colors,
+      }:
+      {
+        programs.zen-browser.profiles = lib.genAttrs cfg.profileNames (_: {
+          settings = {
+            "toolkit.legacyUserProfileCustomizations.stylesheets" = true;
+          };
 
-              userChrome = import ./userChrome.nix { inherit colors; };
+          userChrome = import ./userChrome.nix { inherit colors; };
 
-              userContent = import ./userContent.nix { inherit colors; };
-            });
-          }
-        )
-      ];
+          userContent = import ./userContent.nix { inherit colors; };
+        });
+      }
+    )
+  ];
 }


### PR DESCRIPTION
```
Fixes: c32c82e460b9 ("zen-browser: init (#1694)")
Fixes: e594886eb095 ("nixcord: init (#767)")
```

For convenience, here is the `--ignore-all-space` diff:

```patch
commit 0c67dd9ee600b961256e34e091e0a09d7804f6e7
Author: NAHO <90870942+trueNAHO@users.noreply.github.com>
Date:   2025-09-27 18:56:28 +0200

    modules: replace static builtins.hasAttrs instances with '?' operator

    Fixes: c32c82e460b9 ("zen-browser: init (#1694)")
    Fixes: e594886eb095 ("nixcord: init (#767)")

diff --git a/modules/discord/nixcord.nix b/modules/discord/nixcord.nix
index b7409bce..3aeb621c 100644
--- a/modules/discord/nixcord.nix
+++ b/modules/discord/nixcord.nix
@@ -32,7 +32,7 @@ mkTarget {
       lib.mkIf
         (cfg.themeBody != (import ./common/theme-header.nix) || cfg.extraCss != "")
         (
-          lib.optionalAttrs (builtins.hasAttr "nixcord" options.programs) (
+          lib.optionalAttrs (options.programs ? nixcord) (
             lib.mkMerge [
               (lib.mkIf nixcord.discord.enable (
                 lib.mkMerge [
diff --git a/modules/zen-browser/hm.nix b/modules/zen-browser/hm.nix
index 9945e4f3..71c6f190 100644
--- a/modules/zen-browser/hm.nix
+++ b/modules/zen-browser/hm.nix
@@ -19,9 +19,7 @@ mkTarget {
     };
   };

-  configElements =
-    lib.optionals (builtins.hasAttr "zen-browser" options.programs)
-      [
+  configElements = lib.optionals (options.programs ? zen-browser) [
     (
       { cfg }:
       {
```

---

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [X] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [X] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [ ] Each commit in this PR is suitable for backport to the current stable branch
    - `/modules/zen-browser/hm.nix` has not been backported and bothering to backport the `/modules/discord/nixcord.nix` change might not be all that worth it.
