### PR TITLE
zen-browser: theme canvas and inputs

### DIFF
--- a/modules/zen-browser/userContent.nix
+++ b/modules/zen-browser/userContent.nix
@@ -10,6 +10,11 @@ with colors;
       --color-accent-primary-active: #${base0D-hex} !important;
       background-color: #${base00-hex}${opacityHex} !important;
       --in-content-page-background: #${base00-hex}${opacityHex} !important;
+      --background-color-canvas: #${base00-hex}${opacityHex} !important;
+    }
+
+    input {
+      background-color: #${base02-hex}${opacityHex} !important;
     }
   }
 


### PR DESCRIPTION
Themes Zen Browser `about:` page canvas and input backgrounds.

This fixes unthemed backgrounds near input fields in `about:` pages like `about:preferences` and `about:config`.
 
Original | Fixed |
| :---: | :---: |
|<img width="400" alt="image" src="https://github.com/user-attachments/assets/30cb57c9-97dd-4cd8-822f-9bccd3ae4e75" /> | <img width="400" alt="image" src="https://github.com/user-attachments/assets/5254ea3c-a521-45ce-90cd-a5110deaec1c" /> |
---

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [x] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [x] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [x] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [x] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [x] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [x] Each commit in this PR is [suitable for backport](https://nix-community.github.io/stylix/backport_policy.html)
