### PR TITLE
xresources/meta: update homepage to canonical URL

### DIFF
--- a/modules/xresources/meta.nix
+++ b/modules/xresources/meta.nix
@@ -1,5 +1,5 @@
 { lib, ... }: {
   name = "Xresources file";
-  homepage = "https://www.x.org/wiki";
+  homepage = "https://www.x.org";
   maintainers = [ lib.maintainers.berber ];
 }


### PR DESCRIPTION
The previous URL is a permanent redirect:

```
$ curl --head --silent https://www.x.org/wiki | head -3
HTTP/2 301
content-type: text/html; charset=utf-8
location: http://www.x.org/
```

<!-- Describe your PR above, following Stylix commit conventions. -->

---

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [X] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [X] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [ ] Each commit in this PR is [suitable for backport](https://nix-community.github.io/stylix/backport_policy.html)
