### PR TITLE
opencode: fix theme polarity for light base16 schemes

### DIFF
--- a/modules/opencode/hm.nix
+++ b/modules/opencode/hm.nix
@@ -1,220 +1,227 @@
 { mkTarget, ... }:
 mkTarget {
   config =
-    { colors }:
-    {
-      programs.opencode =
-        let
-          theme = "stylix";
-        in
-        {
-          tui = { inherit theme; };
-          themes.${theme} = {
-            theme = {
-              accent = {
-                dark = colors.withHashtag.base0F;
-                light = colors.withHashtag.base07;
-              };
-              background = {
-                dark = colors.withHashtag.base00;
-                light = colors.withHashtag.base06;
-              };
-              backgroundElement = {
-                dark = colors.withHashtag.base01;
-                light = colors.withHashtag.base04;
-              };
-              backgroundPanel = {
-                dark = colors.withHashtag.base01;
-                light = colors.withHashtag.base05;
-              };
-              border = {
-                dark = colors.withHashtag.base02;
-                light = colors.withHashtag.base03;
-              };
-              borderActive = {
-                dark = colors.withHashtag.base03;
-                light = colors.withHashtag.base02;
-              };
-              borderSubtle = {
-                dark = colors.withHashtag.base02;
-                light = colors.withHashtag.base03;
-              };
-              diffAdded = {
-                dark = colors.withHashtag.base0B;
-                light = colors.withHashtag.base0B;
-              };
-              diffAddedBg = {
-                dark = colors.withHashtag.base01;
-                light = colors.withHashtag.base05;
-              };
-              diffAddedLineNumberBg = {
-                dark = colors.withHashtag.base01;
-                light = colors.withHashtag.base05;
-              };
-              diffContext = {
-                dark = colors.withHashtag.base03;
-                light = colors.withHashtag.base03;
-              };
-              diffContextBg = {
-                dark = colors.withHashtag.base01;
-                light = colors.withHashtag.base05;
-              };
-              diffHighlightAdded = {
-                dark = colors.withHashtag.base0B;
-                light = colors.withHashtag.base0B;
-              };
-              diffHighlightRemoved = {
-                dark = colors.withHashtag.base08;
-                light = colors.withHashtag.base08;
-              };
-              diffHunkHeader = {
-                dark = colors.withHashtag.base03;
-                light = colors.withHashtag.base03;
-              };
-              diffLineNumber = {
-                dark = colors.withHashtag.base03;
-                light = colors.withHashtag.base04;
-              };
-              diffRemoved = {
-                dark = colors.withHashtag.base08;
-                light = colors.withHashtag.base08;
-              };
-              diffRemovedBg = {
-                dark = colors.withHashtag.base01;
-                light = colors.withHashtag.base05;
-              };
-              diffRemovedLineNumberBg = {
-                dark = colors.withHashtag.base01;
-                light = colors.withHashtag.base05;
-              };
-              error = {
-                dark = colors.withHashtag.base08;
-                light = colors.withHashtag.base08;
-              };
-              info = {
-                dark = colors.withHashtag.base0C;
-                light = colors.withHashtag.base0F;
-              };
-              markdownBlockQuote = {
-                dark = colors.withHashtag.base03;
-                light = colors.withHashtag.base01;
-              };
-              markdownCode = {
-                dark = colors.withHashtag.base0B;
-                light = colors.withHashtag.base0B;
-              };
-              markdownCodeBlock = {
-                dark = colors.withHashtag.base01;
-                light = colors.withHashtag.base00;
-              };
-              markdownEmph = {
-                dark = colors.withHashtag.base0A;
-                light = colors.withHashtag.base09;
-              };
-              markdownHeading = {
-                dark = colors.withHashtag.base0E;
-                light = colors.withHashtag.base0F;
-              };
-              markdownHorizontalRule = {
-                dark = colors.withHashtag.base04;
-                light = colors.withHashtag.base03;
-              };
-              markdownImage = {
-                dark = colors.withHashtag.base0D;
-                light = colors.withHashtag.base0D;
-              };
-              markdownImageText = {
-                dark = colors.withHashtag.base0C;
-                light = colors.withHashtag.base07;
-              };
-              markdownLink = {
-                dark = colors.withHashtag.base0D;
-                light = colors.withHashtag.base0D;
-              };
-              markdownLinkText = {
-                dark = colors.withHashtag.base0C;
-                light = colors.withHashtag.base07;
-              };
-              markdownListEnumeration = {
-                dark = colors.withHashtag.base0C;
-                light = colors.withHashtag.base07;
-              };
-              markdownListItem = {
-                dark = colors.withHashtag.base0D;
-                light = colors.withHashtag.base0F;
-              };
-              markdownStrong = {
-                dark = colors.withHashtag.base09;
-                light = colors.withHashtag.base0A;
-              };
-              markdownText = {
-                dark = colors.withHashtag.base05;
-                light = colors.withHashtag.base00;
-              };
-              primary = {
-                dark = colors.withHashtag.base0D;
-                light = colors.withHashtag.base0F;
-              };
-              secondary = {
-                dark = colors.withHashtag.base0E;
-                light = colors.withHashtag.base0D;
-              };
-              success = {
-                dark = colors.withHashtag.base0B;
-                light = colors.withHashtag.base0B;
-              };
-              syntaxComment = {
-                dark = colors.withHashtag.base04;
-                light = colors.withHashtag.base03;
-              };
-              syntaxFunction = {
-                dark = colors.withHashtag.base0D;
-                light = colors.withHashtag.base0C;
-              };
-              syntaxKeyword = {
-                dark = colors.withHashtag.base0E;
-
-                light = colors.withHashtag.base0D;
-
-              };
-              syntaxNumber = {
-                dark = colors.withHashtag.base09;
-                light = colors.withHashtag.base0E;
-              };
-              syntaxOperator = {
-                dark = colors.withHashtag.base0C;
-                light = colors.withHashtag.base0D;
-              };
-              syntaxPunctuation = {
-                dark = colors.withHashtag.base05;
-                light = colors.withHashtag.base00;
-              };
-              syntaxString = {
-                dark = colors.withHashtag.base0B;
-                light = colors.withHashtag.base0B;
-              };
-              syntaxType = {
-                dark = colors.withHashtag.base0A;
-                light = colors.withHashtag.base07;
-              };
-              syntaxVariable = {
-                dark = colors.withHashtag.base07;
-                light = colors.withHashtag.base07;
-              };
-              text = {
-                dark = colors.withHashtag.base05;
-                light = colors.withHashtag.base00;
-              };
-              textMuted = {
-                dark = colors.withHashtag.base04;
-                light = colors.withHashtag.base01;
-              };
-              warning = {
-                dark = colors.withHashtag.base0A;
-                light = colors.withHashtag.base0A;
-              };
-            };
-          };
+    { colors, polarity }:
+    let
+      themeName = "stylix";
+      themeValues = {
+        accent = {
+          dark = colors.withHashtag.base0F;
+          light = colors.withHashtag.base07;
         };
+        background = {
+          dark = colors.withHashtag.base00;
+          light = colors.withHashtag.base06;
+        };
+        backgroundElement = {
+          dark = colors.withHashtag.base01;
+          light = colors.withHashtag.base04;
+        };
+        backgroundPanel = {
+          dark = colors.withHashtag.base01;
+          light = colors.withHashtag.base05;
+        };
+        border = {
+          dark = colors.withHashtag.base02;
+          light = colors.withHashtag.base03;
+        };
+        borderActive = {
+          dark = colors.withHashtag.base03;
+          light = colors.withHashtag.base02;
+        };
+        borderSubtle = {
+          dark = colors.withHashtag.base02;
+          light = colors.withHashtag.base03;
+        };
+        diffAdded = {
+          dark = colors.withHashtag.base0B;
+          light = colors.withHashtag.base0B;
+        };
+        diffAddedBg = {
+          dark = colors.withHashtag.base01;
+          light = colors.withHashtag.base05;
+        };
+        diffAddedLineNumberBg = {
+          dark = colors.withHashtag.base01;
+          light = colors.withHashtag.base05;
+        };
+        diffContext = {
+          dark = colors.withHashtag.base03;
+          light = colors.withHashtag.base03;
+        };
+        diffContextBg = {
+          dark = colors.withHashtag.base01;
+          light = colors.withHashtag.base05;
+        };
+        diffHighlightAdded = {
+          dark = colors.withHashtag.base0B;
+          light = colors.withHashtag.base0B;
+        };
+        diffHighlightRemoved = {
+          dark = colors.withHashtag.base08;
+          light = colors.withHashtag.base08;
+        };
+        diffHunkHeader = {
+          dark = colors.withHashtag.base03;
+          light = colors.withHashtag.base03;
+        };
+        diffLineNumber = {
+          dark = colors.withHashtag.base03;
+          light = colors.withHashtag.base04;
+        };
+        diffRemoved = {
+          dark = colors.withHashtag.base08;
+          light = colors.withHashtag.base08;
+        };
+        diffRemovedBg = {
+          dark = colors.withHashtag.base01;
+          light = colors.withHashtag.base05;
+        };
+        diffRemovedLineNumberBg = {
+          dark = colors.withHashtag.base01;
+          light = colors.withHashtag.base05;
+        };
+        error = {
+          dark = colors.withHashtag.base08;
+          light = colors.withHashtag.base08;
+        };
+        info = {
+          dark = colors.withHashtag.base0C;
+          light = colors.withHashtag.base0F;
+        };
+        markdownBlockQuote = {
+          dark = colors.withHashtag.base03;
+          light = colors.withHashtag.base01;
+        };
+        markdownCode = {
+          dark = colors.withHashtag.base0B;
+          light = colors.withHashtag.base0B;
+        };
+        markdownCodeBlock = {
+          dark = colors.withHashtag.base01;
+          light = colors.withHashtag.base00;
+        };
+        markdownEmph = {
+          dark = colors.withHashtag.base0A;
+          light = colors.withHashtag.base09;
+        };
+        markdownHeading = {
+          dark = colors.withHashtag.base0E;
+          light = colors.withHashtag.base0F;
+        };
+        markdownHorizontalRule = {
+          dark = colors.withHashtag.base04;
+          light = colors.withHashtag.base03;
+        };
+        markdownImage = {
+          dark = colors.withHashtag.base0D;
+          light = colors.withHashtag.base0D;
+        };
+        markdownImageText = {
+          dark = colors.withHashtag.base0C;
+          light = colors.withHashtag.base07;
+        };
+        markdownLink = {
+          dark = colors.withHashtag.base0D;
+          light = colors.withHashtag.base0D;
+        };
+        markdownLinkText = {
+          dark = colors.withHashtag.base0C;
+          light = colors.withHashtag.base07;
+        };
+        markdownListEnumeration = {
+          dark = colors.withHashtag.base0C;
+          light = colors.withHashtag.base07;
+        };
+        markdownListItem = {
+          dark = colors.withHashtag.base0D;
+          light = colors.withHashtag.base0F;
+        };
+        markdownStrong = {
+          dark = colors.withHashtag.base09;
+          light = colors.withHashtag.base0A;
+        };
+        markdownText = {
+          dark = colors.withHashtag.base05;
+          light = colors.withHashtag.base00;
+        };
+        primary = {
+          dark = colors.withHashtag.base0D;
+          light = colors.withHashtag.base0F;
+        };
+        secondary = {
+          dark = colors.withHashtag.base0E;
+          light = colors.withHashtag.base0D;
+        };
+        success = {
+          dark = colors.withHashtag.base0B;
+          light = colors.withHashtag.base0B;
+        };
+        syntaxComment = {
+          dark = colors.withHashtag.base04;
+          light = colors.withHashtag.base03;
+        };
+        syntaxFunction = {
+          dark = colors.withHashtag.base0D;
+          light = colors.withHashtag.base0C;
+        };
+        syntaxKeyword = {
+          dark = colors.withHashtag.base0E;
+          light = colors.withHashtag.base0D;
+        };
+        syntaxNumber = {
+          dark = colors.withHashtag.base09;
+          light = colors.withHashtag.base0E;
+        };
+        syntaxOperator = {
+          dark = colors.withHashtag.base0C;
+          light = colors.withHashtag.base0D;
+        };
+        syntaxPunctuation = {
+          dark = colors.withHashtag.base05;
+          light = colors.withHashtag.base00;
+        };
+        syntaxString = {
+          dark = colors.withHashtag.base0B;
+          light = colors.withHashtag.base0B;
+        };
+        syntaxType = {
+          dark = colors.withHashtag.base0A;
+          light = colors.withHashtag.base07;
+        };
+        syntaxVariable = {
+          dark = colors.withHashtag.base07;
+          light = colors.withHashtag.base07;
+        };
+        text = {
+          dark = colors.withHashtag.base05;
+          light = colors.withHashtag.base00;
+        };
+        textMuted = {
+          dark = colors.withHashtag.base04;
+          light = colors.withHashtag.base01;
+        };
+        warning = {
+          dark = colors.withHashtag.base0A;
+          light = colors.withHashtag.base0A;
+        };
+      };
+    in
+    {
+      programs.opencode = {
+        tui = {
+          theme = themeName;
+        };
+        themes.${themeName} = {
+          theme =
+            if polarity == "light" then
+              builtins.mapAttrs (_: v: {
+                dark = v.light;
+                light = v.dark;
+              }) themeValues
+            else
+              themeValues;
+        };
+      };
     };
 }


### PR DESCRIPTION
From https://github.com/nix-community/stylix/pull/2192 , which seems stalled to me:

> OpenCode themes have separate "dark" and "light" color variants,
> selected at runtime based on terminal background detection (OSC 11).
> The existing mapping always assigns base00 to the "dark" variant and
> base06 to "light".
> For dark-polarity schemes (base00 = dark background), this is correct.
> For light-polarity schemes (e.g. base00 = #ffffff), the assignments are
> inverted: when the terminal correctly reports light mode, OpenCode uses
> the "light" variant which contains the dark colors, and vice versa.
> The result is that light scheme users always see wrong colors regardless
> of terminal detection.
> Fix this by adding the polarity argument and using builtins.mapAttrs to
> swap dark/light values across all theme keys when polarity is "light".
> This is simpler than calling a helper per key — the single mapAttrs
> transformation flips every {dark, light} pair in one operation.
> No behavioral change for dark-polarity schemes (the default code path
> is identical).
> 

before:

<img width="1882" height="2136" alt="screenshot-1779636462-18:27:42" src="https://github.com/user-attachments/assets/af349740-a61d-404b-9236-db9d6eaabfb9" />

after:

<img width="1882" height="2136" alt="screenshot-1779636781-18:33:01" src="https://github.com/user-attachments/assets/67b6e7a6-c165-4a34-a896-1f6a21abae33" />

Code logic for dark polarity is unchanged.

---

- [x] I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [x] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [x] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [x] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [x] Each commit in this PR is suitable for backport to the current stable branch