### PR TITLE
doc: readme: add contributing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,3 +60,9 @@ nix run github:nix-community/stylix#testbed:gnome:dark
 
 Since KDE theming is still a work in progress, some manual steps may be required
 to properly apply its theme.
+
+## Contributing
+
+Information on how to contribute can be found on the
+[Stylix Documentation](https://nix-community.github.io/stylix)
+under the "Contributing" section.


### PR DESCRIPTION
I think new contributors will be more like to read the contributing docs if we link to them from the README.
<!-- Describe your PR above, following Stylix commit conventions. -->

---

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [x] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [x] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [x] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [x] Each commit in this PR is [suitable for backport](https://nix-community.github.io/stylix/backport_policy.html)
