### PR TITLE
wayle: init

### DIFF
--- a/flake/dev/pre-commit.nix
+++ b/flake/dev/pre-commit.nix
@@ -39,6 +39,7 @@
             enable = true;
             settings.config.default.extend-identifiers = lib.genAttrs [
               "MrSom3body"
+              "Relm4"
               "substituters"
             ] lib.id;
           };

--- a/generated/all-maintainers.nix
+++ b/generated/all-maintainers.nix
@@ -103,6 +103,12 @@
     githubId = 86579;
     name = "Chet Luther";
   };
+  csanthiago = {
+    email = "git@csanthiago.dev";
+    github = "csanthiago";
+    githubId = 8346803;
+    name = "Cirios Santhiago";
+  };
   danth = {
     email = "danth@danth.me";
     github = "danth";

--- a/modules/wayle/hm.nix
+++ b/modules/wayle/hm.nix
@@ -1,0 +1,31 @@
+{ mkTarget, ... }:
+mkTarget {
+  config = [
+    (
+      { fonts }:
+      {
+        services.wayle.settings.general = {
+          font-sans = fonts.sansSerif.name;
+          font-mono = fonts.monospace.name;
+        };
+      }
+    )
+    (
+      { colors }:
+      {
+        services.wayle.settings.styling.palette = with colors.withHashtag; {
+          bg = base00;
+          surface = base01;
+          elevated = base02;
+          fg = base05;
+          fg-muted = base04;
+          primary = base0D;
+          red = base08;
+          yellow = base0A;
+          green = base0B;
+          blue = base0D;
+        };
+      }
+    )
+  ];
+}

--- a/modules/wayle/meta.nix
+++ b/modules/wayle/meta.nix
@@ -1,0 +1,10 @@
+{ lib, ... }:
+{
+  name = "Wayle";
+  homepage = "https://github.com/wayle-rs/wayle";
+  maintainers = [ lib.maintainers.csanthiago ];
+  description = ''
+    A Wayland desktop shell with the bar, notifications, OSD, wallpaper, and
+    device controls built in. Written in Rust with GTK4 and Relm4.
+  '';
+}

--- a/modules/wayle/testbeds/wayle.nix
+++ b/modules/wayle/testbeds/wayle.nix
@@ -1,0 +1,5 @@
+{ lib, pkgs, ... }:
+{
+  stylix.testbed.ui.command.text = lib.getExe pkgs.wayle;
+  home-manager.sharedModules = lib.singleton { services.wayle.enable = true; };
+}

--- a/stylix/maintainers.nix
+++ b/stylix/maintainers.nix
@@ -25,6 +25,12 @@
     github = "cluther";
     githubId = 86579;
   };
+  csanthiago = {
+    name = "Cirios Santhiago";
+    email = "git@csanthiago.dev";
+    github = "csanthiago";
+    githubId = 8346803;
+  };
   gideonwolfe = {
     email = "wolfegideon@gmail.com";
     name = "Gideon Wolfe";


### PR DESCRIPTION
## PR: wayle: init

### Summary

- Add Stylix target for [Wayle](https://github.com/wayle-rs/wayle), a Wayland desktop shell providing a top bar, notifications, OSD, and wallpaper management
- Colors are applied directly in the Home Manager config via `services.wayle.settings.styling.palette`, following the base16 style guide
- Fonts are applied via `services.wayle.settings.general`
- Includes a testbed
- Adds `csanthiago` as module maintainer

Closes: #2300

### Test plan

- [x] I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [x] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [x] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [x] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [ ] Each commit in this PR is [suitable for backport](https://nix-community.github.io/stylix/backport_policy.html)

### AI Usage Disclaimer

This PR was entirely generated with the assistance of AI tools. I reviewed, verified, and tested all changes locally with Stylix before submitting.

💘 Generated with Crush