### PR TITLE
zellij: fix theme config by using color triples instead of hashed hexes

### DIFF
--- a/modules/zellij/hm.nix
+++ b/modules/zellij/hm.nix
@@ -2,125 +2,135 @@
 mkTarget {
   config =
     { colors }:
+    let
+      # makes an array of the rgb components, parsing them as numbers
+      mkColorTriple =
+        name:
+        (map (color: builtins.fromJSON colors."${name}-rgb-${color}") [
+          "r"
+          "g"
+          "b"
+        ]);
+    in
     {
       programs.zellij.themes.stylix = {
-        themes = with colors.withHashtag; {
+        themes = {
           default = {
             text_unselected = {
-              base = base05;
-              background = base01;
-              emphasis_0 = base09;
-              emphasis_1 = base0C;
-              emphasis_2 = base0B;
-              emphasis_3 = base0F;
+              base = mkColorTriple "base05";
+              background = mkColorTriple "base01";
+              emphasis_0 = mkColorTriple "base09";
+              emphasis_1 = mkColorTriple "base0C";
+              emphasis_2 = mkColorTriple "base0B";
+              emphasis_3 = mkColorTriple "base0F";
             };
             text_selected = {
-              base = base05;
-              background = base04;
-              emphasis_0 = base09;
-              emphasis_1 = base0C;
-              emphasis_2 = base0B;
-              emphasis_3 = base0F;
+              base = mkColorTriple "base05";
+              background = mkColorTriple "base04";
+              emphasis_0 = mkColorTriple "base09";
+              emphasis_1 = mkColorTriple "base0C";
+              emphasis_2 = mkColorTriple "base0B";
+              emphasis_3 = mkColorTriple "base0F";
             };
             ribbon_selected = {
-              base = base01;
-              background = base0E;
-              emphasis_0 = base08;
-              emphasis_1 = base09;
-              emphasis_2 = base0F;
-              emphasis_3 = base0D;
+              base = mkColorTriple "base01";
+              background = mkColorTriple "base0E";
+              emphasis_0 = mkColorTriple "base08";
+              emphasis_1 = mkColorTriple "base09";
+              emphasis_2 = mkColorTriple "base0F";
+              emphasis_3 = mkColorTriple "base0D";
             };
             ribbon_unselected = {
-              base = base05;
-              background = base02;
-              emphasis_0 = base08;
-              emphasis_1 = base05;
-              emphasis_2 = base0D;
-              emphasis_3 = base0F;
+              base = mkColorTriple "base05";
+              background = mkColorTriple "base02";
+              emphasis_0 = mkColorTriple "base08";
+              emphasis_1 = mkColorTriple "base05";
+              emphasis_2 = mkColorTriple "base0D";
+              emphasis_3 = mkColorTriple "base0F";
             };
             table_title = {
-              base = base0E;
-              background = base00;
-              emphasis_0 = base09;
-              emphasis_1 = base0C;
-              emphasis_2 = base0B;
-              emphasis_3 = base0F;
+              base = mkColorTriple "base0E";
+              background = mkColorTriple "base00";
+              emphasis_0 = mkColorTriple "base09";
+              emphasis_1 = mkColorTriple "base0C";
+              emphasis_2 = mkColorTriple "base0B";
+              emphasis_3 = mkColorTriple "base0F";
             };
             table_cell_selected = {
-              base = base05;
-              background = base04;
-              emphasis_0 = base09;
-              emphasis_1 = base0C;
-              emphasis_2 = base0B;
-              emphasis_3 = base0F;
+              base = mkColorTriple "base05";
+              background = mkColorTriple "base04";
+              emphasis_0 = mkColorTriple "base09";
+              emphasis_1 = mkColorTriple "base0C";
+              emphasis_2 = mkColorTriple "base0B";
+              emphasis_3 = mkColorTriple "base0F";
             };
             table_cell_unselected = {
-              base = base05;
-              background = base01;
-              emphasis_0 = base09;
-              emphasis_1 = base0C;
-              emphasis_2 = base0B;
-              emphasis_3 = base0F;
+              base = mkColorTriple "base05";
+              background = mkColorTriple "base01";
+              emphasis_0 = mkColorTriple "base09";
+              emphasis_1 = mkColorTriple "base0C";
+              emphasis_2 = mkColorTriple "base0B";
+              emphasis_3 = mkColorTriple "base0F";
             };
             list_selected = {
-              base = base05;
-              background = base04;
-              emphasis_0 = base09;
-              emphasis_1 = base0C;
-              emphasis_2 = base0B;
-              emphasis_3 = base0F;
+              base = mkColorTriple "base05";
+              background = mkColorTriple "base04";
+              emphasis_0 = mkColorTriple "base09";
+              emphasis_1 = mkColorTriple "base0C";
+              emphasis_2 = mkColorTriple "base0B";
+              emphasis_3 = mkColorTriple "base0F";
             };
             list_unselected = {
-              base = base05;
-              background = base01;
-              emphasis_0 = base09;
-              emphasis_1 = base0C;
-              emphasis_2 = base0B;
-              emphasis_3 = base0F;
+              base = mkColorTriple "base05";
+              background = mkColorTriple "base01";
+              emphasis_0 = mkColorTriple "base09";
+              emphasis_1 = mkColorTriple "base0C";
+              emphasis_2 = mkColorTriple "base0B";
+              emphasis_3 = mkColorTriple "base0F";
             };
             frame_selected = {
-              base = base0E;
-              background = base00;
-              emphasis_0 = base09;
-              emphasis_1 = base0C;
-              emphasis_2 = base0F;
-              emphasis_3 = base00;
+              base = mkColorTriple "base0E";
+              background = mkColorTriple "base00";
+              emphasis_0 = mkColorTriple "base09";
+              emphasis_1 = mkColorTriple "base0C";
+              emphasis_2 = mkColorTriple "base0F";
+              emphasis_3 = mkColorTriple "base00";
             };
             frame_highlight = {
-              base = base08;
-              background = base00;
-              emphasis_0 = base0F;
-              emphasis_1 = base09;
-              emphasis_2 = base09;
-              emphasis_3 = base09;
+              base = mkColorTriple "base08";
+              background = mkColorTriple "base00";
+              emphasis_0 = mkColorTriple "base0F";
+              emphasis_1 = mkColorTriple "base09";
+              emphasis_2 = mkColorTriple "base09";
+              emphasis_3 = mkColorTriple "base09";
             };
             exit_code_success = {
-              base = base0B;
-              background = base00;
-              emphasis_0 = base0C;
-              emphasis_1 = base01;
-              emphasis_2 = base0F;
-              emphasis_3 = base0D;
+              base = mkColorTriple "base0B";
+              background = mkColorTriple "base00";
+              emphasis_0 = mkColorTriple "base0C";
+              emphasis_1 = mkColorTriple "base01";
+              emphasis_2 = mkColorTriple "base0F";
+              emphasis_3 = mkColorTriple "base0D";
             };
             exit_code_error = {
-              base = base08;
-              background = base00;
-              emphasis_0 = base0A;
-              emphasis_1 = base00;
-              emphasis_2 = base00;
-              emphasis_3 = base00;
+              base = mkColorTriple "base08";
+              background = mkColorTriple "base00";
+              emphasis_0 = mkColorTriple "base0A";
+              emphasis_1 = mkColorTriple "base00";
+              emphasis_2 = mkColorTriple "base00";
+              emphasis_3 = mkColorTriple "base00";
             };
             multiplayer_user_colors = {
-              player_1 = base0F;
-              player_2 = base0D;
-              player_3 = base00;
-              player_4 = base0A;
-              player_5 = base0C;
-              player_6 = base00;
-              player_7 = base08;
-              player_8 = base00;
-              player_9 = base00;
-              player_10 = base00;
+              player_1 = mkColorTriple "base0F";
+              player_2 = mkColorTriple "base0D";
+              player_3 = mkColorTriple "base00";
+              player_4 = mkColorTriple "base0A";
+              player_5 = mkColorTriple "base0C";
+              player_6 = mkColorTriple "base00";
+              player_7 = mkColorTriple "base08";
+              player_8 = mkColorTriple "base00";
+              player_9 = mkColorTriple "base00";
+              player_10 = mkColorTriple "base00";
             };
           };
         };


### PR DESCRIPTION
Previously, the Zellij module was using hex strings for the Zellij configuration. [Zellij expects a triple of integers for colors.](https://zellij.dev/documentation/themes.html#structure-of-a-theme-definition)

This PR ensures the generated theme for Zellij uses the integer triples instead of hex strings.

---

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [x] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [x] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [x] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [x] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [x] Each commit in this PR is suitable for backport to the current stable branch
