### PR TITLE
ci: update-flake: bump stable branch to 26.05

### DIFF
--- a/.github/workflows/update-flake.yml
+++ b/.github/workflows/update-flake.yml
@@ -16,7 +16,7 @@ jobs:
     if: vars.APP_ID
     strategy:
       matrix:
-        branch: [master, release-25.11]
+        branch: [master, release-26.05]
     steps:
       - id: generate-token
         uses: actions/create-github-app-token@v3


### PR DESCRIPTION
Removed 25.11 because of reasons specified in https://github.com/nix-community/stylix/issues/2325#issuecomment-4585611937
<!-- Describe your PR above, following Stylix commit conventions. -->

---

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [x] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [x] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [x] Each commit in this PR is [suitable for backport](https://nix-community.github.io/stylix/backport_policy.html)
