### PR TITLE
wob: Opacity Fix + Testbed

### DIFF
--- a/generated/all-maintainers.nix
+++ b/generated/all-maintainers.nix
@@ -30,6 +30,12 @@
     githubId = 64027365;
     name = "Erin Pletches";
   };
+  Lyndeno = {
+    email = "lsanche@lyndeno.ca";
+    github = "Lyndeno";
+    githubId = 13490857;
+    name = "Lyndon Sanche";
+  };
   MrSom3body = {
     email = "nix@sndh.dev";
     github = "MrSom3body";

--- a/modules/wob/hm.nix
+++ b/modules/wob/hm.nix
@@ -10,8 +10,8 @@ mkTarget {
     (
       { opacity }:
       {
-        stylix.targets.wob._opacity = lib.toHexString (
-          builtins.floor (opacity.popups * 255 + 0.5)
+        stylix.targets.wob._opacity = lib.fixedWidthString 2 "0" (
+          lib.toHexString (builtins.floor (opacity.popups * 255 + 0.5))
         );
       }
     )

--- a/modules/wob/meta.nix
+++ b/modules/wob/meta.nix
@@ -1,5 +1,6 @@
+{ lib, ... }:
 {
   name = "wob";
   homepage = "https://github.com/francma/wob";
-  maintainers = [ ];
+  maintainers = [ lib.maintainers.lyndeno ];
 }

--- a/modules/wob/testbeds/wob.nix
+++ b/modules/wob/testbeds/wob.nix
@@ -1,0 +1,18 @@
+{ lib, pkgs, ... }:
+{
+  stylix.testbed.ui = {
+    graphicalEnvironment = "hyprland";
+    command.text = lib.getExe (
+      pkgs.writeShellScriptBin "wob-invoker" ''
+        while true; do
+          for percent in {0..200}; do
+            echo "$percent" >"$XDG_RUNTIME_DIR/wob.sock"
+            sleep 0.05
+          done
+        done
+      ''
+    );
+  };
+
+  home-manager.sharedModules = lib.singleton { services.wob.enable = true; };
+}


### PR DESCRIPTION

<!-- Describe your PR above, following Stylix commit conventions. -->

Wob supports colours in `RRGGBB[AA]` format. This PR hooks the `popups.opacity` option into the `AA` so that Wob can be displayed with a configurable level of transparency.

This includes a guard for small values to be 0 padded so that they are always two hex digits.

Here is an example of this being used (`opacity = 0.85` and blurred) in my config:
<img width="494" height="106" alt="image" src="https://github.com/user-attachments/assets/99ce5801-c67e-431d-baeb-8399e6a87487" />

Using [mkOpacityHexColor](https://github.com/nix-community/stylix/blob/18ed8d270231e067fe2739998479ed5d7c659c2c/stylix/colors.nix#L6-L15) is not appropriate as the ordering of the color, opacity and he preceeding `0x` do not match what wob wants.

If it matters, I used Claude to assist in designing this change. It was quicker than finding the nix library functions needed for the hex conversion.

---

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [x] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [x] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [x] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [x] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [x] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [x] Each commit in this PR is suitable for backport to the current stable branch
