### PR TITLE
foot: set colors manually instead of relying on tinted-theming

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -188,7 +188,6 @@
         "nixpkgs": "nixpkgs",
         "nur": "nur",
         "systems": "systems",
-        "tinted-foot": "tinted-foot",
         "tinted-kitty": "tinted-kitty",
         "tinted-schemes": "tinted-schemes",
         "tinted-tmux": "tinted-tmux",
@@ -207,23 +206,6 @@
       "original": {
         "owner": "nix-systems",
         "repo": "default",
-        "type": "github"
-      }
-    },
-    "tinted-foot": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1726913040,
-        "narHash": "sha256-+eDZPkw7efMNUf3/Pv0EmsidqdwNJ1TaOum6k7lngDQ=",
-        "owner": "tinted-theming",
-        "repo": "tinted-foot",
-        "rev": "fd1b924b6c45c3e4465e8a849e67ea82933fcbe4",
-        "type": "github"
-      },
-      "original": {
-        "owner": "tinted-theming",
-        "repo": "tinted-foot",
-        "rev": "fd1b924b6c45c3e4465e8a849e67ea82933fcbe4",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -63,18 +63,6 @@
       };
     };
 
-    tinted-foot = {
-      # Lock the tinted-foot input to prevent upstream breaking changes.
-      #
-      # Considering that Stylix eventually re-implements this input's
-      # functionality [1], it might be easiest to lock this input to avoid
-      # wasted maintenance effort.
-      #
-      # [1]: https://github.com/nix-community/stylix/issues/571
-      url = "github:tinted-theming/tinted-foot/fd1b924b6c45c3e4465e8a849e67ea82933fcbe4";
-      flake = false;
-    };
-
     tinted-kitty = {
       url = "github:tinted-theming/tinted-kitty";
       flake = false;

--- a/modules/foot/hm.nix
+++ b/modules/foot/hm.nix
@@ -1,4 +1,4 @@
-{ lib, mkTarget, ... }:
+{ mkTarget, ... }:
 mkTarget {
   config = [
     (
@@ -11,19 +11,45 @@ mkTarget {
       }
     )
     (
-      { opacity }:
       {
-        programs.foot.settings.colors.alpha = opacity.terminal;
-      }
-    )
-    (
-      { colors, inputs }:
+        polarity,
+        opacity,
+        colors,
+      }:
+      let
+        colorTheme = if polarity == "either" then "light" else polarity;
+      in
       {
-        programs.foot.settings.main.include = lib.singleton (
-          toString (colors {
-            templateRepo = inputs.tinted-foot;
-          })
-        );
+        programs.foot.settings = {
+          main.initial-color-theme = colorTheme;
+          "colors-${colorTheme}" = {
+            alpha = opacity.terminal;
+            foreground = colors.base05;
+            background = colors.base00;
+            regular0 = colors.base00;
+            regular1 = colors.base08;
+            regular2 = colors.base0B;
+            regular3 = colors.base0A;
+            regular4 = colors.base0D;
+            regular5 = colors.base0E;
+            regular6 = colors.base0C;
+            regular7 = colors.base05;
+            bright0 = colors.base03;
+            bright1 = colors.base08;
+            bright2 = colors.base0B;
+            bright3 = colors.base0A;
+            bright4 = colors.base0D;
+            bright5 = colors.base0E;
+            bright6 = colors.base0C;
+            bright7 = colors.base07;
+            "16" = colors.base09;
+            "17" = colors.base0F;
+            "18" = colors.base01;
+            "19" = colors.base02;
+            "20" = colors.base04;
+            "21" = colors.base06;
+          };
+        };
       }
     )
   ];


### PR DESCRIPTION
Removes the tinted-theming input for foot and instead manually set the colors.

The testbed won't work until the inputs get updated but updating breaks the gnome shell colors patch

fixes #2234

<!-- Describe your PR above, following Stylix commit conventions. -->

---

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->

- [x] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [x] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [x] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [ ] Each commit in this PR is suitable for backport to the current stable branch
