### PR TITLE
stylix/release: bump to 26.11

### DIFF
--- a/stylix/release.nix
+++ b/stylix/release.nix
@@ -3,7 +3,7 @@
   options.stylix = {
     release = lib.mkOption {
       description = "The version of NixOS that Stylix is built to support";
-      default = "26.05";
+      default = "26.11";
       internal = true;
       readOnly = true;
     };


### PR DESCRIPTION
26.05 has been branched off, so we can now update `stylix.release` to 26.11
<!-- Describe your PR above, following Stylix commit conventions. -->

---

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [x] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [x] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [ ] Each commit in this PR is suitable for backport to the current stable branch
