### PR TITLE
gnome: update to GNOME 50

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -123,18 +123,20 @@
     "gnome-shell": {
       "flake": false,
       "locked": {
+        "host": "gitlab.gnome.org",
         "lastModified": 1776175984,
         "narHash": "sha256-RJFlFW8GiMei6oqUGrMkGEvVqOH8U7Q8abc1yK4VKD8=",
         "owner": "GNOME",
         "repo": "gnome-shell",
         "rev": "e0fdc4c13250e9a9b8ea9594c83925274f4a5dca",
-        "type": "github"
+        "type": "gitlab"
       },
       "original": {
+        "host": "gitlab.gnome.org",
         "owner": "GNOME",
         "ref": "50.1",
         "repo": "gnome-shell",
-        "type": "github"
+        "type": "gitlab"
       }
     },
     "nixpkgs": {

--- a/flake.lock
+++ b/flake.lock
@@ -123,17 +123,17 @@
     "gnome-shell": {
       "flake": false,
       "locked": {
-        "lastModified": 1767737596,
-        "narHash": "sha256-eFujfIUQDgWnSJBablOuG+32hCai192yRdrNHTv0a+s=",
+        "lastModified": 1776175984,
+        "narHash": "sha256-RJFlFW8GiMei6oqUGrMkGEvVqOH8U7Q8abc1yK4VKD8=",
         "owner": "GNOME",
         "repo": "gnome-shell",
-        "rev": "ef02db02bf0ff342734d525b5767814770d85b49",
+        "rev": "e0fdc4c13250e9a9b8ea9594c83925274f4a5dca",
         "type": "github"
       },
       "original": {
         "owner": "GNOME",
+        "ref": "50.1",
         "repo": "gnome-shell",
-        "rev": "ef02db02bf0ff342734d525b5767814770d85b49",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -51,7 +51,7 @@
       # TODO: Unlocking the input and pointing to official repository requires
       # updating the patch:
       # https://github.com/nix-community/stylix/pull/224#discussion_r1460339607.
-      url = "github:GNOME/gnome-shell/ef02db02bf0ff342734d525b5767814770d85b49";
+      url = "github:GNOME/gnome-shell/50.1";
       flake = false;
     };
 

--- a/flake.nix
+++ b/flake.nix
@@ -50,7 +50,7 @@
     gnome-shell = {
       # Lock the gnome-shell input to minimize breaking changes and
       # patching.
-      url = "github:GNOME/gnome-shell/50.1";
+      url = "gitlab:GNOME/gnome-shell/50.1?host=gitlab.gnome.org";
       flake = false;
     };
 

--- a/flake.nix
+++ b/flake.nix
@@ -48,9 +48,8 @@
     };
 
     gnome-shell = {
-      # TODO: Unlocking the input and pointing to official repository requires
-      # updating the patch:
-      # https://github.com/nix-community/stylix/pull/224#discussion_r1460339607.
+      # Lock the gnome-shell input to minimize breaking changes and
+      # patching.
       url = "github:GNOME/gnome-shell/50.1";
       flake = false;
     };

--- a/modules/gnome/colors.scss.mustache
+++ b/modules/gnome/colors.scss.mustache
@@ -75,6 +75,8 @@ $active_fg_color: #{{base05-hex}};
 
 $accent_borders_color: transparentize(#{{base0D-hex}}, 0.5);
 
+$card_insensitive_fg_color: if($variant =='light', darken($insensitive_fg_color, 5%), lighten($insensitive_fg_color, 9%));
+
 // Other required variables
 
 $_base_color_light: #{{base00-hex}}; // Foreground color of screen sharing/recording indicator


### PR DESCRIPTION
Updates gnome-shell's flake input to point to 50.1 and fixes the error described in https://github.com/nix-community/stylix/issues/2327 by setting `$card_insensitive_fg_color` to the default upstream in https://github.com/GNOME/gnome-shell/blob/eaa4e0577a08c3ed38b5f512b4af0b88ede7f1f5/data/theme/gnome-shell-sass/_colors.scss#L77.

Closes: https://github.com/nix-community/stylix/issues/2327

---

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [x] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [x] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [x] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [x] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [x] Each commit in this PR is [suitable for backport](https://nix-community.github.io/stylix/backport_policy.html)
