### PR TITLE
treewide: replace ImageMagick 7 deprecated convert command with magick

### DIFF
--- a/doc/src/tricks.md
+++ b/doc/src/tricks.md
@@ -19,7 +19,7 @@ let
 in
 {
   stylix.image = pkgs.runCommand "dimmed-background.png" { } ''
-    ${lib.getExe' pkgs.imagemagick "convert"} "${inputImage}" -brightness-contrast ${brightness},${contrast} -fill ${fillColor} $out
+    ${lib.getExe' pkgs.imagemagick "magick"} "${inputImage}" -brightness-contrast ${brightness},${contrast} -fill ${fillColor} $out
   '';
 }
 ```

--- a/modules/grub/nixos.nix
+++ b/modules/grub/nixos.nix
@@ -135,7 +135,7 @@ in
               # Make sure the background image is .png by asking to convert it
               then
                 ''
-                  ${lib.getExe' pkgs.imagemagick "convert"} \
+                  ${lib.getExe' pkgs.imagemagick "magick"} \
                     ${lib.escapeShellArg config.stylix.image} \
                     "png32:$out/background.png"
                 ''

--- a/modules/plymouth/nixos.nix
+++ b/modules/plymouth/nixos.nix
@@ -41,7 +41,7 @@ mkTarget {
         themeDir="$out/share/plymouth/themes/stylix"
         mkdir -p $themeDir
 
-        ${lib.getExe' pkgs.imagemagick "convert"} \
+        ${lib.getExe' pkgs.imagemagick "magick"} \
           -background transparent \
           -bordercolor transparent \
           ${

--- a/modules/wayfire/hm.nix
+++ b/modules/wayfire/hm.nix
@@ -36,7 +36,7 @@ mkTarget {
       { image, imageScalingMode }:
       let
         wayfireBackground = pkgs.runCommand "wayfire-background.png" { } ''
-          ${lib.getExe' pkgs.imagemagick "convert"} ${image} $out
+          ${lib.getExe' pkgs.imagemagick "magick"} ${image} $out
         '';
       in
       {

--- a/stylix/pixel.nix
+++ b/stylix/pixel.nix
@@ -10,5 +10,5 @@
     color:
     pkgs.runCommand "${color}-pixel.png" {
       color = config.lib.stylix.colors.withHashtag.${color};
-    } "${lib.getExe' pkgs.imagemagick "convert"} xc:$color png32:$out";
+    } "${lib.getExe' pkgs.imagemagick "magick"} xc:$color png32:$out";
 }


### PR DESCRIPTION
```
Closes: https://github.com/nix-community/stylix/issues/2255
```

> [!IMPORTANT]
>
> This PR should not be merged without manually verifying each migrated command. This has not been done yet. This PR is totally untested.

@landure, could you verify whether this PR at least resolves https://github.com/nix-community/stylix/issues/2255?

---

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [X] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [X] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [X] Each commit in this PR is suitable for backport to the current stable branch
