### PR TITLE
zen-browser: add saadndm as maintainer

### DIFF
--- a/generated/all-maintainers.nix
+++ b/generated/all-maintainers.nix
@@ -237,6 +237,12 @@
     githubId = 63157919;
     name = "Alexander";
   };
+  saadndm = {
+    email = "saad29nadeem@gmail.com";
+    github = "saadndm";
+    githubId = 88615188;
+    name = "Saad Nadeem";
+  };
   skiletro = {
     email = "git@skilet.ro";
     github = "skiletro";

--- a/modules/zen-browser/meta.nix
+++ b/modules/zen-browser/meta.nix
@@ -2,7 +2,10 @@
 {
   name = "Zen Browser";
   homepage = "https://zen-browser.app";
-  maintainers = [ lib.maintainers.MrSom3body ];
+  maintainers = with lib.maintainers; [
+    MrSom3body
+    saadndm
+  ];
   description = ''
     This module supports the [Zen Browser](https://zen-browser.app).
 


### PR DESCRIPTION
Added myself as a maintainer for zen-browser as suggested in https://github.com/nix-community/stylix/pull/2365#pullrequestreview-4585950462. (thanks @trueNAHO and @MrSom3body)
<!-- Describe your PR above, following Stylix commit conventions. -->

---

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [x] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [x] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [x] Each commit in this PR is [suitable for backport](https://nix-community.github.io/stylix/backport_policy.html)
