### PR TITLE
stylix: test the global enable option using assertions

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -162,11 +162,10 @@
                   nix-fast-build
                 ];
                 text = ''
-                  cores="$(nproc)"
                   system="$(nix eval --expr builtins.currentSystem --impure --raw)"
                   nix-fast-build \
                     --eval-max-memory-size 512 \
-                    --eval-workers "$cores" \
+                    --eval-workers 1 \
                     --flake ".#checks.$system" \
                     --no-link \
                     --skip-cached \

--- a/stylix/testbed.nix
+++ b/stylix/testbed.nix
@@ -147,7 +147,7 @@ let
       );
 
       systems = {
-        clean = lib.nixosSystem {
+        base = lib.nixosSystem {
           inherit (pkgs) system;
 
           modules = [
@@ -159,7 +159,21 @@ let
           ];
         };
 
-        disabled = systems.clean.extendModules {
+        clean = systems.base.extendModules {
+          modules = [
+            {
+              options.stylix.targets = lib.mkOption {
+                description = ''
+                  Mock option to replace Stylix options in testbeds before
+                  Stylix is installed; since the testbed may define options
+                  related to the target it is testing.
+                '';
+              };
+            }
+          ];
+        };
+
+        disabled = systems.base.extendModules {
           modules = [
             inputs.self.nixosModules.stylix
           ];


### PR DESCRIPTION
This is a resubmission of #1066, having migrated the branch to my personal fork. Please refer to the original pull request.

---

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [x] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [x] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [ ] Each commit in this PR is [suitable for backport](https://nix-community.github.io/stylix/backport_policy.html)
