### PR TITLE
hyprpanel: more granularly split configElements

### DIFF
--- a/modules/hyprpanel/hm.nix
+++ b/modules/hyprpanel/hm.nix
@@ -5,14 +5,19 @@ mkTarget {
 
   configElements = [
     (
-      { colors, fonts }:
+      { fonts }:
+      {
+        programs.hyprpanel.settings.theme.fonts = {
+          inherit (fonts.monospace) name;
+          size = fonts.sizes.desktop;
+        };
+      }
+    )
+
+    (
+      { colors }:
       {
         programs.hyprpanel.settings.theme = with colors.withHashtag; {
-          fonts = {
-            inherit (fonts.monospace) name;
-            size = fonts.sizes.desktop;
-          };
-
           bar = {
             menus = {
               menu = {

--- a/modules/hyprpanel/hm.nix
+++ b/modules/hyprpanel/hm.nix
@@ -13,7 +13,6 @@ mkTarget {
         };
       }
     )
-
     (
       { colors }:
       {


### PR DESCRIPTION
```
Fixes: 3f70c5855572 ("hyprpanel: init (#1916)")
```

CC: @khas-amir

---

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [X] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [X] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [ ] Each commit in this PR is suitable for backport to the current stable branch
    - Commit 3f70c5855572 has not been backported yet.
