### PR TITLE
obsidian: include both light and dark themes when polarity is either

### DIFF
--- a/modules/obsidian/hm.nix
+++ b/modules/obsidian/hm.nix
@@ -32,56 +32,50 @@ mkTarget {
         colors,
         polarity,
       }:
+      let
+        themeSelectors =
+          if polarity == "either" then
+            [
+              "light"
+              "dark"
+            ]
+          else
+            [ polarity ];
+
+        mkSnippet =
+          selector: with colors.withHashtag; ''
+            .theme-${selector} {
+                /* Base Colors */
+                --color-base-00: ${base00};
+                --color-base-05: ${base00};
+                --color-base-10: ${base00};
+                --color-base-20: ${base01};
+                --color-base-25: ${base01};
+                --color-base-30: ${base02};
+                --color-base-35: ${base02};
+                --color-base-40: ${base03};
+                --color-base-50: ${base03};
+                --color-base-60: ${base04};
+                --color-base-70: ${base04};
+                --color-base-100: ${base05};
+
+                --color-accent: ${base0E};
+                --color-accent-1: ${base0E};
+            }
+          '';
+      in
       {
-        programs.obsidian.defaultSettings.cssSnippets = with colors.withHashtag; [
+        programs.obsidian.defaultSettings.cssSnippets = [
           {
             name = "Stylix Config";
-            text = ''
-              .theme-${polarity} {
-                  /* Base Colors */
-                  --color-base-00: ${base00};
-                  --color-base-05: ${base00};
-                  --color-base-10: ${base00};
-                  --color-base-20: ${base01};
-                  --color-base-25: ${base01};
-                  --color-base-30: ${base02};
-                  --color-base-35: ${base02};
-                  --color-base-40: ${base03};
-                  --color-base-50: ${base03};
-                  --color-base-60: ${base04};
-                  --color-base-70: ${base04};
-                  --color-base-100: ${base05};
-
-                  --color-accent: ${base0E};
-                  --color-accent-1: ${base0E};
-              }
-            '';
+            text = lib.concatStrings (map mkSnippet themeSelectors);
           }
         ];
         programs.obsidian.vaults = lib.genAttrs cfg.vaultNames (_: {
-          settings.cssSnippets = with colors.withHashtag; [
+          settings.cssSnippets = [
             {
               name = "Stylix Config";
-              text = ''
-                .theme-${polarity} {
-                    /* Base Colors */
-                    --color-base-00: ${base00};
-                    --color-base-05: ${base00};
-                    --color-base-10: ${base00};
-                    --color-base-20: ${base01};
-                    --color-base-25: ${base01};
-                    --color-base-30: ${base02};
-                    --color-base-35: ${base02};
-                    --color-base-40: ${base03};
-                    --color-base-50: ${base03};
-                    --color-base-60: ${base04};
-                    --color-base-70: ${base04};
-                    --color-base-100: ${base05};
-
-                    --color-accent: ${base0E};
-                    --color-accent-1: ${base0E};
-                }
-              '';
+              text = lib.concatStrings (map mkSnippet themeSelectors);
             }
           ];
         });

--- a/modules/obsidian/hm.nix
+++ b/modules/obsidian/hm.nix
@@ -33,49 +33,58 @@ mkTarget {
         polarity,
       }:
       let
-        themeSelectors =
-          if polarity == "either" then
-            [
-              "light"
-              "dark"
-            ]
-          else
-            [ polarity ];
-
-        mkSnippet =
-          selector: with colors.withHashtag; ''
-            .theme-${selector} {
-                /* Base Colors */
-                --color-base-00: ${base00};
-                --color-base-05: ${base00};
-                --color-base-10: ${base00};
-                --color-base-20: ${base01};
-                --color-base-25: ${base01};
-                --color-base-30: ${base02};
-                --color-base-35: ${base02};
-                --color-base-40: ${base03};
-                --color-base-50: ${base03};
-                --color-base-60: ${base04};
-                --color-base-70: ${base04};
-                --color-base-100: ${base05};
-
-                --color-accent: ${base0E};
-                --color-accent-1: ${base0E};
-            }
-          '';
+        polarity' = if polarity == "dark" then polarity else "light";
       in
       {
-        programs.obsidian.defaultSettings.cssSnippets = [
+        programs.obsidian.defaultSettings.cssSnippets = with colors.withHashtag; [
           {
             name = "Stylix Config";
-            text = lib.concatStrings (map mkSnippet themeSelectors);
+            text = ''
+              .theme-${polarity'} {
+                  /* Base Colors */
+                  --color-base-00: ${base00};
+                  --color-base-05: ${base00};
+                  --color-base-10: ${base00};
+                  --color-base-20: ${base01};
+                  --color-base-25: ${base01};
+                  --color-base-30: ${base02};
+                  --color-base-35: ${base02};
+                  --color-base-40: ${base03};
+                  --color-base-50: ${base03};
+                  --color-base-60: ${base04};
+                  --color-base-70: ${base04};
+                  --color-base-100: ${base05};
+
+                  --color-accent: ${base0E};
+                  --color-accent-1: ${base0E};
+              }
+            '';
           }
         ];
         programs.obsidian.vaults = lib.genAttrs cfg.vaultNames (_: {
-          settings.cssSnippets = [
+          settings.cssSnippets = with colors.withHashtag; [
             {
               name = "Stylix Config";
-              text = lib.concatStrings (map mkSnippet themeSelectors);
+              text = ''
+                .theme-${polarity'} {
+                    /* Base Colors */
+                    --color-base-00: ${base00};
+                    --color-base-05: ${base00};
+                    --color-base-10: ${base00};
+                    --color-base-20: ${base01};
+                    --color-base-25: ${base01};
+                    --color-base-30: ${base02};
+                    --color-base-35: ${base02};
+                    --color-base-40: ${base03};
+                    --color-base-50: ${base03};
+                    --color-base-60: ${base04};
+                    --color-base-70: ${base04};
+                    --color-base-100: ${base05};
+
+                    --color-accent: ${base0E};
+                    --color-accent-1: ${base0E};
+                }
+              '';
             }
           ];
         });


### PR DESCRIPTION
When `stylix.polarity` is set to `"either"`, the obsidian module generates a CSS snippet with the selector `.theme-either`, which is not a valid Obsidian theme class. This causes the stylix theme to silently fail to apply in Obsidian.

This change generates CSS for both `.theme-light` and `.theme-dark` when polarity is `"either"`, ensuring the stylix colors apply regardless of whether Obsidian is in light mode, dark mode, or set to adapt to system.

For `"light"` or `"dark"` polarity, behavior is unchanged.