### PR TITLE
home-manager-integration: forward enableReleaseChecks to Home Manager

### DIFF
--- a/stylix/home-manager-integration.nix
+++ b/stylix/home-manager-integration.nix
@@ -49,6 +49,12 @@ let
         {
           path = [
             "stylix"
+            "enableReleaseChecks"
+          ];
+        }
+        {
+          path = [
+            "stylix"
             "fonts"
             "emoji"
           ];


### PR DESCRIPTION
`stylix.enableReleaseChecks` is documented as a single switch covering the NixOS, Home Manager, and nix-darwin release checks, but it is declared independently per scope in `release.nix` and absent from the `copyModules` forwarding list in `home-manager-integration.nix`, so setting `stylix.enableReleaseChecks = false` in a NixOS configuration silences only the NixOS-side check while the Home Manager check keeps its `true` default and still warns. This forwards it through `copyModules` so a NixOS-level setting propagates to Home Manager.

---

- [x] I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [x] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [x] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [ ] Each commit in this PR is [suitable for backport](https://nix-community.github.io/stylix/backport_policy.html)
