### PR TITLE
hyprland: remove skoove from maintainers

### DIFF
--- a/generated/all-maintainers.nix
+++ b/generated/all-maintainers.nix
@@ -231,12 +231,6 @@
     githubId = 19377854;
     name = "jamie";
   };
-  skoove = {
-    email = "zie@sturges.com.au";
-    github = "skoove";
-    githubId = 53106860;
-    name = "Zie Sturges";
-  };
   trueNAHO = {
     email = "nix@noahbiewesch.com";
     github = "trueNAHO";

--- a/modules/hyprland/meta.nix
+++ b/modules/hyprland/meta.nix
@@ -2,8 +2,5 @@
 {
   name = "Hyprland";
   homepage = "https://github.com/hyprwm/Hyprland";
-  maintainers = with lib.maintainers; [
-    noahbiewesch
-    skoove
-  ];
+  maintainers = [ lib.maintainers.noahbiewesch ];
 }

--- a/stylix/maintainers.nix
+++ b/stylix/maintainers.nix
@@ -83,12 +83,6 @@
     github = "skiletro";
     githubId = 19377854;
   };
-  skoove = {
-    email = "zie@sturges.com.au";
-    name = "Zie Sturges";
-    github = "skoove";
-    githubId = 53106860;
-  };
   vidhanio = {
     email = "me@vidhan.io";
     name = "Vidhan Bhatt";


### PR DESCRIPTION
```
Link: https://github.com/nix-community/stylix/pull/2316#issuecomment-4459406794
Reverts: 6421b5c2d268 ("hyprland: add skoove as maintainer (#1030)")
```

@skoove, could you approve whether this is appropriate?

<!-- Describe your PR above, following Stylix commit conventions. -->

---

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [X] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [X] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [X] Each commit in this PR is [suitable for backport](https://nix-community.github.io/stylix/backport_policy.html)
    - The fact that this needs to be backported may be explicitly listed in https://github.com/nix-community/stylix/pull/2344.
