### PR TITLE
Television theme

### DIFF
--- a/generated/all-maintainers.nix
+++ b/generated/all-maintainers.nix
@@ -103,6 +103,12 @@
     githubId = 86579;
     name = "Chet Luther";
   };
+  csanthiago = {
+    email = "git@csanthiago.dev";
+    github = "csanthiago";
+    githubId = 8346803;
+    name = "Cirios Santhiago";
+  };
   danth = {
     email = "danth@danth.me";
     github = "danth";

--- a/modules/television/hm.nix
+++ b/modules/television/hm.nix
@@ -6,24 +6,27 @@ mkTarget {
   config =
     { colors }:
     {
-      programs.television.settings.ui.theme_overrides = with colors.withHashtag; {
-        background = base00;
-        border_fg = base03;
-        text_fg = base05;
-        dimmed_text_fg = base04;
-        input_text_fg = base05;
-        result_count_fg = base03;
-        result_name_fg = base0D;
-        result_line_number_fg = base03;
-        result_value_fg = base05;
-        selection_bg = base02;
-        selection_fg = base05;
-        match_fg = base0A;
-        preview_title_fg = base0E;
-        channel_mode_fg = base0B;
-        channel_mode_bg = base00;
-        remote_control_mode_fg = base0C;
-        remote_control_mode_bg = base00;
+      programs.television = {
+        settings.ui.theme = "stylix";
+        themes.stylix = with colors.withHashtag; {
+          background = base00;
+          border_fg = base03;
+          text_fg = base05;
+          dimmed_text_fg = base04;
+          input_text_fg = base05;
+          result_count_fg = base03;
+          result_name_fg = base0D;
+          result_line_number_fg = base03;
+          result_value_fg = base05;
+          selection_bg = base02;
+          selection_fg = base05;
+          match_fg = base0A;
+          preview_title_fg = base0E;
+          channel_mode_fg = base0B;
+          channel_mode_bg = base00;
+          remote_control_mode_fg = base0C;
+          remote_control_mode_bg = base00;
+        };
       };
     };
 }

--- a/modules/television/hm.nix
+++ b/modules/television/hm.nix
@@ -1,0 +1,29 @@
+# Documentation is available at:
+# - https://github.com/alexpasmantier/television
+# - `man television`
+{ mkTarget, ... }:
+mkTarget {
+  config =
+    { colors }:
+    {
+      programs.television.settings.ui.theme_overrides = with colors.withHashtag; {
+        background = base00;
+        border_fg = base03;
+        text_fg = base05;
+        dimmed_text_fg = base04;
+        input_text_fg = base05;
+        result_count_fg = base03;
+        result_name_fg = base0D;
+        result_line_number_fg = base03;
+        result_value_fg = base05;
+        selection_bg = base02;
+        selection_fg = base05;
+        match_fg = base0A;
+        preview_title_fg = base0E;
+        channel_mode_fg = base0B;
+        channel_mode_bg = base00;
+        remote_control_mode_fg = base0C;
+        remote_control_mode_bg = base00;
+      };
+    };
+}

--- a/modules/television/meta.nix
+++ b/modules/television/meta.nix
@@ -5,7 +5,7 @@
   maintainers = [ lib.maintainers.csanthiago ];
   description = ''
     A cross-platform, fast, extensible fuzzy finder for the terminal,
-    also known as `tv`. Colors are applied via `ui.theme_overrides` in
-    the Home Manager [settings](https://github.com/nix-community/home-manager/blob/master/modules/programs/television.nix) option.
+    also known as `tv`. Colors are applied via theme files in the Home
+    Manager [themes](https://github.com/nix-community/home-manager/blob/master/modules/programs/television.nix) option.
   '';
 }

--- a/modules/television/meta.nix
+++ b/modules/television/meta.nix
@@ -1,0 +1,11 @@
+{ lib, ... }:
+{
+  name = "Television";
+  homepage = "https://github.com/alexpasmantier/television";
+  maintainers = [ lib.maintainers.csanthiago ];
+  description = ''
+    A cross-platform, fast, extensible fuzzy finder for the terminal,
+    also known as `tv`. Colors are applied via `ui.theme_overrides` in
+    the Home Manager [settings](https://github.com/nix-community/home-manager/blob/master/modules/programs/television.nix) option.
+  '';
+}

--- a/modules/television/testbeds/television.nix
+++ b/modules/television/testbeds/television.nix
@@ -1,0 +1,11 @@
+{ lib, pkgs, ... }:
+{
+  stylix.testbed.ui.command = {
+    text = lib.getExe pkgs.television;
+    useTerminal = true;
+  };
+
+  home-manager.sharedModules = lib.singleton {
+    programs.television.enable = true;
+  };
+}

--- a/stylix/maintainers.nix
+++ b/stylix/maintainers.nix
@@ -25,6 +25,12 @@
     github = "cluther";
     githubId = 86579;
   };
+  csanthiago = {
+    name = "Cirios Santhiago";
+    email = "git@csanthiago.dev";
+    github = "csanthiago";
+    githubId = 8346803;
+  };
   gideonwolfe = {
     email = "wolfegideon@gmail.com";
     name = "Gideon Wolfe";


### PR DESCRIPTION
## PR: television: use theme file generation

### Summary

- Switch from inline `ui.theme_overrides` to generating a separate `stylix.toml` theme file via `programs.television.themes.stylix`
- Sets `ui.theme = "stylix"` in the main config to select the generated theme
- Follows the same pattern as `ghostty`, `helix`, `k9s`, and `foliate`

**Depends on [home-manager#9496](https://github.com/nix-community/home-manager/pull/9496)** — this PR requires the `themes` option from the Home Manager television module. It should not be merged until that PR lands.

This is the second of **two PRs** for television support. The first PR (#2369) uses inline `ui.theme_overrides` and works with the current Home Manager module. Once the HM PR is merged, this PR replaces the inline approach with the cleaner theme file approach. If the HM PR is rejected, this PR should be closed in favor of the first.

### Test plan

- [x] I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [x] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [x] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [x] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [ ] Each commit in this PR is [suitable for backport](https://nix-community.github.io/stylix/backport_policy.html)

### AI Usage Disclaimer

This PR was entirely generated with the assistance of AI tools. I reviewed, verified, and tested all changes locally with Stylix before submitting.

💘 Generated with Crush