### PR TITLE
treewide: remove optional builtins prefixes from prelude functions

### DIFF
--- a/doc/default.nix
+++ b/doc/default.nix
@@ -314,7 +314,7 @@ let
     lib.pipe platforms.${platform}.configuration.options [
 
       # Drop options that come from the module system
-      (lib.flip builtins.removeAttrs [ "_module" ])
+      (lib.flip removeAttrs [ "_module" ])
 
       # Get a list of all options, flattening sub-options recursively.
       # This also normalises things like `defaultText` and `visible="shallow"`.

--- a/stylix/autoload.nix
+++ b/stylix/autoload.nix
@@ -29,7 +29,7 @@ builtins.concatLists (
             name: ''while evaluating the module argument `${name}' in "${toString file}":'';
           extraArgs = lib.pipe module [
             builtins.functionArgs
-            (lib.flip builtins.removeAttrs [ "mkTarget" ])
+            (lib.flip removeAttrs [ "mkTarget" ])
             (builtins.mapAttrs (
               name: _:
               builtins.addErrorContext (context name) (

--- a/stylix/testbed/modules/common.nix
+++ b/stylix/testbed/modules/common.nix
@@ -3,7 +3,7 @@ let
   user = lib.importTOML ../user.toml;
 in
 {
-  users.users.${user.username} = builtins.removeAttrs user [ "username" ];
+  users.users.${user.username} = removeAttrs user [ "username" ];
 
   security.sudo.wheelNeedsPassword = false;
 


### PR DESCRIPTION
```
Remove optional builtins prefixes from prelude functions by running:

    builtins=(
      abort
      baseNameOf
      break
      derivation
      derivationStrict
      dirOf
      false
      fetchGit
      fetchMercurial
      fetchTarball
      fetchTree
      fromTOML
      import
      isNull
      map
      null
      placeholder
      removeAttrs
      scopedImport
      throw
      toString
      true
    )

    fd --type file --exec-batch sed --in-place --regexp-extended "
      s/\<builtins\.($(
          printf '%s\n' "${builtins[@]}" |
            paste --delimiter '|' --serial -
      ))\>/\1/g
    "

    nix fmt

This patch is heavily inspired by [1] ("treewide: remove optional
builtins prefixes from prelude functions").

[1]: https://github.com/NixOS/nixpkgs/pull/444432
```

---

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [X] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [X] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [ ] Each commit in this PR is suitable for backport to the current stable branch
    - Since similar patches have not been backported, this is manually backported in https://github.com/nix-community/stylix/pull/1914.
