### PR TITLE
ci: temporarily downgrade actions/checkout from 7 to 6

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -40,7 +40,7 @@ jobs:
           permission-contents: write
           permission-pull-requests: write
 
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -28,7 +28,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
 

--- a/.github/workflows/request-reviewers.yml
+++ b/.github/workflows/request-reviewers.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-24.04
     if: vars.APP_ID
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.base_ref }}
 

--- a/.github/workflows/update-flake.yml
+++ b/.github/workflows/update-flake.yml
@@ -26,7 +26,7 @@ jobs:
           permission-contents: write
           permission-pull-requests: write
 
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v6
         with:
           ref: ${{ matrix.branch }}
           token: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
```
Temporarily downgrade actions/checkout from 7 to 6 until resolving
pull_request_target uses blocked from the otherwise pulled upstream
commit [1] ("block checking out fork pr for pull_request_target and
workflow_run (#2454)").

[1]: https://github.com/actions/checkout/commit/f9e715a95fcd1f9253f77dd28f11e88d2d6460c7

Reverts: a6a493119e49 ("ci: bump actions/checkout from 6 to 7")
```

After merging this, failed backports since the introduction of the faulty commit should be retriggered.

CC: @0xda157

---

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [X] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [X] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [ ] Each commit in this PR is [suitable for backport](https://nix-community.github.io/stylix/backport_policy.html)
    - The reverted commit has not been backported yet.
