### PR TITLE
Hyprland: Fix breaking config for Hyprland v0.55+ Lua API

### DIFF
--- a/modules/hyprland/hm.nix
+++ b/modules/hyprland/hm.nix
@@ -20,7 +20,7 @@ mkTarget {
       { colors }:
       {
         wayland.windowManager.hyprland.settings =
-          if config.windowManager.hyprland.configType == "hyprlang" then
+          if config.wayland.windowManager.hyprland.configType == "hyprlang" then
             (
               let
                 rgb = color: "rgb(${color})";

--- a/modules/hyprland/hm.nix
+++ b/modules/hyprland/hm.nix
@@ -69,8 +69,8 @@ mkTarget {
                       "col.active" = rgb colors.base0D;
                       "col.inactive" = rgb colors.base03;
                     };
+                    misc.background_color = rgb colors.base00;
                   };
-                  misc.background_color = rgb colors.base00;
                 };
               }
             );

--- a/modules/hyprland/hm.nix
+++ b/modules/hyprland/hm.nix
@@ -20,29 +20,60 @@ mkTarget {
       { colors }:
       {
         wayland.windowManager.hyprland.settings =
-          let
-            rgb = color: "rgb(${color})";
-            rgba = color: alpha: "rgba(${color}${alpha})";
-          in
-          {
-            decoration.shadow.color = rgba colors.base00 "99";
-            general = {
-              "col.active_border" = rgb colors.base0D;
-              "col.inactive_border" = rgb colors.base03;
-            };
-            group = {
-              "col.border_inactive" = rgb colors.base03;
-              "col.border_active" = rgb colors.base0D;
-              "col.border_locked_active" = rgb colors.base0C;
+          if config.windowManager.hyprland.configType == "hyprlang" then
+            (
+              let
+                rgb = color: "rgb(${color})";
+                rgba = color: alpha: "rgba(${color}${alpha})";
+              in
+              {
+                decoration.shadow.color = rgba colors.base00 "99";
+                general = {
+                  "col.active_border" = rgb colors.base0D;
+                  "col.inactive_border" = rgb colors.base03;
+                };
+                group = {
+                  "col.border_inactive" = rgb colors.base03;
+                  "col.border_active" = rgb colors.base0D;
+                  "col.border_locked_active" = rgb colors.base0C;
 
-              groupbar = {
-                text_color = rgb colors.base05;
-                "col.active" = rgb colors.base0D;
-                "col.inactive" = rgb colors.base03;
-              };
-            };
-            misc.background_color = rgb colors.base00;
-          };
+                  groupbar = {
+                    text_color = rgb colors.base05;
+                    "col.active" = rgb colors.base0D;
+                    "col.inactive" = rgb colors.base03;
+                  };
+                };
+                misc.background_color = rgb colors.base00;
+              }
+            )
+          else
+            (
+              let
+                rgb = color: "rgb(${color})";
+                rgba = color: alpha: "rgba(${color}${alpha})";
+              in
+              {
+                config = {
+                  decoration.shadow.color = rgba colors.base00 "99";
+                  general = {
+                    "col.active_border" = rgb colors.base0D;
+                    "col.inactive_border" = rgb colors.base03;
+                  };
+                  group = {
+                    "col.border_inactive" = rgb colors.base03;
+                    "col.border_active" = rgb colors.base0D;
+                    "col.border_locked_active" = rgb colors.base0C;
+
+                    groupbar = {
+                      text_color = rgb colors.base05;
+                      "col.active" = rgb colors.base0D;
+                      "col.inactive" = rgb colors.base03;
+                    };
+                  };
+                  misc.background_color = rgb colors.base00;
+                };
+              }
+            );
       }
     )
     (

--- a/modules/hyprland/hm.nix
+++ b/modules/hyprland/hm.nix
@@ -82,7 +82,11 @@ mkTarget {
         {
           services.hyprpaper.enable = true;
           stylix.targets.hyprpaper.enable = true;
-          wayland.windowManager.hyprland.settings.misc.disable_hyprland_logo = true;
+          wayland.windowManager.hyprland.settings =
+            if config.wayland.windowManager.hyprland.configType == "hyprlang" then
+              { misc.disable_hyprland_logo = true; }
+            else
+              { config.misc.disable_hyprland_logo = true; };
         }
     )
   ];

--- a/modules/hyprland/hm.nix
+++ b/modules/hyprland/hm.nix
@@ -59,6 +59,7 @@ mkTarget {
                     "col.active_border" = rgb colors.base0D;
                     "col.inactive_border" = rgb colors.base03;
                   };
+                  misc.background_color = rgb colors.base00;
                   group = {
                     "col.border_inactive" = rgb colors.base03;
                     "col.border_active" = rgb colors.base0D;
@@ -69,7 +70,6 @@ mkTarget {
                       "col.active" = rgb colors.base0D;
                       "col.inactive" = rgb colors.base03;
                     };
-                    misc.background_color = rgb colors.base00;
                   };
                 };
               }


### PR DESCRIPTION

This PR updates the Stylix theming to be used with the new Hyprland Lua config via the new Home-Manager API.

Because of the new defaults in Home-Manager, now Stylix breaks the Hyprland config. Because this is a transition period, Home-Manager will keep backwards compatibility via the option `configType`, however, the API changes a bit, so Stylix needs to match that new API base on the after-mentioned option.

---

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [x] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [ ] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [ ] Each commit in this PR is suitable for backport to the current stable branch
