### PR TITLE
zen: add enableCss option

### DIFF
--- a/modules/zen-browser/hm.nix
+++ b/modules/zen-browser/hm.nix
@@ -17,6 +17,12 @@ mkTarget {
       default = [ ];
       example = [ "default" ];
     };
+
+    enableCss = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = "enables userChrome and userContent css styles for the browser";
+    };
   };
 
   configElements = lib.optionals (options.programs ? zen-browser) [
@@ -49,15 +55,17 @@ mkTarget {
         colors,
       }:
       {
-        programs.zen-browser.profiles = lib.genAttrs cfg.profileNames (_: {
-          settings = {
-            "toolkit.legacyUserProfileCustomizations.stylesheets" = true;
-          };
+        programs.zen-browser.profiles = lib.mkIf cfg.enableCss (
+          lib.genAttrs cfg.profileNames (_: {
+            settings = {
+              "toolkit.legacyUserProfileCustomizations.stylesheets" = true;
+            };
 
-          userChrome = import ./userChrome.nix { inherit colors; };
+            userChrome = import ./userChrome.nix { inherit colors; };
 
-          userContent = import ./userContent.nix { inherit colors; };
-        });
+            userContent = import ./userContent.nix { inherit colors; };
+          })
+        );
       }
     )
   ];


### PR DESCRIPTION
Adds an option to disable adding userChrome and userContent css files to zen
fixes #1944

---

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->

- [x] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [x] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [x] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [x] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [ ] Each commit in this PR is suitable for backport to the current stable branch
