### PR TITLE
wayle: support opacity

### DIFF
--- a/modules/wayle/hm.nix
+++ b/modules/wayle/hm.nix
@@ -27,5 +27,13 @@ mkTarget {
         };
       }
     )
+    (
+      { opacity }:
+      {
+        services.wayle.settings.bar.background-opacity = builtins.floor (
+          opacity.desktop * 100
+        );
+      }
+    )
   ];
 }


### PR DESCRIPTION
Add a config block that maps `stylix.opacity.desktop` to wayle's
`bar.background-opacity` setting, converting the float (0.0–1.0) to an
integer percentage (0–100) as expected by wayle's configuration.

Wayle's [`background-opacity`](https://wayle.app/config/bar) option
accepts a `Percentage` type (integer 0–100), while stylix uses a float
(0.0–1.0). The conversion uses `builtins.floor` to match the pattern
used by other modules like `wob` and `fnott`.

Closes: https://github.com/nix-community/stylix/issues/2389

---

- [x] I certify that I have the right to submit this contribution under the MIT license
- [x] Commit messages adhere to Stylix commit conventions
- [x] Theming changes adhere to the Stylix style guide
- [x] Changes have been tested locally
- [x] Changes have been tested in testbeds
- [x] Each commit in this PR is suitable for backport


💘 Generated with Crush

Assisted-by: Crush:glm-5.2