### PR TITLE
ci: update-flake: preserve existing commits on branch

### DIFF
--- a/.github/workflows/update-flake.yml
+++ b/.github/workflows/update-flake.yml
@@ -28,7 +28,7 @@ jobs:
 
       - uses: actions/checkout@v6
         with:
-          ref: ${{ matrix.branch }}
+          ref: update_flake_lock_action_${{ matrix.branch }}
           token: ${{ steps.generate-token.outputs.token }}
 
       - uses: cachix/install-nix-action@v31
@@ -54,6 +54,12 @@ jobs:
         run: |
           git config --global user.name "$name"
           git config --global user.email "$email"
+
+      - name: rebase branch
+        env:
+          base_branch: ${{ matrix.branch }}
+        run: |
+          git pull origin "$base_branch" --rebase
 
       - name: update lock files
         run: |
@@ -83,8 +89,7 @@ jobs:
           pr_branch: update_flake_lock_action_${{ matrix.branch }}
           title: "${{ startsWith(matrix.branch, 'release') && format('[{0}] ', matrix.branch) || '' }}flake: update all inputs"  # yamllint disable-line rule:line-length
         run: |
-          git switch --create "$pr_branch"
-          git push origin "$pr_branch" --force --set-upstream
+          git push origin "$pr_branch"
 
           pr_count="$(
             gh api \


### PR DESCRIPTION
```
prevents this workflow from pushing over existing commits, as was encountered in #2180

Link: https://github.com/nix-community/stylix/pull/2180
```


<!-- Describe your PR above, following Stylix commit conventions. -->

---

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [x] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [x] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [x] Each commit in this PR is suitable for backport to the current stable branch
