### PR TITLE
treewide: remove danth from some targets

### DIFF
--- a/modules/chromium/meta.nix
+++ b/modules/chromium/meta.nix
@@ -2,5 +2,5 @@
 {
   name = "Chromium";
   homepage = "https://www.chromium.org";
-  maintainers = [ lib.maintainers.danth ];
+  maintainers = [ ];
 }

--- a/modules/eog/meta.nix
+++ b/modules/eog/meta.nix
@@ -2,5 +2,5 @@
 {
   name = "Eye of GNOME";
   homepage = "https://gitlab.gnome.org/GNOME/eog";
-  maintainers = [ lib.maintainers.danth ];
+  maintainers = [ ];
 }

--- a/modules/firefox/meta.nix
+++ b/modules/firefox/meta.nix
@@ -8,7 +8,6 @@
   };
   maintainers = with lib.maintainers; [
     Flameopathic
-    danth
     noahbiewesch
   ];
   description = ''

--- a/modules/plymouth/meta.nix
+++ b/modules/plymouth/meta.nix
@@ -2,8 +2,5 @@
 {
   name = "Plymouth";
   homepage = "https://www.freedesktop.org/wiki/Software/Plymouth";
-  maintainers = with lib.maintainers; [
-    _0x5a4
-    danth
-  ];
+  maintainers = with lib.maintainers; [ _0x5a4 ];
 }

--- a/modules/vscode/meta.nix
+++ b/modules/vscode/meta.nix
@@ -2,10 +2,7 @@
 {
   name = "VSCode";
   homepage = "https://code.visualstudio.com";
-  maintainers = with lib.maintainers; [
-    Flameopathic
-    danth
-  ];
+  maintainers = with lib.maintainers; [ Flameopathic ];
   description = ''
     When theming is enabled for VSCode, Stylix will create and apply its own
     VSCode theme, as well as configure settings concerning fonts.


### PR DESCRIPTION
I currently have a large backlog of notifications, and do not have time to maintain these in addition to being a core maintainer.

Chromium is very simple and should be easy for anyone interested to pick up. The upstream documentation is [here](https://chromeenterprise.google/policies/).

Eye of GNOME has largely been replaced by Loupe, so it is unlikely to need further maintenance.

I will continue to maintain GNOME and GTK since I have several ongoing pull requests, plus the procedure for updating GNOME is not well documented.

All other targets I have dropped have at least one other maintainer.

---

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [x] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [x] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [x] Each commit in this PR is [suitable for backport](https://nix-community.github.io/stylix/backport_policy.html)
