### PR TITLE
gtksourceview:  use simpiler enable check, disable by default

### DIFF
--- a/modules/gnome-text-editor/testbeds/gnome-text-editor.nix
+++ b/modules/gnome-text-editor/testbeds/gnome-text-editor.nix
@@ -1,3 +1,4 @@
+# NOTE: ../../gtksourceview/testbeds/gtksourceview.nix depends on this file
 { pkgs, ... }:
 {
   stylix.testbed.ui.command.text = "gnome-text-editor flake-parts/flake.nix";

--- a/modules/gtksourceview/hm.nix
+++ b/modules/gtksourceview/hm.nix
@@ -1,5 +1,7 @@
 { mkTarget, lib, ... }:
 mkTarget {
+  autoEnable = false;
+
   config =
     { colors, ... }:
     {

--- a/modules/gtksourceview/meta.nix
+++ b/modules/gtksourceview/meta.nix
@@ -2,4 +2,10 @@
 {
   maintainers = [ lib.maintainers.bricked ];
   name = "GTKSourceView";
+  description = ''
+    > [!WARNING]
+    > GTKSourceView is disabled by default because it causes many packages
+    > to no longer be cached in hydra, forcing the user to compile these
+    > packages themselves.
+  '';
 }

--- a/modules/gtksourceview/nixos.nix
+++ b/modules/gtksourceview/nixos.nix
@@ -1,3 +1,3 @@
 { mkTarget, ... }:
 # Used to enable overlay.
-mkTarget { }
+mkTarget { autoEnable = false; }

--- a/modules/gtksourceview/overlay.nix
+++ b/modules/gtksourceview/overlay.nix
@@ -21,11 +21,7 @@ in
   overlay =
     _final: prev:
     optionalAttrs
-      (
-        config.stylix.enable
-        && config.stylix.targets ? gtksourceview
-        && config.stylix.targets.gtksourceview.enable
-      )
+      (config.stylix.enable && config.stylix.targets.gtksourceview.enable or false)
       {
         gnome2 = prev.gnome2 // {
           gtksourceview = prev.gnome2.gtksourceview.overrideAttrs (attrsOverride "2.0");

--- a/modules/gtksourceview/testbeds/gtksourceview.nix
+++ b/modules/gtksourceview/testbeds/gtksourceview.nix
@@ -1,0 +1,5 @@
+{
+  imports = [ ../../gnome-text-editor/testbeds/gnome-text-editor.nix ];
+
+  stylix.targets.gtksourceview.enable = true;
+}


### PR DESCRIPTION
relevant: https://github.com/nix-community/stylix/pull/2107#discussion_r2648625791

> > GTKSourceView is disabled by default because it causes many packages
> > to no longer be cached in hydra, forcing the user to compile these
> > packages themselves.

> [!NOTE]
> this is a breaking change, so only `gtksourceview: use simpler or false in enabled check` should be backported.
<!-- Describe your PR above, following Stylix commit conventions. -->

---

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [x] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [x] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [ ] Each commit in this PR is suitable for backport to the current stable branch
