### PR TITLE
doc/src/modules: simplify usage of nix overrides

### DIFF
--- a/doc/src/modules.md
+++ b/doc/src/modules.md
@@ -16,7 +16,7 @@ frontends: `nixos-rebuild`, `nix-on-droid` and even `nh`). It allows you to
 deploy your changes in one fell swoop, without having to update the lock file of
 your flake every time you make an edit.
 
-Just append `--override-input stylix git+file:/home/user/path/to/stylix` to your
+Just append `--override-input stylix ~/path/to/stylix` to your
 standard `nix` (or `nix` frontend) incantation.
 
 Nix only reads files which are tracked by Git, so you also need to `git add


### PR DESCRIPTION
**EDIT**: Frozen until the minimal nix version reaches 2.34.

Path-like[^1] syntax is honoured by nix.  This saves us a little typing.

Combined with tilde expansion by the shell, we go from:

```sh
nixos-rebuild switch --input-override stylix git+file:/home/user/path/to/stylix
```

to:

```sh
nixos-rebuild switch --input-override stylix ~/path/to/stylix
```

This is a follow-up of #1261.

[^1]: https://nix.dev/manual/nix/2.34/nix-2.34.html#path-like-syntax

<!-- Describe your PR above, following Stylix commit conventions. -->

---

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [x] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [x] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [x] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)[^2]
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [x] Each commit in this PR is [suitable for backport](https://nix-community.github.io/stylix/backport_policy.html)

[^2]: Checked manually following https://nix-community.github.io/stylix/development_environment.html#documentation