### PR TITLE
firefox: support Glide derivative

### DIFF
--- a/flake/dev/flake.lock
+++ b/flake/dev/flake.lock
@@ -113,6 +113,29 @@
         "type": "github"
       }
     },
+    "glide": {
+      "inputs": {
+        "home-manager": [
+          "home-manager"
+        ],
+        "nixpkgs": [
+          "dev-nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1779668702,
+        "narHash": "sha256-voOAZYH429fsPg2PBRXtHP0yWXhtGOmTfl0I03uNwfA=",
+        "owner": "glide-browser",
+        "repo": "glide.nix",
+        "rev": "287f90235434f7e574dccebed3a4caa1ca443d1d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "glide-browser",
+        "repo": "glide.nix",
+        "type": "github"
+      }
+    },
     "home-manager": {
       "inputs": {
         "nixpkgs": [
@@ -281,6 +304,7 @@
         "dev-systems": "dev-systems",
         "flake-compat": "flake-compat",
         "git-hooks": "git-hooks",
+        "glide": "glide",
         "home-manager": "home-manager",
         "nixvim": "nixvim",
         "noctalia-shell": "noctalia-shell",

--- a/flake/dev/flake.nix
+++ b/flake/dev/flake.nix
@@ -149,6 +149,14 @@
       };
     };
 
+    glide = {
+      url = "github:glide-browser/glide.nix";
+      inputs = {
+        nixpkgs.follows = "dev-nixpkgs";
+        home-manager.follows = "home-manager";
+      };
+    };
+
     home-manager = {
       url = "github:nix-community/home-manager";
       inputs.nixpkgs.follows = "dev-nixpkgs";

--- a/modules/firefox/hm.nix
+++ b/modules/firefox/hm.nix
@@ -10,5 +10,6 @@
         "firefox" = "Firefox";
         "librewolf" = "LibreWolf";
         "floorp" = "Floorp";
+        "glide-browser" = "Glide";
       };
 }

--- a/modules/firefox/meta.nix
+++ b/modules/firefox/meta.nix
@@ -5,15 +5,17 @@
     Firefox = "http://www.mozilla.com/en-US/firefox";
     Floorp = "https://floorp.app";
     LibreWolf = "https://librewolf.net";
+    Glide = "https://glide-browser.app";
   };
   maintainers = with lib.maintainers; [
     Flameopathic
     danth
     naho
+    zzzealed
   ];
   description = ''
     This module supports [Firefox](https://www.mozilla.org/firefox), in addition
-    to [Floorp](https://floorp.app) and [LibreWolf](https://librewolf.net),
+    to [Floorp](https://floorp.app), [LibreWolf](https://librewolf.net) and [Glide](https://glide-browser.app),
     which are Firefox derivatives.
 
     The same implementation is shared between all of these browsers, but they don't

--- a/modules/firefox/meta.nix
+++ b/modules/firefox/meta.nix
@@ -15,8 +15,8 @@
   ];
   description = ''
     This module supports [Firefox](https://www.mozilla.org/firefox), in addition
-    to [Floorp](https://floorp.app), [LibreWolf](https://librewolf.net) and [Glide](https://glide-browser.app),
-    which are Firefox derivatives.
+    to [Floorp](https://floorp.app), [LibreWolf](https://librewolf.net) and
+    [Glide](https://glide-browser.app), which are Firefox derivatives.
 
     The same implementation is shared between all of these browsers, but they don't
     share option values.

--- a/modules/firefox/meta.nix
+++ b/modules/firefox/meta.nix
@@ -11,7 +11,6 @@
     Flameopathic
     danth
     naho
-    zzzealed
   ];
   description = ''
     This module supports [Firefox](https://www.mozilla.org/firefox), in addition

--- a/modules/firefox/meta.nix
+++ b/modules/firefox/meta.nix
@@ -4,8 +4,8 @@
   homepage = {
     Firefox = "http://www.mozilla.com/en-US/firefox";
     Floorp = "https://floorp.app";
-    LibreWolf = "https://librewolf.net";
     Glide = "https://glide-browser.app";
+    LibreWolf = "https://librewolf.net";
   };
   maintainers = with lib.maintainers; [
     Flameopathic

--- a/modules/firefox/meta.nix
+++ b/modules/firefox/meta.nix
@@ -5,6 +5,7 @@
     Firefox = "http://www.mozilla.com/en-US/firefox";
     Floorp = "https://floorp.app";
     LibreWolf = "https://librewolf.net";
+    Glide = "https://glide-browser.app";
   };
   maintainers = with lib.maintainers; [
     Flameopathic
@@ -14,8 +15,8 @@
   ];
   description = ''
     This module supports [Firefox](https://www.mozilla.org/firefox), in addition
-    to [Floorp](https://floorp.app) and [LibreWolf](https://librewolf.net),
-    which are Firefox derivatives.
+    to [Floorp](https://floorp.app), [LibreWolf](https://librewolf.net), and
+    [Glide](https://glide-browser.app), which are Firefox derivatives.
 
     The same implementation is shared between all of these browsers, but they don't
     share option values.

--- a/modules/firefox/meta.nix
+++ b/modules/firefox/meta.nix
@@ -10,6 +10,7 @@
     Flameopathic
     danth
     noahbiewesch
+    zeal
   ];
   description = ''
     This module supports [Firefox](https://www.mozilla.org/firefox), in addition

--- a/modules/firefox/testbeds/glide-browser.nix
+++ b/modules/firefox/testbeds/glide-browser.nix
@@ -1,18 +1,13 @@
-{ lib, pkgs, inputs, ... }:
+{ lib, ... }:
 let
-  package = inputs.glide.packages.${pkgs.stdenv.hostPlatform.system}.default;
   profileName = "stylix";
 in
 {
-  stylix.testbed.ui.application = {
-    name = "glide";
-    inherit package;
-  };
+  stylix.testbed.ui.command.text = "glide";
 
   home-manager.sharedModules = lib.singleton {
     programs.glide-browser = {
       enable = true;
-      inherit package;
       profiles.${profileName}.isDefault = true;
     };
 

--- a/modules/firefox/testbeds/glide.nix
+++ b/modules/firefox/testbeds/glide.nix
@@ -1,0 +1,21 @@
+{ lib, pkgs, inputs, ... }:
+let
+  package = inputs.glide.packages.${pkgs.stdenv.hostPlatform.system}.default;
+  profileName = "stylix";
+in
+{
+  stylix.testbed.ui.application = {
+    name = "glide";
+    inherit package;
+  };
+
+  home-manager.sharedModules = lib.singleton {
+    programs.glide-browser = {
+      enable = true;
+      inherit package;
+      profiles.${profileName}.isDefault = true;
+    };
+
+    stylix.targets.glide-browser.profileNames = [ profileName ];
+  };
+}

--- a/stylix/maintainers.nix
+++ b/stylix/maintainers.nix
@@ -89,5 +89,11 @@
     github = "vidhanio";
     githubId = 41439633;
   };
+  zeal = {
+    email = "zzzealed@proton.me";
+    name = "Mads Jensen";
+    github = "zzzealed";
+    githubId = 108904280;
+  };
   # keep-sorted end
 }

--- a/stylix/testbed/default.nix
+++ b/stylix/testbed/default.nix
@@ -39,6 +39,10 @@ let
                 inputs.dankMaterialShell.homeModules.dank-material-shell
               ];
 
+              glide-browser.home-manager.sharedModules = [
+                inputs.glide.homeModules.default
+              ];
+
               nixvim-integrated = inputs.nixvim.nixosModules.nixvim;
 
               nixvim-standalone.lib.stylix.testbed = {


### PR DESCRIPTION
Hello and thanks for your work on Stylix :)

I added [Glide](https://glide-browser.app) to the Firefox (and derivatives)-module, since Glide now has a Home Manager-module made with `mkFirefoxModule`. This means it should be compatible with the same options as the other derivatives.

I tested this myself and can confirm that the options looks to be working.

I hope I added everything correctly, as this is my first time making a contribution. Please do not hesitate to leave feedback or request changes.

<!-- Describe your PR above, following Stylix commit conventions. -->

---

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [x] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [ ] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [x] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [x] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [x] Each commit in this PR is suitable for backport to the current stable branch
