### PR TITLE
nixos-icons: allow customizing icon colors

### DIFF
--- a/modules/nixos-icons/overlay.nix
+++ b/modules/nixos-icons/overlay.nix
@@ -69,66 +69,54 @@ in
         description = "Replaces the white color in the 'nix-snowflake-white' icon.";
         type = strMatchingHexColor;
       };
-      nix-snowflake-colours = {
-        gradient-light-blue = {
-          dark = mkOption {
-            default =
-              hexColorAddRgb cfg.colors.nix-snowflake-colours.gradient-light-blue.neutral
-                {
-                  r = -21;
-                  g = -23;
-                  b = -6;
-                };
-            description = "Replaces the darker part of light blue color gradient (#699ad7) in the 'nix-snowflake-colours' icon.";
-            type = strMatchingHexColor;
+      nix-snowflake = {
+        light-blue-darker = mkOption {
+          default = hexColorAddRgb cfg.colors.nix-snowflake.light-blue {
+            r = -21;
+            g = -23;
+            b = -6;
           };
-          neutral = mkOption {
-            default = colors.base0C;
-            defaultText = "config.lib.stylix.colors.base0C";
-            description = "Replaces the neutral part of light blue color gradient (#7eb1dd) in the 'nix-snowflake-colours' icon.";
-            type = strMatchingHexColor;
-          };
-          light = mkOption {
-            default =
-              hexColorAddRgb cfg.colors.nix-snowflake-colours.gradient-light-blue.neutral
-                {
-                  r = 0;
-                  g = 9;
-                  b = 7;
-                };
-            description = "Replaces the lighter part of light blue color gradient (#7ebae4) the 'nix-snowflake-colours' icon.";
-            type = strMatchingHexColor;
-          };
+          description = "Replaces the darker part of light blue color gradient (#699ad7) in the 'nix-snowflake-colours' icon.";
+          type = strMatchingHexColor;
         };
-        gradient-blue = {
-          dark = mkOption {
-            default =
-              hexColorAddRgb cfg.colors.nix-snowflake-colours.gradient-blue.neutral
-                {
-                  r = -9;
-                  g = -13;
-                  b = -21;
-                };
-            description = "Replaces the darker part of blue color gradient (#415e9a) in the 'nix-snowflake-colours' icon.";
-            type = strMatchingHexColor;
+        light-blue = mkOption {
+          default = colors.base0C;
+          defaultText = "config.lib.stylix.colors.base0C";
+          description = "Replaces the neutral part of light blue color gradient (#7eb1dd) in the 'nix-snowflake-colours' icon.";
+          type = strMatchingHexColor;
+        };
+        light-blue-lighter = mkOption {
+          default = hexColorAddRgb cfg.colors.nix-snowflake.light-blue {
+            r = 0;
+            g = 9;
+            b = 7;
           };
-          neutral = mkOption {
-            default = colors.base0D;
-            defaultText = "config.lib.stylix.colors.base0D";
-            description = "Replaces the neutral part of blue color gradient (#4a6baf) in the 'nix-snowflake-colours' icon.";
-            type = strMatchingHexColor;
+          description = "Replaces the lighter part of light blue color gradient (#7ebae4) the 'nix-snowflake-colours' icon.";
+          type = strMatchingHexColor;
+        };
+        blue-darker = mkOption {
+          default = hexColorAddRgb cfg.colors.nix-snowflake.blue {
+            r = -9;
+            g = -13;
+            b = -21;
           };
-          light = mkOption {
-            default =
-              hexColorAddRgb cfg.colors.nix-snowflake-colours.gradient-blue.neutral
-                {
-                  r = 8;
-                  g = 12;
-                  b = 20;
-                };
-            description = "Replaces the lighter part of blue color gradient (#5277c3) the 'nix-snowflake-colours' icon.";
-            type = strMatchingHexColor;
+          description = "Replaces the darker part of blue color gradient (#415e9a) in the 'nix-snowflake-colours' icon.";
+          type = strMatchingHexColor;
+        };
+        blue = mkOption {
+          default = colors.base0D;
+          defaultText = "config.lib.stylix.colors.base0D";
+          description = "Replaces the neutral part of blue color gradient (#4a6baf) in the 'nix-snowflake-colours' icon.";
+          type = strMatchingHexColor;
+        };
+        blue-lighter = mkOption {
+          default = hexColorAddRgb cfg.colors.nix-snowflake.blue {
+            r = 8;
+            g = 12;
+            b = 20;
           };
+          description = "Replaces the lighter part of blue color gradient (#5277c3) the 'nix-snowflake-colours' icon.";
+          type = strMatchingHexColor;
         };
       };
     };
@@ -153,37 +141,37 @@ in
               logo/nix-snowflake-colours.svg \
               --replace-fail \
               '#699ad7' \
-              '#${cfg.colors.nix-snowflake-colours.gradient-light-blue.dark}'
+              '#${cfg.colors.nix-snowflake.light-blue-darker}'
 
             substituteInPlace \
               logo/nix-snowflake-colours.svg \
               --replace-fail \
               '#7eb1dd' \
-              '#${cfg.colors.nix-snowflake-colours.gradient-light-blue.neutral}'
+              '#${cfg.colors.nix-snowflake.light-blue}'
 
             substituteInPlace \
               logo/nix-snowflake-colours.svg \
               --replace-fail \
               '#7ebae4' \
-              '#${cfg.colors.nix-snowflake-colours.gradient-light-blue.light}'
+              '#${cfg.colors.nix-snowflake.light-blue-lighter}'
 
             substituteInPlace \
               logo/nix-snowflake-colours.svg \
               --replace-fail \
               '#415e9a' \
-              '#${cfg.colors.nix-snowflake-colours.gradient-blue.dark}'
+              '#${cfg.colors.nix-snowflake.blue-darker}'
 
             substituteInPlace \
               logo/nix-snowflake-colours.svg \
               --replace-fail \
               '#4a6baf' \
-              '#${cfg.colors.nix-snowflake-colours.gradient-blue.neutral}'
+              '#${cfg.colors.nix-snowflake.blue}'
 
             substituteInPlace \
               logo/nix-snowflake-colours.svg \
               --replace-fail \
               '#5277c3' \
-              '#${cfg.colors.nix-snowflake-colours.gradient-blue.light}'
+              '#${cfg.colors.nix-snowflake.blue-lighter}'
 
             # Insert attribution comment after the XML prolog
             attribution='2i<!-- The original NixOS logo from ${oldAttrs.src.url} is licensed under https://creativecommons.org/licenses/by/4.0 and has been modified to match the ${colors.scheme} color scheme. -->'

--- a/modules/nixos-icons/overlay.nix
+++ b/modules/nixos-icons/overlay.nix
@@ -6,7 +6,6 @@
 }:
 let
   inherit (builtins) stringLength substring;
-  inherit (config.lib.stylix) colors;
 
   inherit (lib)
     concatStrings
@@ -62,59 +61,104 @@ in
 {
   options.stylix.targets.nixos-icons = {
     enable = config.lib.stylix.mkEnableTarget "the NixOS logo" true;
+    hexColorAddRgb = mkOption {
+      readOnly = true;
+      default = hexColorAddRgb;
+      description = "Function that adds RGB values to a hex color. For example `hexColorAddRgb \"000000\" {r = 128; g = 128; b = 128;}` evaluates to `\"808080\"`";
+    };
     colors = {
       nix-snowflake-white.white = mkOption {
-        default = colors.base05;
+        default = config.lib.stylix.colors.base05;
         defaultText = "config.lib.stylix.colors.base05";
         description = "Replaces the white color in the 'nix-snowflake-white' icon.";
         type = strMatchingHexColor;
       };
       nix-snowflake = {
         light-blue-darker = mkOption {
-          default = hexColorAddRgb cfg.colors.nix-snowflake.light-blue {
-            r = -21;
-            g = -23;
-            b = -6;
-          };
+          default =
+            with config.stylix.targets.nixos-icons;
+            hexColorAddRgb colors.nix-snowflake.light-blue {
+              r = -21;
+              g = -23;
+              b = -6;
+            };
+          defaultText = ''
+            with config.stylix.targets.nixos-icons;
+            hexColorAddRgb colors.nix-snowflake.light-blue {
+              r = -21;
+              g = -23;
+              b = -6;
+            };
+          '';
           description = "Replaces the darker part of light blue color gradient (#699ad7) in the 'nix-snowflake-colours' icon.";
           type = strMatchingHexColor;
         };
         light-blue = mkOption {
-          default = colors.base0C;
+          default = config.lib.stylix.colors.base0C;
           defaultText = "config.lib.stylix.colors.base0C";
           description = "Replaces the neutral part of light blue color gradient (#7eb1dd) in the 'nix-snowflake-colours' icon.";
           type = strMatchingHexColor;
         };
         light-blue-lighter = mkOption {
-          default = hexColorAddRgb cfg.colors.nix-snowflake.light-blue {
-            r = 0;
-            g = 9;
-            b = 7;
-          };
+          default =
+            with config.stylix.targets.nixos-icons;
+            hexColorAddRgb colors.nix-snowflake.light-blue {
+              r = 0;
+              g = 9;
+              b = 7;
+            };
+          defaultText = ''
+            with config.stylix.targets.nixos-icons;
+            hexColorAddRgb colors.nix-snowflake.light-blue {
+              r = 0;
+              g = 9;
+              b = 7;
+            };
+          '';
           description = "Replaces the lighter part of light blue color gradient (#7ebae4) the 'nix-snowflake-colours' icon.";
           type = strMatchingHexColor;
         };
         blue-darker = mkOption {
-          default = hexColorAddRgb cfg.colors.nix-snowflake.blue {
-            r = -9;
-            g = -13;
-            b = -21;
-          };
+          default =
+            with config.stylix.targets.nixos-icons;
+            hexColorAddRgb colors.nix-snowflake.blue {
+              r = -9;
+              g = -13;
+              b = -21;
+            };
+          defaultText = ''
+            with config.stylix.targets.nixos-icons;
+            hexColorAddRgb colors.nix-snowflake.blue {
+              r = -9;
+              g = -13;
+              b = -21;
+            };
+          '';
           description = "Replaces the darker part of blue color gradient (#415e9a) in the 'nix-snowflake-colours' icon.";
           type = strMatchingHexColor;
         };
         blue = mkOption {
-          default = colors.base0D;
+          default = config.lib.stylix.colors.base0D;
           defaultText = "config.lib.stylix.colors.base0D";
           description = "Replaces the neutral part of blue color gradient (#4a6baf) in the 'nix-snowflake-colours' icon.";
           type = strMatchingHexColor;
         };
         blue-lighter = mkOption {
-          default = hexColorAddRgb cfg.colors.nix-snowflake.blue {
-            r = 8;
-            g = 12;
-            b = 20;
-          };
+          default =
+            with config.stylix.targets.nixos-icons;
+            hexColorAddRgb colors.nix-snowflake.blue {
+              r = 8;
+              g = 12;
+              b = 20;
+            };
+          defaultText = ''
+            with config.stylix.targets.nixos-icons;
+            hexColorAddRgb colors.nix-snowflake.blue {
+              r = 8;
+              g = 12;
+              b = 20;
+            };
+          '';
           description = "Replaces the lighter part of blue color gradient (#5277c3) the 'nix-snowflake-colours' icon.";
           type = strMatchingHexColor;
         };
@@ -174,7 +218,7 @@ in
               '#${cfg.colors.nix-snowflake.blue-lighter}'
 
             # Insert attribution comment after the XML prolog
-            attribution='2i<!-- The original NixOS logo from ${oldAttrs.src.url} is licensed under https://creativecommons.org/licenses/by/4.0 and has been modified to match the ${colors.scheme} color scheme. -->'
+            attribution='2i<!-- The original NixOS logo from ${oldAttrs.src.url} is licensed under https://creativecommons.org/licenses/by/4.0 and has been modified to match the ${config.lib.stylix.colors.scheme} color scheme. -->'
             sed --in-place "$attribution" logo/nix-snowflake-colours.svg
             sed --in-place "$attribution" logo/nix-snowflake-white.svg
           '';

--- a/modules/nixos-icons/overlay.nix
+++ b/modules/nixos-icons/overlay.nix
@@ -36,9 +36,9 @@ let
               if elem == "r" then
                 substring 0 2 hexColor
               else if elem == "g" then
-                substring 2 4 hexColor
+                substring 2 2 hexColor
               else
-                substring 4 6 hexColor
+                substring 4 2 hexColor
             )
             + add.${elem}
           )
@@ -83,7 +83,7 @@ in
             type = strMatchingHexColor;
           };
           neutral = mkOption {
-            default = colors.baseOC;
+            default = colors.base0C;
             defaultText = "config.lib.stylix.colors.base0C";
             description = "Replaces the neutral part of light blue color gradient (#7eb1dd) in the 'nix-snowflake-colours' icon.";
             type = strMatchingHexColor;
@@ -113,7 +113,7 @@ in
             type = strMatchingHexColor;
           };
           neutral = mkOption {
-            default = colors.baseOD;
+            default = colors.base0D;
             defaultText = "config.lib.stylix.colors.base0D";
             description = "Replaces the neutral part of blue color gradient (#4a6baf) in the 'nix-snowflake-colours' icon.";
             type = strMatchingHexColor;

--- a/modules/nixos-icons/overlay.nix
+++ b/modules/nixos-icons/overlay.nix
@@ -4,130 +4,193 @@
   lib,
   ...
 }:
+let
+  inherit (builtins) stringLength substring;
+  inherit (config.lib.stylix) colors;
+
+  inherit (lib)
+    concatStrings
+    max
+    min
+    pipe
+    toHexString
+    fromHexString
+    mkOption
+    types
+    ;
+
+  cfg = config.stylix.targets.nixos-icons;
+
+  strMatchingHexColor = types.strMatching "^[a-zA-Z0-9]{6}$";
+
+  hexColorAddRgb =
+    hexColor: add:
+    pipe hexColor [
+      # convert to hex color to rgb attrset, and add specified value
+      (
+        _:
+        map
+          (
+            elem:
+            fromHexString (
+              if elem == "r" then
+                substring 0 2 hexColor
+              else if elem == "g" then
+                substring 2 4 hexColor
+              else
+                substring 4 6 hexColor
+            )
+            + add.${elem}
+          )
+          [
+            "r"
+            "g"
+            "b"
+          ]
+      )
+      # clamp between 0 and 255
+      (map (min 255))
+      (map (max 0))
+      # convert each to hex string
+      (map toHexString)
+      # add leading 0 if necessary
+      (map (hex: if (stringLength hex < 2) then "0" + hex else hex))
+      # to one string
+      concatStrings
+    ];
+in
 {
-  options.stylix.targets.nixos-icons.enable =
-    config.lib.stylix.mkEnableTarget "the NixOS logo" true;
+  options.stylix.targets.nixos-icons = {
+    enable = config.lib.stylix.mkEnableTarget "the NixOS logo" true;
+    colors = {
+      nix-snowflake-white.white = mkOption {
+        default = colors.base05;
+        defaultText = "config.lib.stylix.colors.base05";
+        description = "Replaces the white color in the 'nix-snowflake-white' icon.";
+        type = strMatchingHexColor;
+      };
+      nix-snowflake-colours = {
+        gradient-light-blue = {
+          dark = mkOption {
+            default =
+              hexColorAddRgb cfg.colors.nix-snowflake-colours.gradient-light-blue.neutral
+                {
+                  r = -21;
+                  g = -23;
+                  b = -6;
+                };
+            description = "Replaces the darker part of light blue color gradient (#699ad7) in the 'nix-snowflake-colours' icon.";
+            type = strMatchingHexColor;
+          };
+          neutral = mkOption {
+            default = colors.baseOC;
+            defaultText = "config.lib.stylix.colors.base0C";
+            description = "Replaces the neutral part of light blue color gradient (#7eb1dd) in the 'nix-snowflake-colours' icon.";
+            type = strMatchingHexColor;
+          };
+          light = mkOption {
+            default =
+              hexColorAddRgb cfg.colors.nix-snowflake-colours.gradient-light-blue.neutral
+                {
+                  r = 0;
+                  g = 9;
+                  b = 7;
+                };
+            description = "Replaces the lighter part of light blue color gradient (#7ebae4) the 'nix-snowflake-colours' icon.";
+            type = strMatchingHexColor;
+          };
+        };
+        gradient-blue = {
+          dark = mkOption {
+            default =
+              hexColorAddRgb cfg.colors.nix-snowflake-colours.gradient-blue.neutral
+                {
+                  r = -9;
+                  g = -13;
+                  b = -21;
+                };
+            description = "Replaces the darker part of blue color gradient (#415e9a) in the 'nix-snowflake-colours' icon.";
+            type = strMatchingHexColor;
+          };
+          neutral = mkOption {
+            default = colors.baseOD;
+            defaultText = "config.lib.stylix.colors.base0D";
+            description = "Replaces the neutral part of blue color gradient (#4a6baf) in the 'nix-snowflake-colours' icon.";
+            type = strMatchingHexColor;
+          };
+          light = mkOption {
+            default =
+              hexColorAddRgb cfg.colors.nix-snowflake-colours.gradient-blue.neutral
+                {
+                  r = 8;
+                  g = 12;
+                  b = 20;
+                };
+            description = "Replaces the lighter part of blue color gradient (#5277c3) the 'nix-snowflake-colours' icon.";
+            type = strMatchingHexColor;
+          };
+        };
+      };
+    };
+  };
 
   overlay =
     _: super:
-    lib.optionalAttrs
-      (config.stylix.enable && config.stylix.targets.nixos-icons.enable)
-      {
-        nixos-icons = super.nixos-icons.overrideAttrs (oldAttrs: {
-          src = pkgs.applyPatches {
-            inherit (oldAttrs) src;
-            prePatch =
-              let
-                inherit (builtins) stringLength;
-                inherit (config.lib.stylix) colors;
+    lib.optionalAttrs (config.stylix.enable && cfg.enable) {
+      nixos-icons = super.nixos-icons.overrideAttrs (oldAttrs: {
+        src = pkgs.applyPatches {
+          inherit (oldAttrs) src;
+          prePatch = ''
+            substituteInPlace \
+              logo/nix-snowflake-white.svg \
+              --replace-fail \
+              '#ffffff' \
+              '#${cfg.colors.nix-snowflake-white.white}'
 
-                inherit (lib)
-                  concatStrings
-                  max
-                  min
-                  pipe
-                  toHexString
-                  toInt
-                  ;
+            # The normal snowflake uses 2 gradients, replace each bluish
+            # color with blue and each light-blueish color with cyan
+            substituteInPlace \
+              logo/nix-snowflake-colours.svg \
+              --replace-fail \
+              '#699ad7' \
+              '#${cfg.colors.nix-snowflake-colours.gradient-light-blue.dark}'
 
-                baseColorAdd =
-                  colorName: add:
-                  pipe colorName [
-                    # convert to base color name to rgb attrset, and add specified value
-                    (
-                      colorName:
-                      map (elem: toInt colors."${colorName}-rgb-${elem}" + add.${elem}) [
-                        "r"
-                        "g"
-                        "b"
-                      ]
-                    )
-                    # clamp between 0 and 255
-                    (map (min 255))
-                    (map (max 0))
-                    # convert each to hex string
-                    (map toHexString)
-                    # add leading 0 if necessary
-                    (map (hex: if (stringLength hex < 2) then "0" + hex else hex))
-                    # to one string
-                    concatStrings
-                  ];
-              in
-              ''
-                substituteInPlace \
-                  logo/nix-snowflake-white.svg \
-                  --replace-fail \
-                  '#ffffff' \
-                  '#${colors.base05}'
+            substituteInPlace \
+              logo/nix-snowflake-colours.svg \
+              --replace-fail \
+              '#7eb1dd' \
+              '#${cfg.colors.nix-snowflake-colours.gradient-light-blue.neutral}'
 
-                # The normal snowflake uses 2 gradients, replace each bluish
-                # color with blue and each light-blueish color with cyan
-                substituteInPlace \
-                  logo/nix-snowflake-colours.svg \
-                  --replace-fail \
-                  '#699ad7' \
-                  '#${
-                    baseColorAdd "base0C" {
-                      r = -21;
-                      g = -23;
-                      b = -6;
-                    }
-                  }'
+            substituteInPlace \
+              logo/nix-snowflake-colours.svg \
+              --replace-fail \
+              '#7ebae4' \
+              '#${cfg.colors.nix-snowflake-colours.gradient-light-blue.light}'
 
-                substituteInPlace \
-                  logo/nix-snowflake-colours.svg \
-                  --replace-fail \
-                  '#7eb1dd' \
-                  '#${colors.base0C}'
+            substituteInPlace \
+              logo/nix-snowflake-colours.svg \
+              --replace-fail \
+              '#415e9a' \
+              '#${cfg.colors.nix-snowflake-colours.gradient-blue.dark}'
 
-                substituteInPlace \
-                  logo/nix-snowflake-colours.svg \
-                  --replace-fail \
-                  '#7ebae4' \
-                  '#${
-                    baseColorAdd "base0C" {
-                      r = 0;
-                      g = 9;
-                      b = 7;
-                    }
-                  }'
+            substituteInPlace \
+              logo/nix-snowflake-colours.svg \
+              --replace-fail \
+              '#4a6baf' \
+              '#${cfg.colors.nix-snowflake-colours.gradient-blue.neutral}'
 
-                substituteInPlace \
-                  logo/nix-snowflake-colours.svg \
-                  --replace-fail \
-                  '#415e9a' \
-                  '#${
-                    baseColorAdd "base0D" {
-                      r = -9;
-                      g = -13;
-                      b = -21;
-                    }
-                  }'
+            substituteInPlace \
+              logo/nix-snowflake-colours.svg \
+              --replace-fail \
+              '#5277c3' \
+              '#${cfg.colors.nix-snowflake-colours.gradient-blue.light}'
 
-                substituteInPlace \
-                  logo/nix-snowflake-colours.svg \
-                  --replace-fail \
-                  '#4a6baf' \
-                  '#${colors.base0D}'
-
-                substituteInPlace \
-                  logo/nix-snowflake-colours.svg \
-                  --replace-fail \
-                  '#5277c3' \
-                  '#${
-                    baseColorAdd "base0D" {
-                      r = 8;
-                      g = 12;
-                      b = 20;
-                    }
-                  }'
-
-                # Insert attribution comment after the XML prolog
-                attribution='2i<!-- The original NixOS logo from ${oldAttrs.src.url} is licensed under https://creativecommons.org/licenses/by/4.0 and has been modified to match the ${colors.scheme} color scheme. -->'
-                sed --in-place "$attribution" logo/nix-snowflake-colours.svg
-                sed --in-place "$attribution" logo/nix-snowflake-white.svg
-              '';
-          };
-        });
-      };
+            # Insert attribution comment after the XML prolog
+            attribution='2i<!-- The original NixOS logo from ${oldAttrs.src.url} is licensed under https://creativecommons.org/licenses/by/4.0 and has been modified to match the ${colors.scheme} color scheme. -->'
+            sed --in-place "$attribution" logo/nix-snowflake-colours.svg
+            sed --in-place "$attribution" logo/nix-snowflake-white.svg
+          '';
+        };
+      });
+    };
 }


### PR DESCRIPTION
This adds options for customization of the colors of the NixOS icons. Previously the colors were hard-coded to the semantically correct base16 values.
As suggested #2155 we also should here add something like colors.override to the target options as people might want to adjust these colors. 
The problem is that this module cannot use `mkTarget` as this is solely an overlay module which as the documentation says should define the target with vanilla NixOS options.
So this PR adds the following options for changing the colors while still communicating that the options are different from the other override options (AI generated options overview):

- **[`stylix.targets.nixos-icons.colors.nix-snowflake-white.white`](https://github.com/nix-community/stylix/blob/172a45cf7996dc1406bb6e953555bfdbb24bb5ea/modules/nixos-icons/overlay.nix#L70)** - Replaces the white color in the 'nix-snowflake-white' icon.
  - **Type:** `strMatchingHexColor`
  - **Default:** `config.lib.stylix.colors.base05`

- **[`stylix.targets.nixos-icons.colors.nix-snowflake.light-blue-darker`](https://github.com/nix-community/stylix/blob/172a45cf7996dc1406bb6e953555bfdbb24bb5ea/modules/nixos-icons/overlay.nix#L77)** - Replaces the darker part of light blue color gradient (#699ad7) in the 'nix-snowflake-colours' icon.
  - **Type:** `strMatchingHexColor`
  - **Default:**
    ```nix
    with config.stylix.targets.nixos-icons;
    hexColorAddRgb colors.nix-snowflake.light-blue {
      r = -21;
      g = -23;
      b = -6;
    };
    ```

- **[`stylix.targets.nixos-icons.colors.nix-snowflake.light-blue`](https://github.com/nix-community/stylix/blob/172a45cf7996dc1406bb6e953555bfdbb24bb5ea/modules/nixos-icons/overlay.nix#L96)** - Replaces the neutral part of light blue color gradient (#7eb1dd) in the 'nix-snowflake-colours' icon.
  - **Type:** `strMatchingHexColor`
  - **Default:** `config.lib.stylix.colors.base0C`

- **[`stylix.targets.nixos-icons.colors.nix-snowflake.light-blue-lighter`](https://github.com/nix-community/stylix/blob/172a45cf7996dc1406bb6e953555bfdbb24bb5ea/modules/nixos-icons/overlay.nix#L102)** - Replaces the lighter part of light blue color gradient (#7ebae4) the 'nix-snowflake-colours' icon.
  - **Type:** `strMatchingHexColor`
  - **Default:**
    ```nix
    with config.stylix.targets.nixos-icons;
    hexColorAddRgb colors.nix-snowflake.light-blue {
      r = 0;
      g = 9;
      b = 7;
    };
    ```

- **[`stylix.targets.nixos-icons.colors.nix-snowflake.blue-darker`](https://github.com/nix-community/stylix/blob/172a45cf7996dc1406bb6e953555bfdbb24bb5ea/modules/nixos-icons/overlay.nix#L121)** - Replaces the darker part of blue color gradient (#415e9a) in the 'nix-snowflake-colours' icon.
  - **Type:** `strMatchingHexColor`
  - **Default:**
    ```nix
    with config.stylix.targets.nixos-icons;
    hexColorAddRgb colors.nix-snowflake.blue {
      r = -9;
      g = -13;
      b = -21;
    };
    ```

- **[`stylix.targets.nixos-icons.colors.nix-snowflake.blue`](https://github.com/nix-community/stylix/blob/172a45cf7996dc1406bb6e953555bfdbb24bb5ea/modules/nixos-icons/overlay.nix#L140)** - Replaces the neutral part of blue color gradient (#4a6baf) in the 'nix-snowflake-colours' icon.
  - **Type:** `strMatchingHexColor`
  - **Default:** `config.lib.stylix.colors.base0D`

- **[`stylix.targets.nixos-icons.colors.nix-snowflake.blue-lighter`](https://github.com/nix-community/stylix/blob/172a45cf7996dc1406bb6e953555bfdbb24bb5ea/modules/nixos-icons/overlay.nix#L146)** - Replaces the lighter part of blue color gradient (#5277c3) the 'nix-snowflake-colours' icon.
  - **Type:** `strMatchingHexColor`
  - **Default:**
    ```nix
    with config.stylix.targets.nixos-icons;
    hexColorAddRgb colors.nix-snowflake.blue {
      r = 8;
      g = 12;
      b = 20;
    };
    ```


The `nix-snowflake-colours` icon has a gradient on each lambda to show a subtle shadow on the tips. So the `darker` and `lighter` variants of the colors are updated accordingly when the main color (for example `stylix.targets.nixos-icons.colors.nix-snowflake.light-blue` for changing the light blue lambdas) is updated. But anyone is free to update the gradient colors can do that too. Even using the same function as the module does.

I would like the users to be able to use the `hexColorAddRgb` function so I just added it as a read-only option to the target. Is that the right procedure here? 


<!-- Describe your PR above, following Stylix commit conventions. -->
closes #2155
---

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [x] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [x] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [x] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [x] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [ ] Each commit in this PR is suitable for backport to the current stable branch
