### PR TITLE
stylix/overlays: do not auto-enable under `useGlobalPkgs`

### DIFF
--- a/stylix/overlays.nix
+++ b/stylix/overlays.nix
@@ -4,9 +4,16 @@
   config,
   options,
   ...
-}:
+}@args:
+let
+  # Home manager check
+  # This will default overlays to false *if* `home-manager.useGlobalPkgs` is enabled
+  globalPackagesEnabled = args.osConfig.home-manager.useGlobalPkgs or false;
+in
 {
-  options.stylix.overlays.enable = config.lib.stylix.mkEnableTarget "packages via overlays" true;
+  options.stylix.overlays.enable =
+    config.lib.stylix.mkEnableTarget "packages via overlays"
+      (!globalPackagesEnabled);
 
   imports = map (
     f:


### PR DESCRIPTION
Setting `nixpkgs.config` or `nixpkgs.overlays` while using `home-manager.useGlobalPkgs` will soon not be possible. This change defaults `stylix.overlays.enable` in the home module to `false` if `home-manager.useGlobalPkgs` is enabled. NOTE: This relies on the `osConfig` special arg

Fixes #1832


AI usage note: The commit message was written with AI.
<!-- Describe your PR above, following Stylix commit conventions. -->

---

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [x] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [x] <!-- MANDATORY --> I have disclosed the scope of involved LLM tools, if any
- [ ] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [x] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [ ] Each commit in this PR is [suitable for backport](https://nix-community.github.io/stylix/backport_policy.html)
