### PR TITLE
feishin: init

### DIFF
--- a/modules/feishin/hm.nix
+++ b/modules/feishin/hm.nix
@@ -9,13 +9,10 @@ mkTarget {
       polarity,
     }:
     let
-      themeDirs = [
-        ".config/feishin"
-      ]
-      ++ lib.optional cfg.dev.enable ".config/feishin-dev";
+      themeDirs = [ "feishin" ] ++ lib.optional cfg.dev.enable "feishin-dev";
     in
     {
-      home.file = builtins.listToAttrs (
+      xdg.configFile = builtins.listToAttrs (
         lib.concatMap (dir: [
           {
             name = "${dir}/Themes/stylix.json";

--- a/modules/feishin/hm.nix
+++ b/modules/feishin/hm.nix
@@ -1,90 +1,14 @@
 { mkTarget, lib, ... }:
 mkTarget {
-  options = {
-    dev.enable = lib.mkEnableOption "installing the theme for the Feishin development build (`~/.config/feishin-dev`) in addition to the stable build";
-  };
+  options.dev.enable = lib.mkEnableOption "installing the theme for the Feishin development build (`~/.config/feishin-dev`) in addition to the stable build";
 
   config =
     {
-      colors,
       cfg,
+      colors,
       polarity,
     }:
     let
-      inherit (colors) withHashtag;
-
-      mode = if polarity == "light" then "light" else "dark";
-
-      themeJson = builtins.toJSON {
-        extends = if mode == "light" then "ayuLight" else "tokyoNight";
-        inherit mode;
-
-        colors = {
-          background = withHashtag.base00;
-          background-alternate = withHashtag.base01;
-          surface = withHashtag.base01;
-          surface-foreground = withHashtag.base06;
-          foreground = withHashtag.base05;
-          foreground-muted = withHashtag.base03;
-
-          primary = withHashtag.base0D;
-
-          state-info = withHashtag.base0D;
-          state-success = withHashtag.base0B;
-          state-warning = withHashtag.base0A;
-          state-error = withHashtag.base08;
-
-          black = withHashtag.base00;
-          white = withHashtag.base07;
-        };
-
-        app = {
-          overlay-header = "linear-gradient(transparent 0%, ${withHashtag.base00}D9 100%), var(--theme-background-noise)";
-          overlay-subheader = "linear-gradient(180deg, ${withHashtag.base00}0D 0%, var(--theme-colors-background) 100%), var(--theme-background-noise)";
-          scrollbar-handle-background = "${withHashtag.base0D}33";
-          scrollbar-handle-hover-background = "${withHashtag.base0D}66";
-        };
-
-        stylesheets = [ "stylix.css" ];
-      };
-
-      themeCss = ''
-        [data-theme="stylix"] ::selection {
-          background-color: ${withHashtag.base0D}59;
-        }
-
-        [data-theme="stylix"] .mantine-Button-root:hover {
-          box-shadow: 0 0 12px ${withHashtag.base0D}40;
-        }
-
-        [data-theme="stylix"] .mantine-Card-root {
-          border: 1px solid ${withHashtag.base02};
-        }
-
-        [data-theme="stylix"] .active,
-        [data-theme="stylix"] [aria-selected="true"] {
-          background: ${withHashtag.base0D}26;
-          color: ${withHashtag.base05};
-        }
-
-        [data-theme="stylix"] tr:hover,
-        [data-theme="stylix"] .mantine-Table-tr:hover {
-          background: ${withHashtag.base01};
-        }
-
-        [data-theme="stylix"] .mantine-Slider-track {
-          background: ${withHashtag.base0D};
-        }
-
-        [data-theme="stylix"] a {
-          color: ${withHashtag.base0D};
-        }
-
-        [data-theme="stylix"] a:hover {
-          color: ${withHashtag.base0C};
-        }
-      '';
-
       themeDirs = [
         ".config/feishin"
       ]
@@ -95,11 +19,76 @@ mkTarget {
         lib.concatMap (dir: [
           {
             name = "${dir}/Themes/stylix.json";
-            value.text = themeJson;
+            value.text = builtins.toJSON {
+              mode = if polarity == "dark" then polarity else "light";
+
+              colors = with colors.withHashtag; {
+                background = base00;
+                background-alternate = base01;
+                surface = base01;
+                surface-foreground = base06;
+                foreground = base05;
+                foreground-muted = base03;
+
+                primary = base0D;
+
+                state-info = base0D;
+                state-success = base0B;
+                state-warning = base0A;
+                state-error = base08;
+
+                black = base00;
+                white = base07;
+              };
+
+              app = with colors.withHashtag; {
+                overlay-header = "linear-gradient(transparent 0%, ${base00}D9 100%), var(--theme-background-noise)";
+                overlay-subheader = "linear-gradient(180deg, ${base00}0D 0%, var(--theme-colors-background) 100%), var(--theme-background-noise)";
+                scrollbar-handle-background = "${base0D}33";
+                scrollbar-handle-hover-background = "${base0D}66";
+              };
+
+              stylesheets = [ "stylix.css" ];
+            };
           }
           {
             name = "${dir}/Themes/stylix.css";
-            value.text = themeCss;
+            value.text = with colors.withHashtag; ''
+              [data-theme="stylix"] ::selection {
+                background-color: ${base0D}59;
+              }
+
+              [data-theme="stylix"] .mantine-Button-root:hover {
+                box-shadow: 0 0 12px ${base0D}40;
+              }
+
+              [data-theme="stylix"] .mantine-Card-root {
+                border: 1px solid ${base02};
+              }
+
+              [data-theme="stylix"] .active,
+              [data-theme="stylix"] [aria-selected="true"] {
+                background: ${base0D}26;
+                color: ${base05};
+              }
+
+              [data-theme="stylix"] tr:hover,
+              [data-theme="stylix"] .mantine-Table-tr:hover {
+                background: ${base01};
+              }
+
+              [data-theme="stylix"] .mantine-Slider-track {
+                background: ${base0D};
+              }
+
+              [data-theme="stylix"] a {
+                color: ${base0D};
+              }
+
+              [data-theme="stylix"] a:hover {
+                color: ${base0C};
+              }
+            '';
           }
         ]) themeDirs
       );

--- a/modules/feishin/hm.nix
+++ b/modules/feishin/hm.nix
@@ -1,0 +1,107 @@
+{ mkTarget, lib, ... }:
+mkTarget {
+  options = {
+    dev.enable = lib.mkEnableOption "installing the theme for the Feishin development build (`~/.config/feishin-dev`) in addition to the stable build";
+  };
+
+  config =
+    {
+      colors,
+      cfg,
+      polarity,
+    }:
+    let
+      inherit (colors) withHashtag;
+
+      mode = if polarity == "light" then "light" else "dark";
+
+      themeJson = builtins.toJSON {
+        extends = if mode == "light" then "ayuLight" else "tokyoNight";
+        inherit mode;
+
+        colors = {
+          background = withHashtag.base00;
+          background-alternate = withHashtag.base01;
+          surface = withHashtag.base01;
+          surface-foreground = withHashtag.base06;
+          foreground = withHashtag.base05;
+          foreground-muted = withHashtag.base03;
+
+          primary = withHashtag.base0D;
+
+          state-info = withHashtag.base0D;
+          state-success = withHashtag.base0B;
+          state-warning = withHashtag.base0A;
+          state-error = withHashtag.base08;
+
+          black = withHashtag.base00;
+          white = withHashtag.base07;
+        };
+
+        app = {
+          overlay-header = "linear-gradient(transparent 0%, ${withHashtag.base00}D9 100%), var(--theme-background-noise)";
+          overlay-subheader = "linear-gradient(180deg, ${withHashtag.base00}0D 0%, var(--theme-colors-background) 100%), var(--theme-background-noise)";
+          scrollbar-handle-background = "${withHashtag.base0D}33";
+          scrollbar-handle-hover-background = "${withHashtag.base0D}66";
+        };
+
+        stylesheets = [ "stylix.css" ];
+      };
+
+      themeCss = ''
+        [data-theme="stylix"] ::selection {
+          background-color: ${withHashtag.base0D}59;
+        }
+
+        [data-theme="stylix"] .mantine-Button-root:hover {
+          box-shadow: 0 0 12px ${withHashtag.base0D}40;
+        }
+
+        [data-theme="stylix"] .mantine-Card-root {
+          border: 1px solid ${withHashtag.base02};
+        }
+
+        [data-theme="stylix"] .active,
+        [data-theme="stylix"] [aria-selected="true"] {
+          background: ${withHashtag.base0D}26;
+          color: ${withHashtag.base05};
+        }
+
+        [data-theme="stylix"] tr:hover,
+        [data-theme="stylix"] .mantine-Table-tr:hover {
+          background: ${withHashtag.base01};
+        }
+
+        [data-theme="stylix"] .mantine-Slider-track {
+          background: ${withHashtag.base0D};
+        }
+
+        [data-theme="stylix"] a {
+          color: ${withHashtag.base0D};
+        }
+
+        [data-theme="stylix"] a:hover {
+          color: ${withHashtag.base0C};
+        }
+      '';
+
+      themeDirs = [
+        ".config/feishin"
+      ]
+      ++ lib.optional cfg.dev.enable ".config/feishin-dev";
+    in
+    {
+      home.file = builtins.listToAttrs (
+        lib.concatMap (dir: [
+          {
+            name = "${dir}/Themes/stylix.json";
+            value.text = themeJson;
+          }
+          {
+            name = "${dir}/Themes/stylix.css";
+            value.text = themeCss;
+          }
+        ]) themeDirs
+      );
+    };
+}

--- a/modules/feishin/meta.nix
+++ b/modules/feishin/meta.nix
@@ -1,0 +1,5 @@
+{ lib, ... }: {
+  name = "Feishin";
+  homepage = "https://github.com/jeffvli/feishin";
+  maintainers = [ lib.maintainers.make-42 ];
+}

--- a/modules/feishin/testbeds/feishin.nix
+++ b/modules/feishin/testbeds/feishin.nix
@@ -1,0 +1,11 @@
+{ pkgs, lib, ... }: {
+  stylix.testbed.ui.application = {
+    name = "feishin";
+    package = pkgs.feishin;
+  };
+
+  home-manager.sharedModules = lib.singleton {
+    home.packages = [ pkgs.feishin ];
+    stylix.targets.feishin.dev.enable = true;
+  };
+}


### PR DESCRIPTION
Adds support for Feishin (music player). It drops theme files into a specific dir. Users can then load the theme files themselves from the application
---
<img width="1728" height="1404" alt="image" src="https://github.com/user-attachments/assets/2fa0d472-84b6-4432-b4c3-a6aede7c9944" />

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [x] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [x] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [x] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [x] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [x] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [ ] Each commit in this PR is [suitable for backport](https://nix-community.github.io/stylix/backport_policy.html)
