### PR TITLE
ci: check: bump and use correct x86_64-darwin runner

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -27,7 +27,7 @@ jobs:
           - name: x86_64-linux
             runs-on: ubuntu-24.04
           - name: x86_64-darwin
-            runs-on: macos-15
+            runs-on: macos-15-intel
 
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -27,7 +27,7 @@ jobs:
           - name: x86_64-linux
             runs-on: ubuntu-24.04
           - name: x86_64-darwin
-            runs-on: macos-13
+            runs-on: macos-15
 
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
```
commit cbb9010d16a265c4b67495fa60d7067b87fc7389
Author: NAHO <90870942+trueNAHO@users.noreply.github.com>
Date:   2025-10-02 19:06:22 +0200

    ci: check: bump x86_64-darwin runner to macos-15

 .github/workflows/check.yml | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

commit 22d291b0a5f7570807337b4d9bff8a5d17536d30
Author: NAHO <90870942+trueNAHO@users.noreply.github.com>
Date:   2025-10-02 19:07:06 +0200

    ci: check: use correct x86_64-darwin runner

 .github/workflows/check.yml | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```

> The macOS 13 runner image will be retired by December 4th, 2025.
>
> [...]
>
> For users that require the x86_64 (Intel) architecture, jobs can be migrated to one of the following labels:
>
> * macos-15-intel (new)
> * macos-14-large
> * macos-latest-large or macos-15-large
>
> [...]
>
> ### Notice of macOS x86_64 (Intel) architecture deprecation
>
> Apple has discontinued support for the x86_64 (Intel) architecture going forward. GitHub will no longer support this architecture on macOS after the macOS 15 runner image is retired in Fall 2027. You should begin migrating your workloads to arm64-based (Apple Silicon) runners as soon as possible to prepare for this eventual deprecation.

This PR follows https://github.com/nix-community/stylix/pull/1069. Since I do not know why both aarch64-darwin and x86_64-darwin strategies use the `macos-{13,15}` runners, I do not know whether the macos-15-intel runner is even desired or correct.

CC: @awwpotato, @danth

---

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [X] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [X] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [X] Each commit in this PR is suitable for backport to the current stable branch
