### PR TITLE
noctalia: add module for v5

### DIFF
--- a/flake/dev/flake.lock
+++ b/flake/dev/flake.lock
@@ -230,11 +230,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780194487,
-        "narHash": "sha256-M+YtjKCTkHrkplNaKVyaxfa8hAWjRF6wFOUBAZvxQ4U=",
+        "lastModified": 1780799499,
+        "narHash": "sha256-YloRtLqJabzYUWvdLyh67zH4DZrR3kQj+dlQJwLPmPM=",
         "owner": "noctalia-dev",
         "repo": "noctalia-qs",
-        "rev": "07398e12b54f194e3a2d47c87e3fd10b8eeaa27d",
+        "rev": "f308426239665e3bc3d624014e9295b2ae2f58ff",
         "type": "github"
       },
       "original": {
@@ -251,16 +251,17 @@
         "noctalia-qs": "noctalia-qs"
       },
       "locked": {
-        "lastModified": 1780197945,
-        "narHash": "sha256-zeluNQgRgTglqKnv5EaM7DzSaqmrCdqTocmaWC7dxy0=",
+        "lastModified": 1780949817,
+        "narHash": "sha256-2oJuPyt+4dd+ZzO7TFqpmkSAAYpRg9SF4eV8kJGl6Tk=",
         "owner": "noctalia-dev",
-        "repo": "noctalia-shell",
-        "rev": "b16dc50250af05d5048ac454dbf4e898d1adcac0",
+        "repo": "noctalia",
+        "rev": "f816591afc2f2f606d1f0cf70b51e95c04a7a8aa",
         "type": "github"
       },
       "original": {
         "owner": "noctalia-dev",
-        "repo": "noctalia-shell",
+        "ref": "legacy-v4",
+        "repo": "noctalia",
         "type": "github"
       }
     },

--- a/flake/dev/flake.lock
+++ b/flake/dev/flake.lock
@@ -196,6 +196,26 @@
         "type": "github"
       }
     },
+    "noctalia": {
+      "inputs": {
+        "nixpkgs": [
+          "dev-nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781121630,
+        "narHash": "sha256-FvJwY670/K4i6YNfA1+1MlcM9A2tB4NYt4X26NeauH8=",
+        "owner": "noctalia-dev",
+        "repo": "noctalia",
+        "rev": "7a623c36b6d9964ea833ed996f7fedc4307ea7c3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "noctalia-dev",
+        "repo": "noctalia",
+        "type": "github"
+      }
+    },
     "noctalia-qs": {
       "inputs": {
         "nixpkgs": [
@@ -283,6 +303,7 @@
         "git-hooks": "git-hooks",
         "home-manager": "home-manager",
         "nixvim": "nixvim",
+        "noctalia": "noctalia",
         "noctalia-shell": "noctalia-shell",
         "nvf": "nvf",
         "spicetify-nix": "spicetify-nix",

--- a/flake/dev/flake.nix
+++ b/flake/dev/flake.nix
@@ -169,7 +169,7 @@
     };
 
     noctalia-shell = {
-      url = "github:noctalia-dev/noctalia-shell";
+      url = "github:noctalia-dev/noctalia/legacy-v4";
       inputs = {
         nixpkgs.follows = "dev-nixpkgs";
         noctalia-qs.inputs = {

--- a/flake/dev/flake.nix
+++ b/flake/dev/flake.nix
@@ -163,6 +163,11 @@
       };
     };
 
+    noctalia = {
+      url = "github:noctalia-dev/noctalia";
+      inputs.nixpkgs.follows = "dev-nixpkgs";
+    };
+
     noctalia-shell = {
       url = "github:noctalia-dev/noctalia-shell";
       inputs = {

--- a/generated/all-maintainers.nix
+++ b/generated/all-maintainers.nix
@@ -55,6 +55,15 @@
     matrix = "@noodlez1232:matrix.org";
     name = "Nathaniel Barragan";
   };
+  Swarsel = {
+    email = "leon@swarsel.win";
+    github = "Swarsel";
+    githubId = 32304731;
+    keys = [
+      { fingerprint = "4BE7 9252 6228 9B47 6DBB  C17B 76FD 3810 215A E097"; }
+    ];
+    name = "Leon Schwarzäugl";
+  };
   TheColorman = {
     email = "nixpkgs@colorman.me";
     github = "TheColorman";

--- a/modules/noctalia-shell/hm.nix
+++ b/modules/noctalia-shell/hm.nix
@@ -5,6 +5,11 @@
   ...
 }:
 mkTarget {
+  autoEnable =
+    lib.warnIf (lib.oldestSupportedReleaseIsAtLeast 2705)
+      "stylix: `config.stylix.targets.noctalia-shell` targets the deprecated Noctalia v4 and is replaced by Noctalia v5 with `config.stylix.targets.noctalia`, with `config.stylix.targets.noctalia-shell` being removed after 27.11."
+      true;
+
   config = lib.optionals (options.programs ? noctalia-shell) [
     (
       { colors }:

--- a/modules/noctalia/hm.nix
+++ b/modules/noctalia/hm.nix
@@ -1,0 +1,101 @@
+{
+  mkTarget,
+  lib,
+  options,
+  ...
+}:
+let
+  theme = "stylix";
+in
+mkTarget {
+  config = lib.optionals (options.programs ? noctalia) [
+    (
+      { colors }:
+      {
+        programs.noctalia = {
+          settings.theme = {
+            source = "custom";
+            custom_palette = theme;
+          };
+
+          customPalettes.${theme}.dark = with colors.withHashtag; {
+            mPrimary = base0D;
+            mOnPrimary = base00;
+            mSecondary = base0E;
+            mOnSecondary = base00;
+            mTertiary = base0C;
+            mOnTertiary = base00;
+            mError = base08;
+            mOnError = base00;
+            mSurface = base00;
+            mOnSurface = base05;
+            mHover = base0C;
+            mOnHover = base00;
+            mSurfaceVariant = base01;
+            mOnSurfaceVariant = base04;
+            mOutline = base03;
+            mShadow = base00;
+
+            terminal = {
+              foreground = base05;
+              background = base00;
+              cursor = base05;
+              cursorText = base00;
+              selectionFg = base05;
+              selectionBg = base02;
+              normal = {
+                black = base00;
+                red = base08;
+                green = base0B;
+                yellow = base0A;
+                blue = base0D;
+                magenta = base0E;
+                cyan = base0C;
+                white = base05;
+              };
+              bright = {
+                black = base03;
+                red = base08;
+                green = base0B;
+                yellow = base0A;
+                blue = base0D;
+                magenta = base0E;
+                cyan = base0C;
+                white = base07;
+              };
+            };
+          };
+        };
+      }
+    )
+    (
+      { polarity }:
+      {
+        programs.noctalia.settings.theme.mode =
+          if polarity == "dark" then polarity else "light";
+      }
+    )
+    (
+      { opacity }:
+      {
+        programs.noctalia.settings = {
+          dock.background_opacity = opacity.desktop;
+          notification.background_opacity = opacity.popups;
+          osd.background_opacity = opacity.popups;
+        };
+      }
+    )
+    (
+      { fonts }:
+      {
+        programs.noctalia.settings.shell.font_family = fonts.sansSerif.name;
+      }
+    )
+    (
+      { image }:
+      {
+        programs.noctalia.settings.wallpaper.default.path = image;
+      }
+    )
+  ];
+}

--- a/modules/noctalia/meta.nix
+++ b/modules/noctalia/meta.nix
@@ -1,0 +1,6 @@
+{ lib, ... }:
+{
+  name = "Noctalia";
+  homepage = "https://docs.noctalia.dev/v5";
+  maintainers = [ lib.maintainers.swarsel ];
+}

--- a/modules/noctalia/testbeds/noctalia.nix
+++ b/modules/noctalia/testbeds/noctalia.nix
@@ -1,0 +1,9 @@
+{ lib, ... }:
+{
+  stylix.testbed.ui = {
+    graphicalEnvironment = "hyprland";
+    command.text = "noctalia";
+  };
+
+  home-manager.sharedModules = lib.singleton { programs.noctalia.enable = true; };
+}

--- a/stylix/testbed/default.nix
+++ b/stylix/testbed/default.nix
@@ -51,6 +51,8 @@ let
                 inputs.noctalia-shell.homeModules.default
               ];
 
+              noctalia.home-manager.sharedModules = [ inputs.noctalia.homeModules.default ];
+
               nvf = inputs.nvf.nixosModules.default;
 
               vicinae.home-manager.sharedModules = [


### PR DESCRIPTION
[Noctalia](https://github.com/noctalia-dev/noctalia) recently made their v5 available, which uses a completely different config scheme than v4. This PR adds support for it

I think currently many people have not yet migrated their configs to v5; since, conveniently, the noctalia team also decided to rename the option from `noctalia-shell` to `noctalia` I added an extra input on the recent version and added v5 support as an extra module. I hope this approach is acceptable, but I am open to your thoughts.

Two notes: 

1) I think many people nixify their noctalia config by getting the config dump and then using some kind of tool to import it into their nix config, redifining the definitions present in stylix in the process - this would then often error. I (somewhat arbitrarily) overrode them with priority 60 so that users can use our styling out of the box but retain the ability to `mkForce` - I am open to change this though if that is controversial (I also thought about adding eval warnings for that case, but I think it does not warrant the amount of extra code that would add)

2) I do not style the bar opacity since bars are now named instances and I did not want to accidentally create an extra bar in the user config

<!-- Describe your PR above, following Stylix commit conventions. -->

---

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [x] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [x] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [x] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [x] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [x] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [] Each commit in this PR is [suitable for backport](https://nix-community.github.io/stylix/backport_policy.html)
