### PR TITLE
pi-coding-agent: init

### DIFF
--- a/generated/all-maintainers.nix
+++ b/generated/all-maintainers.nix
@@ -30,6 +30,12 @@
     githubId = 64027365;
     name = "Erin Pletches";
   };
+  GBHU753 = {
+    email = "me@gurjotbhullar.com";
+    github = "GBHU753";
+    githubId = 100983240;
+    name = "Gurjot Bhullar";
+  };
   Lyndeno = {
     email = "lsanche@lyndeno.ca";
     github = "Lyndeno";

--- a/modules/pi-coding-agent/hm.nix
+++ b/modules/pi-coding-agent/hm.nix
@@ -1,0 +1,72 @@
+{ mkTarget, ... }:
+mkTarget {
+  config = { colors }: {
+    programs.pi-coding-agent.settings.theme = "stylix";
+
+    home.file.".pi/agent/themes/stylix.json".text = builtins.toJSON {
+      "$schema" =
+        "https://raw.githubusercontent.com/earendil-works/pi/main/packages/coding-agent/src/modes/interactive/theme/theme-schema.json";
+      name = "stylix";
+      colors = with colors.withHashtag; {
+        accent = base0D;
+        border = base03;
+        borderAccent = base0D;
+        borderMuted = base02;
+        success = base0B;
+        error = base08;
+        warning = base0A;
+        muted = base04;
+        dim = base03;
+        text = "";
+        thinkingText = base04;
+
+        selectedBg = base02;
+        userMessageBg = base01;
+        userMessageText = "";
+        customMessageBg = base01;
+        customMessageText = "";
+        customMessageLabel = base0D;
+        toolPendingBg = base00;
+        toolSuccessBg = base01;
+        toolErrorBg = base01;
+        toolTitle = base0D;
+        toolOutput = "";
+
+        mdHeading = base0E;
+        mdLink = base0D;
+        mdLinkUrl = base0C;
+        mdCode = base0B;
+        mdCodeBlock = "";
+        mdCodeBlockBorder = base03;
+        mdQuote = base04;
+        mdQuoteBorder = base03;
+        mdHr = base03;
+        mdListBullet = base0C;
+
+        toolDiffAdded = base0B;
+        toolDiffRemoved = base08;
+        toolDiffContext = base04;
+
+        syntaxComment = base03;
+        syntaxKeyword = base0E;
+        syntaxFunction = base0D;
+        syntaxVariable = base08;
+        syntaxString = base0B;
+        syntaxNumber = base09;
+        syntaxType = base0A;
+        syntaxOperator = base0C;
+        syntaxPunctuation = base05;
+
+        thinkingOff = base03;
+        thinkingMinimal = base0D;
+        thinkingLow = base0C;
+        thinkingMedium = base0B;
+        thinkingHigh = base0A;
+        thinkingXhigh = base09;
+        thinkingMax = base08;
+
+        bashMode = base0A;
+      };
+    };
+  };
+}

--- a/modules/pi-coding-agent/meta.nix
+++ b/modules/pi-coding-agent/meta.nix
@@ -1,0 +1,5 @@
+{ lib, ... }: {
+  name = "pi-coding-agent";
+  homepage = "https://pi.dev";
+  maintainers = [ lib.maintainers.gbhu753 ];
+}

--- a/modules/pi-coding-agent/testbeds/pi-coding-agent.nix
+++ b/modules/pi-coding-agent/testbeds/pi-coding-agent.nix
@@ -1,0 +1,10 @@
+{ lib, pkgs, ... }: {
+  stylix.testbed.ui.command = {
+    text = lib.getExe pkgs.pi-coding-agent;
+    useTerminal = true;
+  };
+
+  home-manager.sharedModules = lib.singleton {
+    programs.pi-coding-agent.enable = true;
+  };
+}

--- a/modules/zed/hm.nix
+++ b/modules/zed/hm.nix
@@ -11,14 +11,25 @@ mkTarget {
         };
       };
     })
-    ({ colors, inputs }: {
-      programs.zed-editor = {
-        userSettings.theme = "Base16 ${colors.scheme-name}";
-        themes.stylix = colors {
-          templateRepo = inputs.tinted-zed;
-          target = "base16";
+    (
+      {
+        colors,
+        inputs,
+        polarity,
+      }:
+      {
+        programs.zed-editor = {
+          userSettings.theme = "Base16 ${colors.scheme-name}";
+          themes.stylix =
+            (colors.override {
+              variant = if polarity == "either" then "light" else polarity;
+            })
+              {
+                templateRepo = inputs.tinted-zed;
+                target = "base16";
+              };
         };
-      };
-    })
+      }
+    )
   ];
 }


### PR DESCRIPTION

Adds home-managers pi-coding-agent theming support.
Closes: https://github.com/nix-community/stylix/issues/2421

>  [!WARNING] 
> Assisted by: kimi-k2.6 to check compliance with standard and other modules
---

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [x] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [x] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [x] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [x] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [x] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [ ] Each commit in this PR is [suitable for backport](https://nix-community.github.io/stylix/backport_policy.html)
