### PR TITLE
home-manager-integration: guard useGlobalPkgs overlay disable on autoImport

### DIFF
--- a/stylix/home-manager-integration.nix
+++ b/stylix/home-manager-integration.nix
@@ -223,11 +223,17 @@ in
           ]
           ++ lib.optionals config.stylix.homeManagerIntegration.followSystem copyModules;
         })
-        (lib.mkIf config.home-manager.useGlobalPkgs {
-          home-manager.sharedModules = lib.singleton {
-            config.stylix.overlays.enable = false;
-          };
-        })
+        (lib.mkIf
+          (
+            config.stylix.homeManagerIntegration.autoImport
+            && config.home-manager.useGlobalPkgs
+          )
+          {
+            home-manager.sharedModules = lib.singleton {
+              config.stylix.overlays.enable = false;
+            };
+          }
+        )
       ]
     )
   );


### PR DESCRIPTION
## Summary

When `homeManagerIntegration.autoImport = false` and `home-manager.useGlobalPkgs = true`, stylix pushes `stylix.overlays.enable = false` into all HM users via `sharedModules`. But since `autoImport` is false, the stylix HM module isn't imported — so the `stylix` option doesn't exist in the HM config, causing an eval error.

## Reproduction

```nix
{
  stylix = {
    enable = true;
    homeManagerIntegration.autoImport = false;
    homeManagerIntegration.followSystem = false;
  };
  home-manager.useGlobalPkgs = true;
  home-manager.users.someuser = {};
}
```

Errors with:
```
error: The option `home-manager.users.someuser.stylix' does not exist.
```

## Fix

One-line change: add `config.stylix.homeManagerIntegration.autoImport &&` to the `useGlobalPkgs` guard in `home-manager-integration.nix`, since the overlay disable only applies when stylix is actually imported into Home Manager.