### PR TITLE
zen-browser: set polarity explicitly

### DIFF
--- a/modules/zen-browser/hm.nix
+++ b/modules/zen-browser/hm.nix
@@ -52,6 +52,17 @@ mkTarget {
       inherit lib;
       name = "zen-browser";
     })
+    ({ cfg, polarity }: {
+      programs.zen-browser.profiles = lib.genAttrs cfg.profileNames (_: {
+        settings."zen.view.window.scheme" =
+          if polarity == "dark" then
+            0
+          else if polarity == "light" then
+            1
+          else
+            2; # follow system
+      });
+    })
     ({ cfg, colors }: {
       programs.zen-browser.profiles = lib.mkIf cfg.enableCss (
         lib.genAttrs cfg.profileNames (_: {


### PR DESCRIPTION
Sets the polarity for Zen Browser explicitly instead of relying on Zen to follow
the system theme.

fixes #2454

---

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->

- [x] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [x] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [x] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [x] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [x] Each commit in this PR is [suitable for backport](https://nix-community.github.io/stylix/backport_policy.html)
