### PR TITLE
ci: dependabot: bump stable branch to 26.05

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,6 @@ updates:
     target-branch: "master"
     schedule:
       interval: daily
-    labels: ["topic: dependencies", "backport: release-25.11"]
+    labels: ["topic: dependencies", "backport: release-26.05"]
     commit-message:
       prefix: "ci"


### PR DESCRIPTION
```
Fixes: 6b6b874d0829 ("ci: update-flake: bump stable branch to 26.05 (#2352)")
```

This resolves the https://github.com/nix-community/stylix/pull/2412#issuecomment-4929750698 error.

---

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [X] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [X] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [X] Each commit in this PR is [suitable for backport](https://nix-community.github.io/stylix/backport_policy.html)
