### PR TITLE
zen-browser: fix theming

### DIFF
--- a/flake/dev/flake.lock
+++ b/flake/dev/flake.lock
@@ -358,11 +358,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1767763594,
-        "narHash": "sha256-5ysv8EuVAgDoYmNuXEUNf7vBzdeRaFxeIlIndv5HMvs=",
+        "lastModified": 1773290887,
+        "narHash": "sha256-L1yMYmFffHfZNP+hKJGRBmrFKkn/VDhu7jEbVftBQuM=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "8b2302d8c10369c9135552cc892da75cff5ddb03",
+        "rev": "9346698c4562819f61b4e5097151ec0b17729fab",
         "type": "github"
       },
       "original": {

--- a/modules/zen-browser/userChrome.nix
+++ b/modules/zen-browser/userChrome.nix
@@ -31,6 +31,11 @@ with colors;
     color: #${base05-hex} !important;
   }
 
+  #historySwipeAnimationPreviousArrow,#historySwipeAnimationNextArrow {
+    --swipe-nav-icon-primary-color: #${base0D-hex} !important;
+    --swipe-nav-icon-accent-color: #${base00-hex} !important;
+  }
+
   .sidebar-placesTree {
     background-color: #${base00-hex} !important;
   }

--- a/modules/zen-browser/userChrome.nix
+++ b/modules/zen-browser/userChrome.nix
@@ -24,6 +24,7 @@ with colors;
     --zen-themed-toolbar-bg: #${base00-hex} !important;
     --zen-main-browser-background: #${base00-hex} !important;
     --toolbox-bgcolor-inactive: #${base01-hex} !important;
+    --zen-themed-toolbar-bg-transparent: #${base01-hex} !important;
   }
 
   #permissions-granted-icon {
@@ -125,12 +126,20 @@ with colors;
     --identity-icon-color: #${base0F-hex} !important;
   }
 
-  #navigator-toolbox {
+  #zen-toolbar-background {
     --zen-main-browser-background-toolbar: #${base00-hex} !important;
   }
 
   #zen-appcontent-navbar-container {
     background-color: #${base00-hex} !important;
+  }
+
+  #commonDialog {
+    background-color: #${base00-hex} !important;
+  }
+
+  #zen-browser-background {
+    --zen-main-browser-background: #${base00-hex} !important;
   }
 
   #contentAreaContextMenu menu,


### PR DESCRIPTION
In a recent zen twilight updates, some elements got moved around. This pr includes a fix for that, and also themes the previously unthemed back/forward history animation arrows.
These changes are taken from https://github.com/catppuccin/zen-browser/pull/61 and slightly modified.

f890f7a5f9793452c057acc52a8a30f741d6cc92 fixes this (and adds background-color theming to dialog popups):
| Original | Fixed |
| :---: | :---: |
| <img width="300" alt="image" src="https://github.com/user-attachments/assets/f93978be-6280-474b-ac03-f0758d969d6b" /> | <img width="300" alt="image" src="https://github.com/user-attachments/assets/debdf3db-c79f-40a1-a410-df24698da623" /> |

2fdb6db0dc8df27699e11dcd21e61818b0fa568b themes the previously unthemed history swipe arrows:
| Original | Fixed |
| :---: | :---: |
| <img width="200" alt="image" src="https://github.com/user-attachments/assets/f401cc41-c05d-4955-b9f8-4feac79b1e2f" /> | <img width="200" alt="image" src="https://github.com/user-attachments/assets/01a45da3-27af-44db-b3f3-94fe3c9b1b5c" /> |
<!-- Describe your PR above, following Stylix commit conventions. -->

---

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [x] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [x] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [x] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [x] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [x] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [x] Each commit in this PR is suitable for backport to the current stable branch
