### PR TITLE
[release-25.05] treewide: remove optional builtins prefixes from prelude functions

### DIFF
--- a/doc/default.nix
+++ b/doc/default.nix
@@ -314,7 +314,7 @@ let
     lib.pipe platforms.${platform}.configuration.options [
 
       # Drop options that come from the module system
-      (lib.flip builtins.removeAttrs [ "_module" ])
+      (lib.flip removeAttrs [ "_module" ])
 
       # Get a list of all options, flattening sub-options recursively.
       # This also normalises things like `defaultText` and `visible="shallow"`.

--- a/flake/deprecation/per-system-option.nix
+++ b/flake/deprecation/per-system-option.nix
@@ -66,7 +66,7 @@
             ]) { inherit old new; };
             names = builtins.mapAttrs (_: lib.showAttrPath) paths // {
               until = lib.pipe until [
-                builtins.toString
+                toString
                 (builtins.match "([[:digit:]]{2})([[:digit:]]{2})")
                 (lib.concatStringsSep ".")
               ];

--- a/modules/bemenu/hm.nix
+++ b/modules/bemenu/hm.nix
@@ -31,7 +31,7 @@ mkTarget {
         programs.bemenu.settings = {
           # Font name
           fn = "${fonts.sansSerif.name} ${
-            lib.optionalString (cfg.fontSize != null) (builtins.toString cfg.fontSize)
+            lib.optionalString (cfg.fontSize != null) (toString cfg.fontSize)
           }";
         };
       }

--- a/modules/glance/testbeds/glance-hm.nix
+++ b/modules/glance/testbeds/glance-hm.nix
@@ -3,7 +3,7 @@ let
   host = "127.0.0.1";
 
   package = pkgs.wrapFirefox pkgs.firefox-unwrapped {
-    extraPolicies.OverrideFirstRunPage = "http://${host}:${builtins.toString port}";
+    extraPolicies.OverrideFirstRunPage = "http://${host}:${toString port}";
   };
 
   port = 1234;

--- a/modules/glance/testbeds/glance-nixos.nix
+++ b/modules/glance/testbeds/glance-nixos.nix
@@ -3,7 +3,7 @@ let
   host = "127.0.0.1";
 
   package = pkgs.wrapFirefox pkgs.firefox-unwrapped {
-    extraPolicies.OverrideFirstRunPage = "http://${host}:${builtins.toString port}";
+    extraPolicies.OverrideFirstRunPage = "http://${host}:${toString port}";
   };
 
   port = 1234;

--- a/modules/neovim/neovim.nix
+++ b/modules/neovim/neovim.nix
@@ -28,7 +28,7 @@
         programs.neovim =
           let
             cfg = config.stylix.targets.neovim;
-            transparencyCfg = builtins.toString (
+            transparencyCfg = toString (
               lib.optional cfg.transparentBackground.main ''
                 vim.cmd.highlight({ "Normal", "guibg=NONE", "ctermbg=NONE" })
                 vim.cmd.highlight({ "NonText", "guibg=NONE", "ctermbg=NONE" })

--- a/modules/rofi/hm.nix
+++ b/modules/rofi/hm.nix
@@ -24,7 +24,7 @@ mkTarget {
           in
           mkLiteral "rgba ( ${r}, ${g}, ${b}, ${opacity'} % )";
         mkRgb = mkRgba "100";
-        rofiOpacity = builtins.toString (builtins.ceil (opacity.popups * 100));
+        rofiOpacity = toString (builtins.ceil (opacity.popups * 100));
       in
       {
         programs.rofi.theme = {

--- a/modules/swaync/hm.nix
+++ b/modules/swaync/hm.nix
@@ -10,7 +10,7 @@ mkTarget {
         services.swaync.style = ''
           * {
               font-family: "${fonts.sansSerif.name}";
-              font-size: ${builtins.toString fonts.sizes.desktop}pt;
+              font-size: ${toString fonts.sizes.desktop}pt;
           }
         '';
       }

--- a/modules/waybar/hm.nix
+++ b/modules/waybar/hm.nix
@@ -57,7 +57,7 @@ mkTarget {
     (
       { opacity, colors }:
       {
-        stylix.targets.waybar.background = "alpha(@base00, ${builtins.toString opacity.desktop})";
+        stylix.targets.waybar.background = "alpha(@base00, ${toString opacity.desktop})";
       }
     )
     (
@@ -66,7 +66,7 @@ mkTarget {
         programs.waybar.style = ''
           * {
               font-family: "${fonts.${cfg.font}.name}";
-              font-size: ${builtins.toString fonts.sizes.desktop}pt;
+              font-size: ${toString fonts.sizes.desktop}pt;
           }
         '';
       }

--- a/modules/wezterm/hm.nix
+++ b/modules/wezterm/hm.nix
@@ -88,8 +88,8 @@
                     "${fonts.monospace.name}",
                     "${fonts.emoji.name}",
                 },
-                font_size = ${builtins.toString fonts.sizes.terminal},
-                window_background_opacity = ${builtins.toString config.stylix.opacity.terminal},
+                font_size = ${toString fonts.sizes.terminal},
+                window_background_opacity = ${toString config.stylix.opacity.terminal},
                 window_frame = {
                     active_titlebar_bg = "${base03}",
                     active_titlebar_fg = "${base05}",
@@ -134,7 +134,7 @@
                 },
                 command_palette_bg_color = "${base01}",
                 command_palette_fg_color = "${base05}",
-                command_palette_font_size = ${builtins.toString fonts.sizes.popups},
+                command_palette_font_size = ${toString fonts.sizes.popups},
             }
             for key, value in pairs(stylix_base_config) do
                 config[key] = value

--- a/modules/zathura/hm.nix
+++ b/modules/zathura/hm.nix
@@ -15,7 +15,7 @@ mkTarget {
             ''rgb(${getColorCh color "r"}, ${getColorCh color "g"}, ${getColorCh color "b"})'';
           rgba =
             color: alpha:
-            ''rgba(${getColorCh color "r"}, ${getColorCh color "g"}, ${getColorCh color "b"}, ${builtins.toString alpha})'';
+            ''rgba(${getColorCh color "r"}, ${getColorCh color "g"}, ${getColorCh color "b"}, ${toString alpha})'';
         in
         {
           # Taken from here:

--- a/stylix/autoload.nix
+++ b/stylix/autoload.nix
@@ -29,7 +29,7 @@ builtins.concatLists (
             name: ''while evaluating the module argument `${name}' in "${toString file}":'';
           extraArgs = lib.pipe module [
             builtins.functionArgs
-            (lib.flip builtins.removeAttrs [ "mkTarget" ])
+            (lib.flip removeAttrs [ "mkTarget" ])
             (builtins.mapAttrs (
               name: _:
               builtins.addErrorContext (context name) (

--- a/stylix/testbed/modules/common.nix
+++ b/stylix/testbed/modules/common.nix
@@ -3,7 +3,7 @@ let
   user = lib.importTOML ../user.toml;
 in
 {
-  users.users.${user.username} = builtins.removeAttrs user [ "username" ];
+  users.users.${user.username} = removeAttrs user [ "username" ];
 
   security.sudo.wheelNeedsPassword = false;
 


### PR DESCRIPTION
```
treewide: remove optional builtins prefixes from prelude functions

Remove optional builtins prefixes from prelude functions by running:

    builtins=(
      abort
      baseNameOf
      break
      derivation
      derivationStrict
      dirOf
      false
      fetchGit
      fetchMercurial
      fetchTarball
      fetchTree
      fromTOML
      import
      isNull
      map
      null
      placeholder
      removeAttrs
      scopedImport
      throw
      toString
      true
    )

    fd --type file --exec-batch sed --in-place --regexp-extended "
      s/\<builtins\.($(
          printf '%s\n' "${builtins[@]}" |
            paste --delimiter '|' --serial -
      ))\>/\1/g
    "

    nix fmt

This patch is heavily inspired by [1] ("treewide: remove optional
builtins prefixes from prelude functions").

[1]: https://github.com/NixOS/nixpkgs/pull/444432
```

<!-- Describe your PR above, following Stylix commit conventions. -->

---

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [X] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [X] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [ ] Each commit in this PR is suitable for backport to the current stable branch
    - This is the manual backport of https://github.com/nix-community/stylix/pull/1915.
