### PR TITLE
gtk: hm: explicitly set gtk4.theme

### DIFF
--- a/modules/gtk/hm.nix
+++ b/modules/gtk/hm.nix
@@ -60,6 +60,7 @@ mkTarget {
             package = pkgs.adw-gtk3;
             name = "adw-gtk3";
           };
+          gtk.gtk4.theme = config.gtk.theme;
 
           xdg.configFile = {
             "gtk-3.0/gtk.css".source = finalCss;


### PR DESCRIPTION
```
Resolves Home Manager warning introduced in commit "gtk4: don't enable theme by default" (ae9f38e)[^1]

[^1]: https://github.com/nix-community/home-manager/commit/ae9f38e88963fcd68b3c07885beb5cf36f1e17c8
```

Closes https://github.com/nix-community/stylix/issues/2250

> [!NOTE]
> This behavior should change when https://github.com/nix-community/stylix/discussions/2112 is implemented.

<!-- Describe your PR above, following Stylix commit conventions. -->

---

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [x] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [x] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [x] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [x] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [x] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [x] Each commit in this PR is suitable for backport to the current stable branch
