### PR TITLE
doc/src/backport_policy: init

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,4 +13,4 @@ drastically accelerate the reviewing and merging process of this PR.
 - [ ] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
 - [ ] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
 - [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
-- [ ] Each commit in this PR is suitable for backport to the current stable branch
+- [ ] Each commit in this PR is [suitable for backport](https://nix-community.github.io/stylix/backport_policy.html)

--- a/doc/src/SUMMARY.md
+++ b/doc/src/SUMMARY.md
@@ -13,6 +13,7 @@
 - [Adding modules](modules.md)
 - [Testbeds](testbeds.md)
 - [Style guide](styling.md)
+- [Backport Policy](backport_policy.md)
 
 # Reference
 

--- a/doc/src/backport_policy.md
+++ b/doc/src/backport_policy.md
@@ -1,0 +1,12 @@
+# Backport Policy
+
+The backport policy defines what changes from the unstable (master) branch are
+applied to the current stable (`release-*.*`) branch.
+
+To reduce maintenance efforts and improve stability on stable branches, security
+fixes, bug fixes, and CI changes are backported, while new features, modules,
+and theme improvements are not backported. Upstream changes causing theming
+issues are considered a bug.
+
+New modules and theme improvements may be backported when explicitly requested
+and backporting is trivial.


### PR DESCRIPTION
```
Initialize a backport policy to avoid ambiguity and reduce maintenance
efforts.
```

Adding the backport policy was first mentioned in https://github.com/nix-community/stylix/pull/2116#pullrequestreview-3662827719.

Here is the output of `nix run .#doc`:

<img width="1246" height="688" alt="image" src="https://github.com/user-attachments/assets/24cbe768-6c93-4138-80b3-ee299cf7cbd8" />

---

- [X] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [X] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [X] Each commit in this PR is suitable for backport to the current stable branch
  - Let's backport this for good measure, although it goes against the proposed backport policy.
