### PR TITLE
zed: appearance field unspecified

### DIFF
--- a/modules/zed/hm.nix
+++ b/modules/zed/hm.nix
@@ -11,14 +11,25 @@ mkTarget {
         };
       };
     })
-    ({ colors, inputs }: {
-      programs.zed-editor = {
-        userSettings.theme = "Base16 ${colors.scheme-name}";
-        themes.stylix = colors {
-          templateRepo = inputs.tinted-zed;
-          target = "base16";
+    (
+      {
+        colors,
+        inputs,
+        polarity,
+      }:
+      {
+        programs.zed-editor = {
+          userSettings.theme = "Base16 ${colors.scheme-name}";
+          themes.stylix =
+            (colors.override {
+              variant = if polarity == "either" then "light" else polarity;
+            })
+              {
+                templateRepo = inputs.tinted-zed;
+                target = "base16";
+              };
         };
-      };
-    })
+      }
+    )
   ];
 }


### PR DESCRIPTION
Fixes bug for zed-editor where field appearance is set to unspecified.
Closes: https://github.com/nix-community/stylix/issues/2275

>  [!WARNING] 
> Assisted by: kimi-k2.6 to check compliance with standard and other modules
---

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [x] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [x] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [x] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [x] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [x] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [ ] Each commit in this PR is [suitable for backport](https://nix-community.github.io/stylix/backport_policy.html)