### PR TITLE
kubecolor: omit preset instead of declaring empty string

### DIFF
--- a/modules/kubecolor/hm.nix
+++ b/modules/kubecolor/hm.nix
@@ -1,9 +1,8 @@
-{ mkTarget, ... }:
+{ mkTarget, lib, ... }:
 mkTarget {
   config = [
     ({ polarity }: {
-      programs.kubecolor.settings.preset =
-        if polarity == "either" then "" else polarity;
+      programs.kubecolor.settings.preset = lib.mkIf (polarity != "either") polarity;
     })
     ({ colors }: {
       programs.kubecolor.settings.theme = with colors.withHashtag; {


### PR DESCRIPTION
```
Fixes: 74ee1ed5057e ("kubecolor: init (#657)")
```

@ajgon, could you verify whether this is semantically equivalent and works in all cases? If `lib.mkIf` is unsupported in this context, `lib.optionalString` could be used instead.

<!-- Describe your PR above, following Stylix commit conventions. -->

---

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [X] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [X] <!-- MANDATORY --> I have disclosed the scope of involved LLM tools, if any
- [X] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [ ] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [ ] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [ ] Each commit in this PR is [suitable for backport](https://nix-community.github.io/stylix/backport_policy.html)
