### PR TITLE
fish: extend tmux fix to zellij for maintaining transparent panes

### DIFF
--- a/modules/fish/shared.nix
+++ b/modules/fish/shared.nix
@@ -9,7 +9,7 @@ mkTarget {
         source ${theme}
 
         # See https://github.com/tomyun/base16-fish/issues/7 for why this condition exists
-        if test -z $TMUX
+        if test -z $TMUX && test -z $ZELLIJ
           base16-${colors.slug}
         end
       '';


### PR DESCRIPTION
Fish shell theme initialization was applying opaque background colors in zellij panes, this PR extends an (unrelated) tmux fix to conditionally not source the base16 theme if $ZELLIJ is set, restoring transparency (if set).

Before:
<img width="2240" height="1400" alt="image" src="https://github.com/user-attachments/assets/23ad660e-435c-4a9d-8390-bbbff08402e3" />
After:
<img width="2240" height="1400" alt="image" src="https://github.com/user-attachments/assets/5f56da97-3d30-48f6-a377-9bd499a85bc4" />

---

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [x] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [x] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [x] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [x] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [ ] Each commit in this PR is [suitable for backport](https://nix-community.github.io/stylix/backport_policy.html)
