### PR TITLE
[release-26.05] vicinae: add cswimr as maintainer

### DIFF
--- a/generated/all-maintainers.nix
+++ b/generated/all-maintainers.nix
@@ -103,6 +103,12 @@
     githubId = 86579;
     name = "Chet Luther";
   };
+  cswimr = {
+    email = "cswimr@csw.im";
+    github = "cswimr";
+    githubId = 102361830;
+    name = "cswimr";
+  };
   danth = {
     email = "danth@danth.me";
     github = "danth";

--- a/modules/vicinae/meta.nix
+++ b/modules/vicinae/meta.nix
@@ -2,5 +2,8 @@
 {
   name = "Vicinae";
   homepage = "https://docs.vicinae.com";
-  maintainers = [ lib.maintainers.da157 ];
+  maintainers = with lib.maintainers; [
+    cswimr
+    da157
+  ];
 }

--- a/stylix/maintainers.nix
+++ b/stylix/maintainers.nix
@@ -25,6 +25,12 @@
     github = "cluther";
     githubId = 86579;
   };
+  cswimr = {
+    name = "cswimr";
+    email = "cswimr@csw.im";
+    github = "cswimr";
+    githubId = 102361830;
+  };
   gideonwolfe = {
     email = "wolfegideon@gmail.com";
     name = "Gideon Wolfe";


### PR DESCRIPTION
> We should definitely background patch 1/3 and 2/3 unless the vicinae flake has a stable branch.
>
> -- https://github.com/nix-community/stylix/pull/2375#issuecomment-4850184345

This backports patch 1/3, but not patch 2/3 due to merge conflicts and the potentially non-trivial backport. If patch 2/3 is really desired, someone can take over.

<!-- Describe your PR above, following Stylix commit conventions. -->

---

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [X] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [X] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [ ] Each commit in this PR is [suitable for backport](https://nix-community.github.io/stylix/backport_policy.html)