### PR TITLE
mailmap: map NAHO developer identity to Noah Biewesch

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,2 @@
+Noah Biewesch <dev@noahbiewesch.com> <90870942+trueNAHO@users.noreply.github.com>
+Noah Biewesch <dev@noahbiewesch.com> <trueNAHO@users.noreply.github.com>


### PR DESCRIPTION
Map my NAHO developer identity to Noah Biewesch to correct existing contributions and align with future contributions.

This PR is part of a coordinated effort to canonicalize my developer identity:

- https://github.com/NixOS/nixpkgs/pull/519557
- https://github.com/nix-community/home-manager/pull/9308
- https://github.com/nix-community/nixvim/pull/4287
- https://github.com/nix-community/stylix/pull/2309

---

@0xda157, you might be interested in doing something similar. Consider taking a look at `man gitmailmap` and https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/.mailmap.

---

As a heads up, accessing `lib.maintainers.naho` will crash once https://github.com/NixOS/nixpkgs/pull/519557 is available.

---

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [X] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [X] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [X] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [X] Each commit in this PR is suitable for backport to the current stable branch
