### PR TITLE
kmscon: support services.kmscon.config with legacy fallback

### DIFF
--- a/modules/kmscon/nixos.nix
+++ b/modules/kmscon/nixos.nix
@@ -1,51 +1,69 @@
-{ mkTarget, ... }:
+{
+  mkTarget,
+  lib,
+  options,
+  ...
+}:
+let
+  hasConfigOption = options ? services.kmscon.config;
+in
 mkTarget {
   config = [
     (
       { fonts }:
-      {
-        services.kmscon = {
-          fonts = [ fonts.monospace ];
-          extraConfig = "font-size=${toString fonts.sizes.terminal}";
-        };
-      }
+      if hasConfigOption then
+        {
+          fonts.fontconfig.enable = true;
+          fonts.packages = [ fonts.monospace.package ];
+          services.kmscon.config = {
+            font-name = fonts.monospace.name;
+            font-size = toString fonts.sizes.terminal;
+          };
+        }
+      else
+        {
+          services.kmscon = {
+            fonts = [ fonts.monospace ];
+            extraConfig = "font-size=${toString fonts.sizes.terminal}";
+          };
+        }
     )
     (
       { colors }:
-      {
-        services.kmscon.extraConfig =
+      let
+        formatBase =
+          name:
           let
-            formatBase =
-              name:
-              let
-                getComponent = comp: colors."${name}-rgb-${comp}";
-              in
-              "${getComponent "r"},${getComponent "g"},${getComponent "b"}";
+            getComponent = comp: colors."${name}-rgb-${comp}";
           in
-          ''
-            palette=custom
+          "${getComponent "r"},${getComponent "g"},${getComponent "b"}";
 
-            palette-black=${formatBase "base00"}
-            palette-red=${formatBase "base08"}
-            palette-green=${formatBase "base0B"}
-            palette-yellow=${formatBase "base0A"}
-            palette-blue=${formatBase "base0D"}
-            palette-magenta=${formatBase "base0E"}
-            palette-cyan=${formatBase "base0C"}
-            palette-light-grey=${formatBase "base05"}
-            palette-dark-grey=${formatBase "base03"}
-            palette-light-red=${formatBase "base08"}
-            palette-light-green=${formatBase "base0B"}
-            palette-light-yellow=${formatBase "base0A"}
-            palette-light-blue=${formatBase "base0D"}
-            palette-light-magenta=${formatBase "base0E"}
-            palette-light-cyan=${formatBase "base0C"}
-            palette-white=${formatBase "base07"}
-
-            palette-background=${formatBase "base00"}
-            palette-foreground=${formatBase "base05"}
-          '';
-      }
+        palette = {
+          palette = "custom";
+          palette-black = formatBase "base00";
+          palette-red = formatBase "base08";
+          palette-green = formatBase "base0B";
+          palette-yellow = formatBase "base0A";
+          palette-blue = formatBase "base0D";
+          palette-magenta = formatBase "base0E";
+          palette-cyan = formatBase "base0C";
+          palette-light-grey = formatBase "base05";
+          palette-dark-grey = formatBase "base03";
+          palette-light-red = formatBase "base08";
+          palette-light-green = formatBase "base0B";
+          palette-light-yellow = formatBase "base0A";
+          palette-light-blue = formatBase "base0D";
+          palette-light-magenta = formatBase "base0E";
+          palette-light-cyan = formatBase "base0C";
+          palette-white = formatBase "base07";
+          palette-background = formatBase "base00";
+          palette-foreground = formatBase "base05";
+        };
+      in
+      if hasConfigOption then
+        { services.kmscon.config = palette; }
+      else
+        { services.kmscon.extraConfig = lib.generators.toKeyValue { } palette; }
     )
   ];
 }


### PR DESCRIPTION
Nixpkgs replaced `services.kmscon.fonts` and `services.kmscon.extraConfig` with a single `services.kmscon.config`
attribute set (a submodule with a `oneOf [ bool int str ]` freeform type). Stylix's kmscon target still sets the old
options, so after a Nixpkgs bump evaluation aborts with `mkRemovedOptionModule` assertions (see #2334):

```
The option definition `services.kmscon.extraConfig' [...] no longer has any effect; please remove it.
The option definition `services.kmscon.fonts' [...] no longer has any effect; please remove it.
```

Switching unconditionally to `services.kmscon.config` is not viable either, because Stylix supports stable as well as
unstable: on the current stable release and any pre-migration revision the option is undeclared, and the path is
rejected even under `mkIf`, raising ``The option `services.kmscon.config' does not exist``.

### Fix

Detect the option with `options ? services.kmscon.config` and branch with `if`/`else`, so only the path valid for the
active Nixpkgs is ever referenced (the same pattern used by the `spicetify`, `nixvim`, and `gtk` targets):

- New API: set `services.kmscon.config`, register the font via `fonts.packages`, and enable fontconfig. The last point
  reproduces what the removed `services.kmscon.fonts` option did implicitly and satisfies the new module's assertion
  that fontconfig is enabled whenever `font-name` is set.
- Legacy API: keep `services.kmscon.fonts` and `services.kmscon.extraConfig` exactly as before.

A shared `palette` attribute set feeds both branches, serialized with `lib.generators.toKeyValue` for the legacy
`lines` option, so the two paths cannot drift. `font-size` uses `toString` so fractional
`stylix.fonts.sizes.terminal` values remain valid under the new freeform type.

### Validation

kmscon has no testbed, so the module was validated by evaluating its exact guard logic against faithful reproductions
of both kmscon option sets (the pre-migration `fonts`/`extraConfig` declarations and the new `config` submodule with
its `mkRemovedOptionModule` stubs):

- New API: `services.kmscon.config` merges the font and palette keys, fontconfig is enabled, the package is registered,
  all assertions pass, and a fractional size serializes without a type error.
- Legacy API: `services.kmscon.config` is never defined (no "option does not exist"), and `fonts` + `extraConfig` carry
  the font and palette.

`nixfmt-rfc-style`, `deadnix`, and `statix` are clean.

Closes #2334

---

- [x] I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [x] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [x] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [x] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup) (evaluated against both kmscon option sets; see Validation)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html) (kmscon has no testbed)
- [x] Each commit in this PR is suitable for backport to the current stable branch
