### PR TITLE
qt: generate qt6ct/qt5ct color scheme from Base16 palette

### DIFF
--- a/modules/qt/hm.nix
+++ b/modules/qt/hm.nix
@@ -85,6 +85,99 @@
           cp ${kvconfig} "$directory/Base16Kvantum.kvconfig"
           cp ${svg} "$directory/Base16Kvantum.svg"
         '';
+
+      palette = config.lib.stylix.colors.withHashtag;
+
+      # Base16 inverts base00..base07 luminance between dark and light
+      # themes, so the Light/Midlight/Dark/Mid/Shadow shade ramp around
+      # Button (base02) has to flip on light schemes or Fusion bevels
+      # render upside-down. Users on the default `either` polarity get
+      # the dark ramp, since most generator outputs end up dark.
+      isDark = config.stylix.polarity != "light";
+      shadeDark = if isDark then palette.base00 else palette.base04;
+      shadeMid = if isDark then palette.base01 else palette.base03;
+      shadeMidlight = if isDark then palette.base03 else palette.base01;
+      shadeLight = if isDark then palette.base04 else palette.base00;
+
+      # QPalette::ColorRole order 0..20. qt6ct's parser iterates the
+      # enum directly. Accent (21, Qt 6.6+) is auto-filled from
+      # Highlight by qt6ct when the row has 21 entries, so omitting it
+      # is forward-compatible. Roles overlapping kvconfig.mustache use
+      # the same Base16 slot to keep mixed Kvantum + QtQuick UIs
+      # visually consistent.
+      activePaletteRoles = [
+        palette.base05 # 0  WindowText      (kvconfig: window.text.color)
+        palette.base02 # 1  Button          (kvconfig: button.color)
+        shadeLight # 2  Light
+        shadeMidlight # 3  Midlight
+        shadeDark # 4  Dark
+        shadeMid # 5  Mid
+        palette.base05 # 6  Text            (kvconfig: text.color)
+        palette.base07 # 7  BrightText      (Qt high-contrast Text fallback)
+        palette.base05 # 8  ButtonText      (kvconfig: button.text.color)
+        palette.base00 # 9  Base            (kvconfig: base.color)
+        palette.base01 # 10 Window          (kvconfig: window.color)
+        shadeDark # 11 Shadow
+        palette.base0E # 12 Highlight       (kvconfig: highlight.color)
+        # HighlightedText diverges from kvconfig.mustache (base00):
+        # on schemes where Highlight (base0E) and Window (base01)
+        # collapse toward similar luminance, base00 makes selected
+        # text unreadable. base05 keeps high contrast against any
+        # Highlight choice.
+        palette.base05 # 13 HighlightedText
+        palette.base0D # 14 Link            (kvconfig: link.color)
+        palette.base0E # 15 LinkVisited     (kvconfig: link.visited.color)
+        palette.base01 # 16 AlternateBase   (kvconfig: alt.base.color)
+        palette.base00 # 17 NoRole
+        palette.base01 # 18 ToolTipBase
+        palette.base05 # 19 ToolTipText     (kvconfig: tooltip.text.color)
+        palette.base04 # 20 PlaceholderText
+      ];
+
+      # Inactive: only Highlight differs (base03), matching kvconfig
+      # `inactive.highlight.color`.
+      inactivePaletteRoles = lib.imap0 (
+        i: v: if i == 12 then palette.base03 else v
+      ) activePaletteRoles;
+
+      # Disabled: foregrounds and accent collapse to muted base02..base04;
+      # backgrounds and shade ramp match active to preserve silhouette.
+      # Without a distinct disabled row, Qt no longer auto-greys widgets
+      # under a custom palette, so disabled controls would render
+      # identical to enabled ones.
+      disabledPaletteRoles = [
+        palette.base04 # 0  WindowText
+        palette.base02 # 1  Button
+        shadeLight # 2  Light
+        shadeMidlight # 3  Midlight
+        shadeDark # 4  Dark
+        shadeMid # 5  Mid
+        palette.base04 # 6  Text
+        palette.base04 # 7  BrightText
+        palette.base04 # 8  ButtonText
+        palette.base00 # 9  Base
+        palette.base01 # 10 Window
+        shadeDark # 11 Shadow
+        palette.base02 # 12 Highlight
+        palette.base04 # 13 HighlightedText
+        palette.base04 # 14 Link
+        palette.base04 # 15 LinkVisited
+        palette.base01 # 16 AlternateBase
+        palette.base00 # 17 NoRole
+        palette.base01 # 18 ToolTipBase
+        palette.base04 # 19 ToolTipText
+        palette.base03 # 20 PlaceholderText
+      ];
+
+      toArgb = c: "#ff${lib.removePrefix "#" c}";
+      formatRow = colours: lib.concatStringsSep ", " (map toArgb colours);
+
+      schemeText = ''
+        [ColorScheme]
+        active_colors=${formatRow activePaletteRoles}
+        inactive_colors=${formatRow inactivePaletteRoles}
+        disabled_colors=${formatRow disabledPaletteRoles}
+      '';
     in
     {
       warnings =
@@ -97,12 +190,13 @@
 
       qt =
         let
-          qtctSettings = {
+          qtctSettings = qtct: {
             Appearance = {
               custom_palette = true;
               standard_dialogs = config.stylix.targets.qt.standardDialogs;
               style = lib.mkIf (config.qt.style ? name) config.qt.style.name;
               icon_theme = lib.mkIf (icons != null) icons;
+              color_scheme_path = "${config.xdg.configHome}/${qtct}/colors/stylix.conf";
             };
 
             Fonts = {
@@ -116,8 +210,12 @@
           style.name = recommendedStyle;
           platformTheme.name = config.stylix.targets.qt.platform;
 
-          qt5ctSettings = lib.mkIf (config.qt.platformTheme.name == "qtct") qtctSettings;
-          qt6ctSettings = lib.mkIf (config.qt.platformTheme.name == "qtct") qtctSettings;
+          qt5ctSettings = lib.mkIf (config.qt.platformTheme.name == "qtct") (
+            qtctSettings "qt5ct"
+          );
+          qt6ctSettings = lib.mkIf (config.qt.platformTheme.name == "qtct") (
+            qtctSettings "qt6ct"
+          );
 
           kvantum = lib.mkIf (config.qt.style.name == "kvantum") {
             enable = true;
@@ -125,6 +223,11 @@
             themes = [ kvantumPackage ];
           };
         };
+
+      xdg.configFile = lib.mkIf (config.qt.platformTheme.name == "qtct") {
+        "qt5ct/colors/stylix.conf".text = schemeText;
+        "qt6ct/colors/stylix.conf".text = schemeText;
+      };
     }
   );
 }

--- a/modules/qt/hm.nix
+++ b/modules/qt/hm.nix
@@ -129,7 +129,7 @@
         palette.base0E # 15 LinkVisited     (kvconfig: link.visited.color)
         palette.base01 # 16 AlternateBase   (kvconfig: alt.base.color)
         palette.base00 # 17 NoRole
-        palette.base01 # 18 ToolTipBase
+        palette.base00 # 18 ToolTipBase    (kvconfig: tooltip.base.color)
         palette.base05 # 19 ToolTipText     (kvconfig: tooltip.text.color)
         palette.base04 # 20 PlaceholderText
       ];
@@ -164,7 +164,7 @@
         palette.base04 # 15 LinkVisited
         palette.base01 # 16 AlternateBase
         palette.base00 # 17 NoRole
-        palette.base01 # 18 ToolTipBase
+        palette.base00 # 18 ToolTipBase
         palette.base04 # 19 ToolTipText
         palette.base03 # 20 PlaceholderText
       ];


### PR DESCRIPTION
<!-- Describe your PR above, following Stylix commit conventions. -->

## Summary

`stylix.targets.qt` enables `custom_palette = true` in the generated `qt6ct.conf` and `qt5ct.conf` but never writes the matching color scheme file or sets `Appearance.color_scheme_path`. The Base16 palette is baked only into Kvantum's `kvconfig`. Every Qt application that does not render through Kvantum therefore receives Qt's default grey palette instead of the user-selected Stylix theme.

This PR generates a 21-role qt6ct color scheme from `config.lib.stylix.colors`, mirrors it at the qt5ct path, wires both qtct configs at `${config.xdg.configHome}/qt{5,6}ct/colors/stylix.conf`, and aligns the role mapping with `modules/qt/kvconfig.mustache` on every overlapping role so Kvantum-painted Widgets and Fusion-painted QtQuick.Controls 2 surfaces stay visually consistent.

## Affected configurations

Any user with all of:

- `stylix.enable = true`
- `stylix.targets.qt.enable = true` (or its NixOS auto-enable default)
- `qt.platformTheme.name = "qtct"` (Stylix's default)

Visible breakage in:

- Every QtQuick.Controls 2 application falling back to Fusion, Basic, Material, Universal, or the platform default style (Qt's Quick stack has no Kvantum implementation).
- Every Qt Widgets application launched with `QT_STYLE_OVERRIDE` set to any non-Kvantum style.
- Any Qt app embedded in a process that disables custom QStyle plugins (sandboxed contexts, debugging launchers).

## Reproduction

```nix
{
  stylix.enable = true;
  stylix.targets.qt.enable = true;
}
```

```
$ cat ~/.config/qt6ct/qt6ct.conf
[Appearance]
custom_palette=true
icon_theme=Qogir-Dark
standard_dialogs=default
style=kvantum

[Fonts]
fixed="..."
general="..."
```

`color_scheme_path` is absent. With `custom_palette = true` and no scheme, qt6ct falls back to the platform default palette, not the Stylix one. Launch any QtQuick.Controls 2 app (e.g. `librepods`, `qBittorrent` 5.x) — window chrome and controls render with Qt default grey on dark setups, ignoring the configured Base16 scheme.

## Root cause

`modules/qt/hm.nix` builds `qtctSettings.Appearance` without `color_scheme_path`, and no derivation in the qt module emits a qt6ct color scheme file. The qt6ct platform-theme plugin only loads a custom palette when **both** `custom_palette` is `true` **and** `color_scheme_path` is non-empty:

```cpp
// qt6ct/src/qt6ct-qtplugin/qt6ctplatformtheme.cpp:254-260
QString schemePath = settings.value("color_scheme_path").toString();
if(!schemePath.isEmpty() && settings.value("custom_palette", false).toBool())
{
    schemePath = Qt6CT::resolvePath(schemePath);
    m_palette = std::make_unique<QPalette>(
        Qt6CT::loadColorScheme(schemePath, *QPlatformTheme::palette(SystemPalette)));
}
```

With `color_scheme_path` empty `m_palette` stays null and Qt falls back to the platform default. Base16 colors only reach a `QPalette` via `Base16Kvantum.kvconfig`, which is consumed solely by the Kvantum widget style plugin.

## Fix

Generate a 21-role color scheme covering `QPalette::ColorRole` 0..20 (Accent at index 21 is auto-filled by qt6ct 0.10+ when the row has 21 entries). Mirror the file at the qt5ct path. Wire `${config.xdg.configHome}/qt{5,6}ct/colors/stylix.conf` into both qtct configs. A literal per-user XDG path so qt6ct's `Qt6CT::resolvePath` picks up the file regardless of generation churn.

Roles that overlap `kvconfig.mustache` use the same Base16 slot:

| Role            | Slot   | kvconfig key                  |
| --------------- | ------ | ----------------------------- |
| WindowText      | base05 | `window.text.color`           |
| Button          | base02 | `button.color`                |
| Text            | base05 | `text.color`                  |
| ButtonText      | base05 | `button.text.color`           |
| Base            | base00 | `base.color`                  |
| Window          | base01 | `window.color`                |
| Highlight       | base0E | `highlight.color`             |
| Link            | base0D | `link.color`                  |
| LinkVisited     | base0E | `link.visited.color`          |
| AlternateBase   | base01 | `alt.base.color`              |
| ToolTipBase     | base00 | `tooltip.base.color`          |
| ToolTipText     | base05 | `tooltip.text.color`          |

Inactive row replaces only `Highlight` (index 12) with `base03`, matching `kvconfig.mustache:84` (`inactive.highlight.color`). Disabled row mutes foreground/highlight/link roles to base02..base04 because Qt no longer auto-greys widgets under a custom palette. Without a distinct disabled row, disabled controls render identically to enabled ones.

`HighlightedText` intentionally diverges from kvconfig (`base00` -> `base05`): on schemes where `base0E` and `base00` collapse in luminance, base00 makes selected text unreadable. base05 keeps high contrast against any Highlight choice.

### Polarity-aware shade ramp

Base16 inverts `base00..base07` luminance between dark and light themes ([base16/styling.md](https://github.com/chriskempson/base16/blob/main/styling.md)). The bevel-shading roles (`Light`, `Midlight`, `Dark`, `Mid`) and `Shadow` therefore need polarity-aware slot picks, otherwise Fusion bevels render upside-down on light schemes:

| Polarity         | Dark   | Mid    | Midlight | Light  |
| ---------------- | ------ | ------ | -------- | ------ |
| `dark` / `either`| base00 | base01 | base03   | base04 |
| `light`          | base04 | base03 | base01   | base00 |

`Shadow` always tracks `Dark` because shadow rendering must contrast against the surrounding background regardless of polarity.

## Validation

- `nix build .#checks.x86_64-linux.treefmt`: passes
- `nix build .#checks.x86_64-linux.pre-commit` — `all-maintainers`, `deadnix`, `editorconfig-checker`, `hlint`, `statix`, `treefmt`, `typos`, `yamllint` all pass
- `nix build .#checks.x86_64-linux."testbed:kde:dark"`: qt module evaluates cleanly under Plasma path
- After activation on a real system, QtQuick.Controls 2 Fusion rendering of `librepods` (test case) picks up the Stylix Base16 palette correctly on a dark scheme. The polarity branching above is required for the same to hold under `stylix.polarity = "light"`; otherwise widget bevels render upside-down.
- A working downstream implementation lives at [Bad3r/nixos#168](https://github.com/Bad3r/nixos/pull/168); this PR is the upstream port plus polarity-awareness, kvconfig role alignment, and a separate inactive row.

## References

- qt6ct color scheme parser: <https://github.com/trialuser02/qt6ct/blob/master/src/qt6ct-common/qt6ct.cpp>
- qt6ct platform theme plugin (palette gating): <https://github.com/trialuser02/qt6ct/blob/master/src/qt6ct-qtplugin/qt6ctplatformtheme.cpp>
- `QPalette::ColorRole`: <https://doc.qt.io/qt-6/qpalette.html#ColorRole-enum>
- Base16 styling specification: <https://github.com/chriskempson/base16/blob/main/styling.md>

---

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [x] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [x] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [x] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [x] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [x] Each commit in this PR is suitable for backport to the current stable branch
