### PR TITLE
doc: create LLM Review Policy

### DIFF
--- a/doc/src/SUMMARY.md
+++ b/doc/src/SUMMARY.md
@@ -14,6 +14,7 @@
 - [Testbeds](testbeds.md)
 - [Style guide](styling.md)
 - [Backport Policy](backport_policy.md)
+- [LLM Review Policy](llm_review_policy.md)
 
 # Reference
 

--- a/doc/src/llm_review_policy.md
+++ b/doc/src/llm_review_policy.md
@@ -1,0 +1,38 @@
+# LLM Review Policy
+
+## Overview
+
+This policy defines how, and when, maintainers may refuse to review automated
+or low effort pull requests to the areas they are responsible for.
+
+It is not designed to outright ban any particular tool. However, it should
+enable our volunteers to make the best use of the time they have available,
+and increase the overall quality of the project.
+
+## The policy
+
+If a pull request is clearly automated or low effort, a maintainer may choose
+to respond with this template:
+
+> It appears that this code was created using large language models.
+> [Or other appropriate reason.]
+>
+> Unfortunately, it does not meet the minimum standard required for a review
+> from the core maintainers.
+>
+> We would suggest you spend some time to improve the code by hand.
+> If you are unsure how to do something, you can ask questions on
+> [GitHub Discussions](https://github.com/nix-community/stylix/discussions),
+> [Matrix](https://matrix.to/#/#stylix:danth.me), or find guidance in our
+> [documentation](https://nix-community.github.io/stylix).
+
+It should be posted as a review requesting changes.
+
+Those with the necessary permissions should follow up by marking the pull
+request as draft, and then closing it if no improvements are seen within a
+few weeks.
+
+It is up to individual maintainers whether or not they wish to use this policy.
+However, once it has been applied, the entire core team will stand by that
+decision.
+


### PR DESCRIPTION
This is a totally alternative idea to #2343, with similar goals.

I tried to design a process which does not add work in the happy case.

In particular, there is nothing new in the pull request template, and no extra labelling. At most we might want to add a link to the policy so people know it exists.

Suggestions to change the wording are of course welcome.

Closes #2178.

---

```mermaid
flowchart TD
    A[Pull request submitted]
    B[Checked by module maintainer]
    C[Checked by core maintainer]
    D[Module maintainer sends refusal]
    E[Core maintainer sends refusal]
    F[Core maintainer marks as draft]
    G[Core maintainer closes pull request]
    H[Core maintainer merges pull request]
    A --> B
    B -->|Review as normal| C
    B -->|Apply policy| D
    C -->|Review as normal| H
    C -->|Apply policy| E
    D --> F
    E --> F
    F -->|After a few weeks| G
```

---

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [x] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [x] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [x] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [x] Each commit in this PR is [suitable for backport](https://nix-community.github.io/stylix/backport_policy.html)
