### PR TITLE
glance: use more appropriate colors for positive and negative

### DIFF
--- a/modules/glance/hm.nix
+++ b/modules/glance/hm.nix
@@ -12,8 +12,8 @@ mkTarget {
           contrast-multiplier = 1.0;
           background-color = rgb-to-hsl "base00";
           primary-color = rgb-to-hsl "base05";
-          positive-color = rgb-to-hsl "base01";
-          negative-color = rgb-to-hsl "base04";
+          positive-color = rgb-to-hsl "base0B";
+          negative-color = rgb-to-hsl "base08";
         };
       }
     )

--- a/modules/glance/nixos.nix
+++ b/modules/glance/nixos.nix
@@ -12,8 +12,8 @@ mkTarget {
           contrast-multiplier = 1.0;
           background-color = rgb-to-hsl "base00";
           primary-color = rgb-to-hsl "base05";
-          positive-color = rgb-to-hsl "base01";
-          negative-color = rgb-to-hsl "base04";
+          positive-color = rgb-to-hsl "base0B";
+          negative-color = rgb-to-hsl "base08";
         };
       }
     )


### PR DESCRIPTION
Currently, the positive color in Glance is `base01`. This leads to things in the
positive color being almost unreadable, as can be seen here:
<img width="747" height="256" alt="image" src="https://github.com/user-attachments/assets/85d14704-7a99-47d8-92ab-e9c0d5a231b7" />

Moreover, it makes negative colors seem to imply something positive rather bad.

This modifies it such that positive colors are `base08` and negative colors are
`base0B`. The two themes provided upstream as defaults use the primary color as the positive color, but I opted for `base0B` to better reflect the meaning.

---

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->

- [x] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [x] <!-- MANDATORY --> I have disclosed the scope of involved LLM tools, if any
- [x] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [x] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [x] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [x] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [x] Each commit in this PR is [suitable for backport](https://nix-community.github.io/stylix/backport_policy.html)
