### PR TITLE
nixbot: build stable release-* branches

### DIFF
--- a/nixbot.toml
+++ b/nixbot.toml
@@ -1,1 +1,2 @@
 attribute = "ci.nixbot"
+build_branches = ["release-*"]


### PR DESCRIPTION
> > should we rely on the default value or explicitly redeclare it in `/nixbot.toml`?
>
> Infra doesn't set a default value, I'd prefer that this be managed explicitly at the repo level.
>
> -- https://github.com/nix-community/stylix/pull/2419#issuecomment-5148091474

@zowoq, will this run nixbot on our stable branches?

<!-- Describe your PR above, following Stylix commit conventions. -->

---

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [X] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [X] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [X] Each commit in this PR is [suitable for backport](https://nix-community.github.io/stylix/backport_policy.html)
