### PR TITLE
stylix/droid: warn that Nix-on-Droid target may be dropped

### DIFF
--- a/stylix/droid/default.nix
+++ b/stylix/droid/default.nix
@@ -1,4 +1,9 @@
-{ lib, pkgs, ... }:
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
 let
   autoload = import ../autoload.nix { inherit lib pkgs; } "droid";
 in
@@ -20,4 +25,17 @@ in
 
   # See https://github.com/nix-community/nix-on-droid/issues/436
   options.lib = lib.mkOption { type = with lib.types; attrsOf attrs; };
+
+  config.warnings = lib.mkIf config.stylix.enable [
+    ''
+      Nix-on-Droid upstream appears unmaintained (few commits over the
+      past year, an unsupported Nixpkgs version, and reports of breakage
+      on current NixOS), so Stylix's Nix-on-Droid target may be dropped
+      without expressions of maintenance interest.
+
+      If you rely on Stylix on Nix-on-Droid, please comment on
+      https://github.com/nix-community/stylix/discussions/2402 to help
+      gauge whether this target should be kept.
+    ''
+  ];
 }


### PR DESCRIPTION
Adds a `config.warnings` entry to the Nix-on-Droid target warning that Nix-on-Droid upstream appears unmaintained (four commits over the past year, an unsupported Nixpkgs version, and reports of breakage on current NixOS — see [discussion #2402](https://github.com/nix-community/stylix/discussions/2402)) and that this target may be dropped without expressions of maintenance interest. This implements the soft-deprecation approach agreed in that discussion and tracked by #2417, mirroring the existing release-mismatch warning pattern in `stylix/nixos/default.nix`.

Closes #2417

**AI disclosure:** This PR was authored by an AI coding agent (Claude), including the diff, commit message, and this description. The change is a single small, mechanical addition following an existing in-repo pattern (`stylix/nixos/default.nix`'s `config.warnings`), based on the maintainer-agreed approach in discussion #2402. I don't have `nix` available in my sandbox to run `pre-commit`/`nix flake check`/`stylix-check` locally, so I could not run the project's own checks — verification was a manual line-by-line comparison against the existing warning pattern and the repo's `nixfmt` (80-col, strict) formatting conventions. Please treat this as unverified-by-build and let CI/a maintainer confirm it evaluates cleanly.

---

<!-- Describe your PR above, following Stylix commit conventions. -->

---

- [x] I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [x] I have disclosed the scope of involved LLM tools, if any
- [x] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html) <!-- N/A: not a theming change -->
- [ ] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup) <!-- could not: no `nix` binary in my sandbox, see AI disclosure note above -->
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html) <!-- same as above -->
- [ ] Each commit in this PR is [suitable for backport](https://nix-community.github.io/stylix/backport_policy.html) <!-- per the backport policy this is neither a security/bug/CI fix nor an explicitly-requested feature backport, so leaving unticked rather than guessing -->
