### PR TITLE
[release-26.05] wob: add lyndeno as maintainer and add testbed

### DIFF
--- a/generated/all-maintainers.nix
+++ b/generated/all-maintainers.nix
@@ -30,6 +30,12 @@
     githubId = 64027365;
     name = "Erin Pletches";
   };
+  Lyndeno = {
+    email = "lsanche@lyndeno.ca";
+    github = "Lyndeno";
+    githubId = 13490857;
+    name = "Lyndon Sanche";
+  };
   MrSom3body = {
     email = "nix@sndh.dev";
     github = "MrSom3body";

--- a/modules/wob/meta.nix
+++ b/modules/wob/meta.nix
@@ -1,5 +1,6 @@
+{ lib, ... }:
 {
   name = "wob";
   homepage = "https://github.com/francma/wob";
-  maintainers = [ ];
+  maintainers = [ lib.maintainers.lyndeno ];
 }

--- a/modules/wob/testbeds/wob.nix
+++ b/modules/wob/testbeds/wob.nix
@@ -1,0 +1,18 @@
+{ lib, pkgs, ... }:
+{
+  stylix.testbed.ui = {
+    graphicalEnvironment = "hyprland";
+    command.text = lib.getExe (
+      pkgs.writeShellScriptBin "wob-invoker" ''
+        while true; do
+          for percent in {0..200}; do
+            echo "$percent" >"$XDG_RUNTIME_DIR/wob.sock"
+            sleep 0.05
+          done
+        done
+      ''
+    );
+  };
+
+  home-manager.sharedModules = lib.singleton { services.wob.enable = true; };
+}


### PR DESCRIPTION
Manual backport of https://github.com/nix-community/stylix/pull/2310 without `[PATCH 1/3] wob: zero-pad opacity hex string to two characters`, as commit 525965744b77 ("wob: support opacity (#2222)") has not been backported.

<!-- Describe your PR above, following Stylix commit conventions. -->

---

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [X] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [X] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [ ] Each commit in this PR is [suitable for backport](https://nix-community.github.io/stylix/backport_policy.html)
