### PR TITLE
starship: define color variables with lowercase names.

### DIFF
--- a/modules/starship/hm.nix
+++ b/modules/starship/hm.nix
@@ -1,67 +1,73 @@
 # Starship configuration documentation: https://starship.rs/config
-{ mkTarget, ... }:
+{ lib, mkTarget, ... }:
 mkTarget {
   config = { colors }: {
     programs.starship.settings = {
       palette = "base16";
-      palettes.base16 = with colors.withHashtag; {
-        black = base00;
-        bright-black = base03;
-        white = base05;
-        bright-white = base07;
+      palettes.base16 =
+        with colors.withHashtag;
+        {
+          black = base00;
+          bright-black = base03;
+          white = base05;
+          bright-white = base07;
 
-        # Starship calls magenta purple.
-        purple = magenta;
-        bright-purple = bright-magenta;
+          # Starship calls magenta purple.
+          purple = magenta;
+          bright-purple = bright-magenta;
 
-        inherit
-          # Set Starship's standard normal color names.
-          red
-          orange
-          yellow
-          green
-          cyan
-          blue
-          magenta
-          brown
+          inherit
+            # Set Starship's standard normal color names.
+            red
+            orange
+            yellow
+            green
+            cyan
+            blue
+            magenta
+            brown
 
-          # Set Starship's standard bright color names.
-          bright-red
-          bright-yellow
-          bright-green
-          bright-cyan
-          bright-blue
-          bright-magenta
+            # Set Starship's standard bright color names.
+            bright-red
+            bright-yellow
+            bright-green
+            bright-cyan
+            bright-blue
+            bright-magenta
 
-          # Add base16 names to the template for custom usage.
-          base00
-          base01
-          base02
-          base03
-          base04
-          base05
-          base06
-          base07
-          base08
-          base09
-          base0A
-          base0B
-          base0C
-          base0D
-          base0E
-          base0F
+            # Add base16 names to the template for custom usage.
+            base00
+            base01
+            base02
+            base03
+            base04
+            base05
+            base06
+            base07
+            base08
+            base09
 
-          # Add base24 names to the template for custom usage.
-          base10
-          base11
-          base12
-          base13
-          base14
-          base15
-          base16
-          base17
-          ;
-      };
+            # Add base24 names to the template for custom usage.
+            base10
+            base11
+            base12
+            base13
+            base14
+            base15
+            base16
+            base17
+            ;
+        }
+        // lib.mapAttrs' (name: value: lib.nameValuePair (lib.toLower name) value) {
+          inherit
+            base0A
+            base0B
+            base0C
+            base0D
+            base0E
+            base0F
+            ;
+        };
     };
   };
 }

--- a/modules/starship/hm.nix
+++ b/modules/starship/hm.nix
@@ -56,7 +56,7 @@ mkTarget {
           base17
           ;
 
-        # Add lowercase color names as variables with uppercase letters are ignored by # Starship calls magenta purple.
+        # Add lowercase color names as variables with uppercase letters are ignored by Starship.
         base0a = base0A;
         base0b = base0B;
         base0c = base0C;

--- a/modules/starship/hm.nix
+++ b/modules/starship/hm.nix
@@ -1,73 +1,69 @@
 # Starship configuration documentation: https://starship.rs/config
-{ lib, mkTarget, ... }:
+{ mkTarget, ... }:
 mkTarget {
   config = { colors }: {
     programs.starship.settings = {
       palette = "base16";
-      palettes.base16 =
-        with colors.withHashtag;
-        {
-          black = base00;
-          bright-black = base03;
-          white = base05;
-          bright-white = base07;
+      palettes.base16 = with colors.withHashtag; {
+        black = base00;
+        bright-black = base03;
+        white = base05;
+        bright-white = base07;
 
-          # Starship calls magenta purple.
-          purple = magenta;
-          bright-purple = bright-magenta;
+        # Starship calls magenta purple.
+        purple = magenta;
+        bright-purple = bright-magenta;
 
-          inherit
-            # Set Starship's standard normal color names.
-            red
-            orange
-            yellow
-            green
-            cyan
-            blue
-            magenta
-            brown
+        inherit
+          # Set Starship's standard normal color names.
+          red
+          orange
+          yellow
+          green
+          cyan
+          blue
+          magenta
+          brown
 
-            # Set Starship's standard bright color names.
-            bright-red
-            bright-yellow
-            bright-green
-            bright-cyan
-            bright-blue
-            bright-magenta
+          # Set Starship's standard bright color names.
+          bright-red
+          bright-yellow
+          bright-green
+          bright-cyan
+          bright-blue
+          bright-magenta
 
-            # Add base16 names to the template for custom usage.
-            base00
-            base01
-            base02
-            base03
-            base04
-            base05
-            base06
-            base07
-            base08
-            base09
+          # Add base16 names to the template for custom usage.
+          base00
+          base01
+          base02
+          base03
+          base04
+          base05
+          base06
+          base07
+          base08
+          base09
 
-            # Add base24 names to the template for custom usage.
-            base10
-            base11
-            base12
-            base13
-            base14
-            base15
-            base16
-            base17
-            ;
-        }
-        // lib.mapAttrs' (name: value: lib.nameValuePair (lib.toLower name) value) {
-          inherit
-            base0A
-            base0B
-            base0C
-            base0D
-            base0E
-            base0F
-            ;
-        };
+          # Add base24 names to the template for custom usage.
+          base10
+          base11
+          base12
+          base13
+          base14
+          base15
+          base16
+          base17
+          ;
+
+        # Add lowercase color names as variables with uppercase letters are ignored by # Starship calls magenta purple.
+        base0a = base0A;
+        base0b = base0B;
+        base0c = base0C;
+        base0d = base0D;
+        base0e = base0E;
+        base0f = base0F;
+      };
     };
   };
 }


### PR DESCRIPTION
add lowercase versions of colors `base0A` through `base0F` for compatibility with starship style tags as they are lowercased during processing by starships internal rust compiler

no breaking changes.

- I tested with testbed `.#testbed:starship:dark` 
- I ran stylix-check

Closes:#2456




<!-- Describe your PR above, following Stylix commit conventions. -->
### Before
<img width="810" height="504" alt="1785917023629641969" src="https://github.com/user-attachments/assets/741d6c80-6287-4216-b1e8-753a6e236c00" />

### After

<img width="806" height="508" alt="1785917060428096008" src="https://github.com/user-attachments/assets/da9b76d2-f902-4243-958c-4632a2252e2b" />


<hr />

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [x] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [x] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [x] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [x] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [x] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [ ] Each commit in this PR is [suitable for backport](https://nix-community.github.io/stylix/backport_policy.html)
