### PR TITLE
ci: workflows: rename app-id option to client-id

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -21,7 +21,7 @@ jobs:
 
     if: >
       (
-        vars.APP_ID &&
+        vars.APP_CLIENT_ID &&
         github.event.pull_request.merged == true &&
         (
           github.event.action != 'labeled' ||
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          app-id: ${{ vars.APP_ID }}
+          client-id: ${{ vars.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           permission-contents: write
           permission-pull-requests: write

--- a/.github/workflows/conflicts.yml
+++ b/.github/workflows/conflicts.yml
@@ -14,12 +14,12 @@ defaults:
 jobs:
   conflicts:
     runs-on: ubuntu-24.04
-    if: vars.APP_ID
+    if: vars.APP_CLIENT_ID
     steps:
       - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          app-id: ${{ vars.APP_ID }}
+          client-id: ${{ vars.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           permission-contents: read
           permission-pull-requests: write

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -26,13 +26,13 @@ jobs:
     name: label-pr
     runs-on: ubuntu-24.04
     if: >
-      vars.APP_ID &&
+      vars.APP_CLIENT_ID &&
       !contains(github.event.pull_request.title, '[skip treewide]')
     steps:
       - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          app-id: ${{ vars.APP_ID }}
+          client-id: ${{ vars.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           permission-contents: read
           permission-pull-requests: write

--- a/.github/workflows/request-reviewers.yml
+++ b/.github/workflows/request-reviewers.yml
@@ -14,7 +14,7 @@ defaults:
 jobs:
   request-reviewers:
     runs-on: ubuntu-24.04
-    if: vars.APP_ID
+    if: vars.APP_CLIENT_ID
     steps:
       - uses: actions/checkout@v7
         with:
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          app-id: ${{ vars.APP_ID }}
+          client-id: ${{ vars.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           permission-members: read
           permission-contents: read

--- a/.github/workflows/update-flake.yml
+++ b/.github/workflows/update-flake.yml
@@ -13,7 +13,7 @@ defaults:
 jobs:
   flake-update:
     runs-on: ubuntu-24.04
-    if: vars.APP_ID
+    if: vars.APP_CLIENT_ID
     strategy:
       matrix:
         branch: [master, release-26.05]
@@ -21,7 +21,7 @@ jobs:
       - id: generate-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.APP_ID }}
+          client-id: ${{ vars.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           permission-contents: write
           permission-pull-requests: write


### PR DESCRIPTION
```
Rename actions/create-github-app-token@v3's app-id option to client-id,
following upstream commit [1] ("feat: add client-id input and deprecate
app-id (#353)").

[1]: https://github.com/actions/create-github-app-token/commit/e6bd4e6970172bed9fe138b2eaf4cbffa4cca8f9

Fixes: af924c3d4df1 ("ci: bump actions/create-github-app-token from 2 to 3 (#2241)")
```

The `client-id` deprecation warning can be seen in:

> Input 'app-id' has been deprecated with message: Use 'client-id' instead.
>
> -- https://github.com/nix-community/stylix/actions/runs/28298487630

> [!IMPORTANT]
>
> This requires creating a new `APP_CLIENT_ID` variable in https://github.com/nix-community/stylix/settings/variables/actions. IIUC, although `client-id` should be able to fallback to `APP_ID`, renaming the GitHub variable results in more consistent naming.
>
> IIUC, the new `client-id` should ideally be updated to a different ID scheme, and I believe this requires access to @danth's https://github.com/apps/stylix-automation dashboard. @danth, could you create the `APP_CLIENT_ID` variable in https://github.com/nix-community/stylix/settings/variables/actions with the more idiomatic value, if possible?

> [!CAUTION]
>
> This PR has not been tested.

---

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [X] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [X] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [X] Each commit in this PR is [suitable for backport](https://nix-community.github.io/stylix/backport_policy.html)
