### PR TITLE
opencode: fix light theme

### DIFF
--- a/modules/opencode/hm.nix
+++ b/modules/opencode/hm.nix
@@ -13,31 +13,31 @@ mkTarget {
             theme = {
               accent = {
                 dark = colors.withHashtag.base0F;
-                light = colors.withHashtag.base07;
+                light = colors.withHashtag.base0F;
               };
               background = {
                 dark = colors.withHashtag.base00;
-                light = colors.withHashtag.base06;
+                light = colors.withHashtag.base00;
               };
               backgroundElement = {
                 dark = colors.withHashtag.base01;
-                light = colors.withHashtag.base04;
+                light = colors.withHashtag.base01;
               };
               backgroundPanel = {
                 dark = colors.withHashtag.base01;
-                light = colors.withHashtag.base05;
+                light = colors.withHashtag.base01;
               };
               border = {
                 dark = colors.withHashtag.base02;
-                light = colors.withHashtag.base03;
+                light = colors.withHashtag.base02;
               };
               borderActive = {
                 dark = colors.withHashtag.base03;
-                light = colors.withHashtag.base02;
+                light = colors.withHashtag.base03;
               };
               borderSubtle = {
                 dark = colors.withHashtag.base02;
-                light = colors.withHashtag.base03;
+                light = colors.withHashtag.base02;
               };
               diffAdded = {
                 dark = colors.withHashtag.base0B;
@@ -45,11 +45,11 @@ mkTarget {
               };
               diffAddedBg = {
                 dark = colors.withHashtag.base01;
-                light = colors.withHashtag.base05;
+                light = colors.withHashtag.base01;
               };
               diffAddedLineNumberBg = {
                 dark = colors.withHashtag.base01;
-                light = colors.withHashtag.base05;
+                light = colors.withHashtag.base01;
               };
               diffContext = {
                 dark = colors.withHashtag.base03;
@@ -57,7 +57,7 @@ mkTarget {
               };
               diffContextBg = {
                 dark = colors.withHashtag.base01;
-                light = colors.withHashtag.base05;
+                light = colors.withHashtag.base01;
               };
               diffHighlightAdded = {
                 dark = colors.withHashtag.base0B;
@@ -73,7 +73,7 @@ mkTarget {
               };
               diffLineNumber = {
                 dark = colors.withHashtag.base03;
-                light = colors.withHashtag.base04;
+                light = colors.withHashtag.base03;
               };
               diffRemoved = {
                 dark = colors.withHashtag.base08;
@@ -81,11 +81,11 @@ mkTarget {
               };
               diffRemovedBg = {
                 dark = colors.withHashtag.base01;
-                light = colors.withHashtag.base05;
+                light = colors.withHashtag.base01;
               };
               diffRemovedLineNumberBg = {
                 dark = colors.withHashtag.base01;
-                light = colors.withHashtag.base05;
+                light = colors.withHashtag.base01;
               };
               error = {
                 dark = colors.withHashtag.base08;
@@ -93,11 +93,11 @@ mkTarget {
               };
               info = {
                 dark = colors.withHashtag.base0C;
-                light = colors.withHashtag.base0F;
+                light = colors.withHashtag.base0C;
               };
               markdownBlockQuote = {
                 dark = colors.withHashtag.base03;
-                light = colors.withHashtag.base01;
+                light = colors.withHashtag.base03;
               };
               markdownCode = {
                 dark = colors.withHashtag.base0B;
@@ -105,19 +105,19 @@ mkTarget {
               };
               markdownCodeBlock = {
                 dark = colors.withHashtag.base01;
-                light = colors.withHashtag.base00;
+                light = colors.withHashtag.base01;
               };
               markdownEmph = {
                 dark = colors.withHashtag.base0A;
-                light = colors.withHashtag.base09;
+                light = colors.withHashtag.base0A;
               };
               markdownHeading = {
                 dark = colors.withHashtag.base0E;
-                light = colors.withHashtag.base0F;
+                light = colors.withHashtag.base0E;
               };
               markdownHorizontalRule = {
                 dark = colors.withHashtag.base04;
-                light = colors.withHashtag.base03;
+                light = colors.withHashtag.base04;
               };
               markdownImage = {
                 dark = colors.withHashtag.base0D;
@@ -125,7 +125,7 @@ mkTarget {
               };
               markdownImageText = {
                 dark = colors.withHashtag.base0C;
-                light = colors.withHashtag.base07;
+                light = colors.withHashtag.base0C;
               };
               markdownLink = {
                 dark = colors.withHashtag.base0D;
@@ -133,31 +133,31 @@ mkTarget {
               };
               markdownLinkText = {
                 dark = colors.withHashtag.base0C;
-                light = colors.withHashtag.base07;
+                light = colors.withHashtag.base0C;
               };
               markdownListEnumeration = {
                 dark = colors.withHashtag.base0C;
-                light = colors.withHashtag.base07;
+                light = colors.withHashtag.base0C;
               };
               markdownListItem = {
                 dark = colors.withHashtag.base0D;
-                light = colors.withHashtag.base0F;
+                light = colors.withHashtag.base0D;
               };
               markdownStrong = {
                 dark = colors.withHashtag.base09;
-                light = colors.withHashtag.base0A;
+                light = colors.withHashtag.base09;
               };
               markdownText = {
                 dark = colors.withHashtag.base05;
-                light = colors.withHashtag.base00;
+                light = colors.withHashtag.base05;
               };
               primary = {
                 dark = colors.withHashtag.base0D;
-                light = colors.withHashtag.base0F;
+                light = colors.withHashtag.base0D;
               };
               secondary = {
                 dark = colors.withHashtag.base0E;
-                light = colors.withHashtag.base0D;
+                light = colors.withHashtag.base0E;
               };
               success = {
                 dark = colors.withHashtag.base0B;
@@ -165,29 +165,27 @@ mkTarget {
               };
               syntaxComment = {
                 dark = colors.withHashtag.base04;
-                light = colors.withHashtag.base03;
+                light = colors.withHashtag.base04;
               };
               syntaxFunction = {
                 dark = colors.withHashtag.base0D;
-                light = colors.withHashtag.base0C;
+                light = colors.withHashtag.base0D;
               };
               syntaxKeyword = {
                 dark = colors.withHashtag.base0E;
-
-                light = colors.withHashtag.base0D;
-
+                light = colors.withHashtag.base0E;
               };
               syntaxNumber = {
                 dark = colors.withHashtag.base09;
-                light = colors.withHashtag.base0E;
+                light = colors.withHashtag.base09;
               };
               syntaxOperator = {
                 dark = colors.withHashtag.base0C;
-                light = colors.withHashtag.base0D;
+                light = colors.withHashtag.base0C;
               };
               syntaxPunctuation = {
                 dark = colors.withHashtag.base05;
-                light = colors.withHashtag.base00;
+                light = colors.withHashtag.base05;
               };
               syntaxString = {
                 dark = colors.withHashtag.base0B;
@@ -195,7 +193,7 @@ mkTarget {
               };
               syntaxType = {
                 dark = colors.withHashtag.base0A;
-                light = colors.withHashtag.base07;
+                light = colors.withHashtag.base0A;
               };
               syntaxVariable = {
                 dark = colors.withHashtag.base07;
@@ -203,11 +201,11 @@ mkTarget {
               };
               text = {
                 dark = colors.withHashtag.base05;
-                light = colors.withHashtag.base00;
+                light = colors.withHashtag.base05;
               };
               textMuted = {
                 dark = colors.withHashtag.base04;
-                light = colors.withHashtag.base01;
+                light = colors.withHashtag.base04;
               };
               warning = {
                 dark = colors.withHashtag.base0A;


### PR DESCRIPTION

<!-- Describe your PR above, following Stylix commit conventions. -->
Fixes light themes. Like here https://github.com/nix-community/stylix/pull/2192 , but I think this is a better fix. This way stylix handles the polarity, not opencode.

Before (catppuccin-latte):

<img width="1878" height="1394" alt="image" src="https://github.com/user-attachments/assets/afa18673-51d2-437c-8a7f-51ed119fdf8a" />

After: on the left, the opencode builtin catppuccin (light) theme. On the right, the stylix catppuccin-latte theme applied.

<img width="3734" height="1362" alt="screenshot-1780482800-13:33:20" src="https://github.com/user-attachments/assets/3016bd98-11ea-4c98-b187-a5ba9ca76f45" />

Some differences, but better than what was there before (+ I think these diffs exist on dark theme too).

Supersedes: https://github.com/nix-community/stylix/pull/2192
Supersedes: https://github.com/nix-community/stylix/pull/2322

---

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [x] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [x] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [x] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [x] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [x] Each commit in this PR is [suitable for backport](https://nix-community.github.io/stylix/backport_policy.html)
