### PR TITLE
doc/src/backport_policy: add maintainer changes to backport criteria

### DIFF
--- a/doc/src/backport_policy.md
+++ b/doc/src/backport_policy.md
@@ -4,9 +4,9 @@ The backport policy defines what changes from the unstable (master) branch are
 applied to the current stable (`release-*.*`) branch.
 
 To reduce maintenance efforts and improve stability on stable branches, security
-fixes, bug fixes, and CI changes are backported, while new features, modules,
-and theme improvements are not backported. Upstream changes causing theming
-issues are considered a bug.
+fixes, bug fixes, CI changes, and maintainer changes are backported, while new
+features, modules, and theme improvements are not backported. Upstream changes
+causing theming issues are considered a bug.
 
 New modules and theme improvements may be backported when explicitly requested
 and backporting is trivial.

--- a/doc/src/backport_policy.md
+++ b/doc/src/backport_policy.md
@@ -4,9 +4,9 @@ The backport policy defines what changes from the unstable (master) branch are
 applied to the current stable (`release-*.*`) branch.
 
 To reduce maintenance efforts and improve stability on stable branches, security
-fixes, bug fixes, CI changes, and maintainer changes are backported, while new
-features, modules, and theme improvements are not backported. Upstream changes
-causing theming issues are considered a bug.
+fixes, bug fixes, and CI changes are backported, while new features, modules,
+and theme improvements are not backported. Upstream changes causing theming
+issues are considered a bug and maintainer changes are considered as CI changes.
 
 New modules and theme improvements may be backported when explicitly requested
 and backporting is trivial.


### PR DESCRIPTION
```
Add maintainer changes to the backport criteria to remove ambiguity
about whether they are included in the existing CI condition.

Maintainer changes should be backported to keep maintainer notifications
in sync between the unstable and stable branches.
```

Should we really explicitly mention this or is the CI implication enough?

<!-- Describe your PR above, following Stylix commit conventions. -->

---

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [X] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [X] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [ ] Each commit in this PR is [suitable for backport](https://nix-community.github.io/stylix/backport_policy.html)
