### PR TITLE
prismlauncher: init

### DIFF
--- a/generated/all-maintainers.nix
+++ b/generated/all-maintainers.nix
@@ -17,6 +17,12 @@
     matrix = "@da157:catgirl.cloud";
     name = "0xda157";
   };
+  ErinaYip = {
+    email = "erinayip@outlook.com";
+    github = "ErinaYip";
+    githubId = 227132255;
+    name = "erina";
+  };
   Eveeifyeve = {
     email = "eveeg1971@gmail.com";
     github = "Eveeifyeve";

--- a/modules/prismlauncher/hm.nix
+++ b/modules/prismlauncher/hm.nix
@@ -1,0 +1,53 @@
+{ mkTarget, ... }:
+mkTarget {
+  config = [
+    ({ fonts }: {
+      programs.prismlauncher.settings = {
+        ConsoleFont = fonts.monospace.name;
+        ConsoleFontSize = fonts.sizes.terminal;
+      };
+    })
+    ({ colors }: {
+      programs.prismlauncher = {
+        settings.ApplicationTheme = "stylix";
+
+        themes.stylix.theme = with colors.withHashtag; {
+          name = "Stylix";
+          widgets = "Fusion";
+
+          colors = {
+            AlternateBase = base01;
+            Base = base00;
+            BrightText = base08;
+            Button = base01;
+            ButtonText = base05;
+            Highlight = base02;
+            HighlightedText = base05;
+            Link = base0D;
+            Text = base05;
+            ToolTipBase = base00;
+            ToolTipText = base05;
+            Window = base00;
+            WindowText = base05;
+            fadeAmount = 0.5;
+            fadeColor = base02;
+          };
+          logColors = {
+            Debug = base0B;
+            DebugHighlight = base03;
+            Error = base08;
+            ErrorHighlight = base03;
+            Fatal = base08;
+            FatalHighlight = base00;
+            Launcher = base0D;
+            LauncherHighlight = base03;
+            Message = base05;
+            MessageHighlight = base02;
+            Warning = base0A;
+            WarningHighlight = base03;
+          };
+        };
+      };
+    })
+  ];
+}

--- a/modules/prismlauncher/meta.nix
+++ b/modules/prismlauncher/meta.nix
@@ -1,0 +1,5 @@
+{ lib, ... }: {
+  name = "Prism Launcher";
+  homepage = "https://prismlauncher.org";
+  maintainers = [ lib.maintainers.erina ];
+}

--- a/modules/prismlauncher/testbeds/prismlauncher.nix
+++ b/modules/prismlauncher/testbeds/prismlauncher.nix
@@ -1,0 +1,14 @@
+{ lib, pkgs, ... }:
+let
+  package = pkgs.prismlauncher;
+in
+{
+  stylix.testbed.ui.command.text = lib.getExe package;
+
+  home-manager.sharedModules = lib.singleton {
+    programs.prismlauncher = {
+      enable = true;
+      inherit package;
+    };
+  };
+}

--- a/stylix/maintainers.nix
+++ b/stylix/maintainers.nix
@@ -37,6 +37,12 @@
     github = "cswimr";
     githubId = 102361830;
   };
+  erina = {
+    email = "erinayip@outlook.com";
+    name = "erina";
+    github = "ErinaYip";
+    githubId = 227132255;
+  };
   gideonwolfe = {
     email = "wolfegideon@gmail.com";
     name = "Gideon Wolfe";


### PR DESCRIPTION

Add a Home Manager target for Prism Launcher.

PrismLauncher does not expose a general UI font or window opacity theme setting; the only relevant font settings are `ConsoleFont` and `ConsoleFontSize`.

Closes: https://github.com/nix-community/stylix/issues/601

---

- [x] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [x] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [x] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [x] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [x] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [x] Each commit in this PR is suitable for backport to the current stable branch
