### PR TITLE
[release-26.05] treewide: migrate to nixbot from buildbot

### DIFF
--- a/buildbot-nix.toml
+++ b/buildbot-nix.toml
@@ -1,1 +1,0 @@
-attribute = "ci.buildbot"

--- a/flake/dev/dev-shell.nix
+++ b/flake/dev/dev-shell.nix
@@ -39,7 +39,7 @@
       '';
     in
     {
-      ci.buildbot = { inherit (config) devShells; };
+      ci.nixbot = { inherit (config) devShells; };
 
       devShells = {
         default = pkgs.mkShell {

--- a/flake/dev/packages.nix
+++ b/flake/dev/packages.nix
@@ -15,11 +15,11 @@
         import ../../stylix/testbed { inherit pkgs inputs lib; }
       );
 
-      ci.buildbot = {
+      ci.nixbot = {
         packages = builtins.removeAttrs config.packages (
           builtins.attrNames config.testbeds
         );
-        # Batching testbeds by target, to avoid overwhelming buildbot
+        # Batching testbeds by target, to avoid overwhelming nixbot
         testbeds = lib.pipe config.testbeds [
           (lib.mapAttrsToList (
             name: testbed:

--- a/flake/dev/pre-commit.nix
+++ b/flake/dev/pre-commit.nix
@@ -5,7 +5,7 @@
   perSystem =
     { config, lib, ... }:
     {
-      ci.buildbot = { inherit (config.checks) pre-commit; };
+      ci.nixbot = { inherit (config.checks) pre-commit; };
 
       pre-commit = {
         check.enable = true;

--- a/flake/dev/public-and-dev-version-consistency.nix
+++ b/flake/dev/public-and-dev-version-consistency.nix
@@ -37,7 +37,7 @@
     {
       inherit checks;
 
-      ci.buildbot = lib.mkIf (system == "x86_64-linux") {
+      ci.nixbot = lib.mkIf (system == "x86_64-linux") {
         public-and-dev-version-consistency = pkgs.linkFarm "public-and-dev-version-consistency" checks;
       };
     };

--- a/flake/options/ci.nix
+++ b/flake/options/ci.nix
@@ -3,12 +3,12 @@ let
   inherit (lib) types;
 in
 {
-  perSystem.options.ci.buildbot = lib.mkOption {
+  perSystem.options.ci.nixbot = lib.mkOption {
     type = types.lazyAttrsOf types.raw;
     default = { };
     description = ''
-      A set of tests for [buildbot] to run.
-      [buildbot]: https://buildbot.nix-community.org
+      A set of tests for [nixbot] to run.
+      [nixbot]: https://nixbot.nix-community.org
     '';
   };
 
@@ -28,8 +28,6 @@ in
     };
 
     # Transpose per-system CI outputs to the top-level
-    config.ci.buildbot = lib.mapAttrs (
-      _: sysCfg: sysCfg.ci.buildbot
-    ) config.allSystems;
+    config.ci.nixbot = lib.mapAttrs (_: sysCfg: sysCfg.ci.nixbot) config.allSystems;
   };
 }

--- a/nixbot.toml
+++ b/nixbot.toml
@@ -1,0 +1,1 @@
+attribute = "ci.nixbot"


### PR DESCRIPTION
Manual backport of https://github.com/nix-community/stylix/pull/2419.

<!-- Describe your PR above, following Stylix commit conventions. -->

---

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [X] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [X] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [ ] Each commit in this PR is [suitable for backport](https://nix-community.github.io/stylix/backport_policy.html)
