### PR TITLE
doc: styling: add filetypes

### DIFF
--- a/doc/src/styling.md
+++ b/doc/src/styling.md
@@ -151,3 +151,23 @@ Text editors are any application that can view or edit source code. Examples
 include vim, helix, and bat.
 
 For these please refer to the official [base16 style guide](https://github.com/chriskempson/base16/blob/main/styling.md).
+
+## File Management
+
+Terminal file managers, shells and other software that displays a filesystem
+with colors. If the target does not support specifying a color for one of the
+following, fall back to regular file.
+
+- Regular file: base05
+- Directory: base0D (bold)
+- Broken symlink, missing file: base08
+- FIFO: base0A
+- Block device, character device: base0A (bold)
+- Socket: base0C
+- Executable: base0B
+- Hidden, ignored: base03
+- Image, audio, video: base0E
+- Compressed: base09 (bold)
+- Document: base09
+
+Symlinks follow the same rules but should be italicized.

--- a/modules/yazi/hm.nix
+++ b/modules/yazi/hm.nix
@@ -121,28 +121,38 @@ mkTarget {
           filetype.rules =
             let
               mkRule = mime: fg: { inherit mime fg; };
+              mkIs = is: fg: {
+                name = "*";
+                inherit is fg;
+              };
             in
             [
-              (mkRule "image/*" cyan)
-              (mkRule "video/*" yellow)
-              (mkRule "audio/*" yellow)
+              ((mkRule "inode/directory" blue) // { bold = true; })
+              # ((mkIs "link" base05) // {bold = true;})
+              (mkIs "orphan" base08)
+              (mkIs "fifo" base0A)
+              ((mkIs "block" base0A) // { bold = true; })
+              ((mkIs "char" base0A) // { bold = true; })
+              (mkIs "sock" base0C)
+              (mkIs "exec" base0B)
+              (mkIs "dummy" base03)
 
-              (mkRule "application/zip" magenta)
-              (mkRule "application/gzip" magenta)
-              (mkRule "application/tar" magenta)
-              (mkRule "application/bzip" magenta)
-              (mkRule "application/bzip2" magenta)
-              (mkRule "application/7z-compressed" magenta)
-              (mkRule "application/rar" magenta)
-              (mkRule "application/xz" magenta)
-
-              (mkRule "application/doc" green)
-              (mkRule "application/pdf" green)
-              (mkRule "application/rtf" green)
-              (mkRule "application/vnd.*" green)
+              (mkRule "{image,audio,video}/*" base0E)
+              (
+                (mkRule "application/{zip,rar,7z*,tar,gzip,xz,zstd,bzip*,lzma,compress,archive,cpio,arj,xar,ms-cab*}" base09)
+                // {
+                  bold = true;
+                }
+              )
+              (mkRule "application/{pdf,doc,rtf}" base09)
 
               ((mkRule "inode/directory" blue) // { bold = true; })
               (mkRule "*" base05)
+              {
+                name = "*";
+                is = "link";
+                italic = true;
+              }
             ];
         };
     };

--- a/modules/yazi/hm.nix
+++ b/modules/yazi/hm.nix
@@ -4,14 +4,6 @@ mkTarget {
   name = "yazi";
   humanName = "Yazi";
 
-  extraOptions = {
-    boldDirectory = lib.mkOption {
-      description = "Whether to use bold font for directories.";
-      type = lib.types.bool;
-      default = true;
-    };
-  };
-
   configElements =
     { cfg, colors }:
     {
@@ -149,7 +141,7 @@ mkTarget {
               (mkRule "application/rtf" green)
               (mkRule "application/vnd.*" green)
 
-              ((mkRule "inode/directory" blue) // { bold = cfg.boldDirectory; })
+              ((mkRule "inode/directory" blue) // { bold = true; })
               (mkRule "*" base05)
             ];
         };


### PR DESCRIPTION
Styling guidelines for file managers.

The color choices are inspired by [base16-vivid](https://github.com/tinted-theming/base16-vivid/blob/main/templates/default.mustache), [tinted-yazi](https://github.com/tinted-theming/tinted-yazi/blob/main/templates/default.mustache) and some of my old configs. I'd love to see some suggestions.

Will follow up with more PRs to make existing modules compliant.

---

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [x] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [x] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [ ] Each commit in this PR is suitable for backport to the current stable branch
