### PR TITLE
kmscon: use `services.kmscon.config` option

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -139,11 +139,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1779560665,
-        "narHash": "sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o=",
+        "lastModified": 1780243769,
+        "narHash": "sha256-x5UQuRsH3MqI0U9afaXSNqzTPSeZlRLvFAav2Ux1pNw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "64c08a7ca051951c8eae34e3e3cb1e202fe36786",
+        "rev": "331800de5053fcebacf6813adb5db9c9dca22a0c",
         "type": "github"
       },
       "original": {

--- a/flake/dev/flake.lock
+++ b/flake/dev/flake.lock
@@ -45,11 +45,11 @@
     },
     "dev-nixpkgs": {
       "locked": {
-        "lastModified": 1779560665,
-        "narHash": "sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o=",
+        "lastModified": 1780243769,
+        "narHash": "sha256-x5UQuRsH3MqI0U9afaXSNqzTPSeZlRLvFAav2Ux1pNw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "64c08a7ca051951c8eae34e3e3cb1e202fe36786",
+        "rev": "331800de5053fcebacf6813adb5db9c9dca22a0c",
         "type": "github"
       },
       "original": {

--- a/modules/kmscon/nixos.nix
+++ b/modules/kmscon/nixos.nix
@@ -4,47 +4,44 @@ mkTarget {
     (
       { fonts }:
       {
-        services.kmscon = {
-          fonts = [ fonts.monospace ];
-          extraConfig = "font-size=${toString fonts.sizes.terminal}";
+        services.kmscon.config = {
+          font-name = fonts.monospace.name;
+          font-size = fonts.sizes.terminal;
         };
       }
     )
     (
       { colors }:
-      {
-        services.kmscon.extraConfig =
+      let
+        formatBase =
+          name:
           let
-            formatBase =
-              name:
-              let
-                getComponent = comp: colors."${name}-rgb-${comp}";
-              in
-              "${getComponent "r"},${getComponent "g"},${getComponent "b"}";
+            getComponent = comp: colors."${name}-rgb-${comp}";
           in
-          ''
-            palette=custom
-
-            palette-black=${formatBase "base00"}
-            palette-red=${formatBase "base08"}
-            palette-green=${formatBase "base0B"}
-            palette-yellow=${formatBase "base0A"}
-            palette-blue=${formatBase "base0D"}
-            palette-magenta=${formatBase "base0E"}
-            palette-cyan=${formatBase "base0C"}
-            palette-light-grey=${formatBase "base05"}
-            palette-dark-grey=${formatBase "base03"}
-            palette-light-red=${formatBase "base08"}
-            palette-light-green=${formatBase "base0B"}
-            palette-light-yellow=${formatBase "base0A"}
-            palette-light-blue=${formatBase "base0D"}
-            palette-light-magenta=${formatBase "base0E"}
-            palette-light-cyan=${formatBase "base0C"}
-            palette-white=${formatBase "base07"}
-
-            palette-background=${formatBase "base00"}
-            palette-foreground=${formatBase "base05"}
-          '';
+          "${getComponent "r"},${getComponent "g"},${getComponent "b"}";
+      in
+      {
+        services.kmscon.config = {
+          palette = "custom";
+          palette-black = formatBase "base00";
+          palette-red = formatBase "base08";
+          palette-green = formatBase "base0B";
+          palette-yellow = formatBase "base0A";
+          palette-blue = formatBase "base0D";
+          palette-magenta = formatBase "base0E";
+          palette-cyan = formatBase "base0C";
+          palette-light-grey = formatBase "base05";
+          palette-dark-grey = formatBase "base03";
+          palette-light-red = formatBase "base08";
+          palette-light-green = formatBase "base0B";
+          palette-light-yellow = formatBase "base0A";
+          palette-light-blue = formatBase "base0D";
+          palette-light-magenta = formatBase "base0E";
+          palette-light-cyan = formatBase "base0C";
+          palette-white = formatBase "base07";
+          palette-background = formatBase "base00";
+          palette-foreground = formatBase "base05";
+        };
       }
     )
   ];


### PR DESCRIPTION
Fix kmscon configuration options, update to use kmscon.config and include fonts.packages configuration per deprecation warnings. 

<!-- Describe your PR above, following Stylix commit conventions. -->

---

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [x] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [ ] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [ ] Each commit in this PR is suitable for backport to the current stable branch
