### PR TITLE
doc: modules: add using lib.mkOverride to common mistakes

### DIFF
--- a/doc/src/modules.md
+++ b/doc/src/modules.md
@@ -294,6 +294,14 @@ mandatory.
 
 ## Common Mistakes
 
+### Using `lib.mkOverride`
+
+When writing modules, using `lib.mkOverride`, `lib.mkDefault`, or `lib.mkForce`
+should be avoided. Stylix modules should aim to declare only the options
+necessary for satisfactory theming. It is preferable for end users to use `lib.mkForce`
+than for their configuration to silently override/silently be overridden by values
+set by Stylix.
+
 ### `home.activation` Scripts
 
 Any script run by `home.activation` must be preceded by `run` if the script is


### PR DESCRIPTION
documents justification for rejecting https://github.com/nix-community/stylix/pull/388, as this has repeatedly come up again.
<!-- Describe your PR above, following Stylix commit conventions. -->

---

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [x] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [x] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [x] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [x] Each commit in this PR is suitable for backport to the current stable branch
