### PR TITLE
treewide: remove redundant parentheses from conditionals

### DIFF
--- a/modules/fnott/hm.nix
+++ b/modules/fnott/hm.nix
@@ -41,7 +41,7 @@ mkTarget {
     })
     ({ polarity, icons }: {
       services.fnott.settings.main."icon-theme" =
-        if (polarity == "dark") then icons.dark else icons.light;
+        if polarity == "dark" then icons.dark else icons.light;
     })
   ];
 }

--- a/modules/fuzzel/hm.nix
+++ b/modules/fuzzel/hm.nix
@@ -28,7 +28,7 @@ mkTarget {
     )
     ({ polarity, icons }: {
       programs.fuzzel.settings.main."icon-theme" =
-        if (polarity == "dark") then icons.dark else icons.light;
+        if polarity == "dark" then icons.dark else icons.light;
     })
   ];
 }

--- a/modules/nixos-icons/overlay.nix
+++ b/modules/nixos-icons/overlay.nix
@@ -48,7 +48,7 @@
                     # convert each to hex string
                     (map toHexString)
                     # add leading 0 if necessary
-                    (map (hex: if (stringLength hex < 2) then "0" + hex else hex))
+                    (map (hex: if stringLength hex < 2 then "0" + hex else hex))
                     # to one string
                     concatStrings
                   ];

--- a/modules/qt/hm.nix
+++ b/modules/qt/hm.nix
@@ -133,8 +133,7 @@ mkTarget {
     )
     ({ icons, polarity }: {
       qt = qtctSettings {
-        Appearance.icon_theme =
-          if (polarity == "dark") then icons.dark else icons.light;
+        Appearance.icon_theme = if polarity == "dark" then icons.dark else icons.light;
       };
     })
     ({ fonts }: {

--- a/modules/regreet/nixos.nix
+++ b/modules/regreet/nixos.nix
@@ -107,7 +107,7 @@ mkTarget {
     ({ polarity, icons }: {
       services.displayManager.regreet.iconTheme = {
         inherit (icons) package;
-        name = if (polarity == "dark") then icons.dark else icons.light;
+        name = if polarity == "dark" then icons.dark else icons.light;
       };
     })
   ];


### PR DESCRIPTION
This only covers trivial `if (` instances that sadly none of our linters and formatters catch.

This change aligns with previous efforts in commit 45749a791efd ("stylix: remove optional parentheses (#1697)").

<!-- Describe your PR above, following Stylix commit conventions. -->

---

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [X] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [X] <!-- MANDATORY --> I have disclosed the scope of involved LLM tools, if any
- [X] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [ ] Each commit in this PR is [suitable for backport](https://nix-community.github.io/stylix/backport_policy.html)
