### PR TITLE
yazi: add icon theming for v26.1.22

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -141,11 +141,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1767767207,
-        "narHash": "sha256-Mj3d3PfwltLmukFal5i3fFt27L6NiKXdBezC1EBuZs4=",
+        "lastModified": 1769461804,
+        "narHash": "sha256-msG8SU5WsBUfVVa/9RPLaymvi5bI8edTavbIq3vRlhI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5912c1772a44e31bf1c63c0390b90501e5026886",
+        "rev": "bfc1b8a4574108ceef22f02bafcf6611380c100d",
         "type": "github"
       },
       "original": {

--- a/modules/yazi/hm.nix
+++ b/modules/yazi/hm.nix
@@ -155,6 +155,58 @@ mkTarget {
               }
               (mkRule "*" base05)
             ];
+
+          icon =
+            let
+              mkIcon = text: fg: { inherit text fg; };
+            in
+            {
+              dirs =
+                let
+                  mkDirIcon =
+                    name: text: fg:
+                    ((mkIcon text fg) // { inherit name; });
+                in
+                [
+                  (mkDirIcon ".config" "" orange)
+                  (mkDirIcon ".git" "" cyan)
+                  (mkDirIcon ".github" "" blue)
+                  (mkDirIcon ".npm" "" blue)
+                  (mkDirIcon "Desktop" "" cyan)
+                  (mkDirIcon "Development" "" cyan)
+                  (mkDirIcon "Documents" "" cyan)
+                  (mkDirIcon "Downloads" "" cyan)
+                  (mkDirIcon "Library" "" cyan)
+                  (mkDirIcon "Movies" "" cyan)
+                  (mkDirIcon "Music" "" cyan)
+                  (mkDirIcon "Pictures" "" cyan)
+                  (mkDirIcon "Public" "" cyan)
+                  (mkDirIcon "Videos" "" cyan)
+                ];
+
+              conds =
+                let
+                  mkCondsIcon =
+                    cond: text: fg:
+                    ((mkIcon text fg) // { "if" = cond; });
+                in
+                [
+                  # Special files
+                  (mkCondsIcon "orphan" "" base05)
+                  (mkCondsIcon "link" "" base04)
+                  (mkCondsIcon "block" "" yellow)
+                  (mkCondsIcon "char" "" yellow)
+                  (mkCondsIcon "fifo" "" yellow)
+                  (mkCondsIcon "sock" "" yellow)
+                  (mkCondsIcon "sticky" "" yellow)
+                  (mkCondsIcon "dummy" "" red)
+
+                  # Fallback
+                  (mkCondsIcon "dir" "" blue)
+                  (mkCondsIcon "exec" "" green)
+                  (mkCondsIcon "!dir" "" base05)
+                ];
+            };
         };
     };
 }


### PR DESCRIPTION
- Manually specified icon colours as the default was changed to blue in https://github.com/sxyazi/yazi/commit/41e5717930141c574442ecc53bd4db5f96188d50
- Update nixpkgs flake input so that it has yazi v26.1.22

Fixes #2165.

Currently, I have just chosen colours from the base16 scheme that were similar to those in https://github.com/sxyazi/yazi/blob/main/yazi-config/preset/theme-dark.toml. Let me know if you think that they should be changed.

The testbed still seems to be having the issue where the instance launched on startup has an error but opening a second instance in a new terminal fixes this.

---

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [x] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [x] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [x] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [x] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [x] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [ ] Each commit in this PR is suitable for backport to the current stable branch
