### PR TITLE
doc/src/installation: recommend 26.05 as stable branch

### DIFF
--- a/doc/src/installation.md
+++ b/doc/src/installation.md
@@ -46,8 +46,8 @@ Stylix release. For example:
 
 ```nix
 {
-  nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
-  stylix.url = "github:nix-community/stylix/release-25.11";
+  nixpkgs.url = "github:NixOS/nixpkgs/nixos-26.05";
+  stylix.url = "github:nix-community/stylix/release-26.05";
 }
 ```
 
@@ -200,9 +200,9 @@ matching Stylix release. For example:
 
 ```nix
 {
-  nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
-  home-manager.url = "github:nix-community/home-manager/release-25.11";
-  stylix.url = "github:nix-community/stylix/release-25.11";
+  nixpkgs.url = "github:NixOS/nixpkgs/nixos-26.05";
+  home-manager.url = "github:nix-community/home-manager/release-26.05";
+  stylix.url = "github:nix-community/stylix/release-26.05";
 }
 ```
 


### PR DESCRIPTION
stylix/doc/src/installation.md: changing stable from 25.11 to 26.05.

in https://nix-community.github.io/stylix/installation.html it mentions 25.11 as the current stable, while the current stable as of 2026-06-24 is 26.05 a new nixOS user wouldn't notice that its a thing so for simplification and clearness i just changed 25.11 to 26.05 

<!-- Describe your PR above, following Stylix commit conventions. -->

---

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [X] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [ ] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [ ] Each commit in this PR is [suitable for backport](https://nix-community.github.io/stylix/backport_policy.html)
