### PR TITLE
stylix/home-manager-integration: enable even when `stylix.enable = false`

### DIFF
--- a/stylix/home-manager-integration.nix
+++ b/stylix/home-manager-integration.nix
@@ -214,21 +214,24 @@ in
     };
   };
 
-  config = lib.mkIf config.stylix.enable (
-    lib.optionalAttrs (options ? home-manager) (
-      lib.mkMerge [
-        (lib.mkIf config.stylix.homeManagerIntegration.autoImport {
-          home-manager.sharedModules = [
-            config.stylix.homeManagerIntegration.module
-          ]
-          ++ lib.optionals config.stylix.homeManagerIntegration.followSystem copyModules;
-        })
-        (lib.mkIf config.home-manager.useGlobalPkgs {
-          home-manager.sharedModules = lib.singleton {
-            config.stylix.overlays.enable = false;
-          };
-        })
-      ]
-    )
+  # Always enable this, even when `!stylix.enable`: if the HM module isn't imported,
+  # it prevents users from settings any stylix related options in HM.
+  # That would go against the standard pattern for `.enable`: it should not affect what
+  # you're allowed to write in `config`, nor the config of the `!enabled` module.
+  config = lib.optionalAttrs (options ? home-manager) (
+    lib.mkMerge [
+      (lib.mkIf config.stylix.homeManagerIntegration.autoImport {
+        home-manager.sharedModules = [
+          config.stylix.homeManagerIntegration.module
+        ]
+        ++ lib.optionals config.stylix.homeManagerIntegration.followSystem copyModules;
+      })
+
+      (lib.mkIf config.home-manager.useGlobalPkgs {
+        home-manager.sharedModules = lib.singleton {
+          config.stylix.overlays.enable = false;
+        };
+      })
+    ]
   );
 }


### PR DESCRIPTION
Always enable this, even when `!stylix.enable`: if the HM module isn't imported, it prevents users from setting any stylix related options in their HM config.  
That would go against the standard pattern for `enable` options: they should not affect what you're allowed to write in `config`, thus we need to import the module; nor affect the value of the module's options, thus we need to propagate the NixOS `config.stylix` values.

---

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [x] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [x] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [x] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [x] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [x] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [x] Each commit in this PR is suitable for backport to the current stable branch
