### PR TITLE
stylix/hm/cursor: explicitly enable home.pointerCursor.enable

### DIFF
--- a/stylix/hm/cursor.nix
+++ b/stylix/hm/cursor.nix
@@ -18,6 +18,7 @@ in
       {
         home.pointerCursor = {
           inherit (cfg) name package;
+          enable = true;
           size = builtins.floor (cfg.size + 0.5);
           x11.enable = true;
           gtk.enable = true;


### PR DESCRIPTION
… to silence warning:

> [!WARNING]
> Relying on `home.pointerCursor` to enable cursor config generation is deprecated.
> Please update your configuration to explicitly set:
>
>   `home.pointerCursor.enable = true;`

This happens because legacy enable of `home.pointerCursor` has been dropped. See:

- https://github.com/nix-community/home-manager/commit/2ad49968c36044ff10bffc515dc687ea00b4d609
- https://github.com/nix-community/home-manager/commit/1aac8895fea6fcabc6a0184c63a80fb2f99fd208

Also done:
- ~~Refactor the sway module to leverage _Home Manager_ to set the cursor.~~
- ~~Gate the individual backends (x11, gtk, sway) to honour the `targets` system.~~

**UPDATE**: Will tackle those on a separate PR (#2420).

<!-- Describe your PR above, following Stylix commit conventions. -->

---

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [x] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [x] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [x] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [x] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [ ] Each commit in this PR is [suitable for backport](https://nix-community.github.io/stylix/backport_policy.html)

**NOT TO BE BACKPORTED**: since only applies to Home Manager changes from its `master` branch.
