### PR TITLE
Init Mango module

### DIFF
--- a/generated/all-maintainers.nix
+++ b/generated/all-maintainers.nix
@@ -17,6 +17,12 @@
     matrix = "@da157:catgirl.cloud";
     name = "0xda157";
   };
+  DarkGuibrine = {
+    email = "darkgui@protonmail.com";
+    github = "DarkGuibrine";
+    githubId = 112888817;
+    name = "Guilherme Hermando";
+  };
   Eveeifyeve = {
     email = "eveeg1971@gmail.com";
     github = "Eveeifyeve";

--- a/modules/mango/hm.nix
+++ b/modules/mango/hm.nix
@@ -1,6 +1,11 @@
-{ mkTarget, ... }:
+{
+  mkTarget,
+  lib,
+  options,
+  ...
+}:
 mkTarget {
-  config = [
+  config = lib.optionals (options.wayland.windowManager ? mango) [
     ({ colors }: {
       wayland.windowManager.mango.settings =
         let

--- a/modules/mango/hm.nix
+++ b/modules/mango/hm.nix
@@ -5,43 +5,45 @@
   ...
 }:
 mkTarget {
-  config = lib.optionals (options.wayland.windowManager ? mango) [
-    ({ colors }: {
-      wayland.windowManager.mango.settings =
-        let
-          hex = color: "0x${color}ff";
-        in
-        {
-          rootcolor = hex colors.base00;
-          bordercolor = hex colors.base03;
-          dropcolor = "0x${colors.base00}55";
-          splitcolor = hex colors.base0D;
-          focuscolor = hex colors.base0D;
-          urgentcolor = hex colors.base08;
+  config =
+    lib.optionals (lib.hasAttrByPath [ "wayland" "windowManager" "mango" ] options)
+      [
+        ({ colors }: {
+          wayland.windowManager.mango.settings =
+            let
+              hex = color: "0x${color}ff";
+            in
+            {
+              rootcolor = hex colors.base00;
+              bordercolor = hex colors.base03;
+              dropcolor = "0x${colors.base00}55";
+              splitcolor = hex colors.base0D;
+              focuscolor = hex colors.base0D;
+              urgentcolor = hex colors.base08;
 
-          maximizescreencolor = hex colors.base0B;
-          scratchpadcolor = hex colors.base0C;
-          globalcolor = hex colors.base0E;
-          overlaycolor = hex colors.base0C;
+              maximizescreencolor = hex colors.base0B;
+              scratchpadcolor = hex colors.base0C;
+              globalcolor = hex colors.base0E;
+              overlaycolor = hex colors.base0C;
 
-          jump_label_decorate_fg_color = hex colors.base05;
-          jump_label_decorate_bg_color = hex colors.base01;
-          jump_label_decorate_focus_fg_color = hex colors.base00;
-          jump_label_decorate_focus_bg_color = hex colors.base0D;
-          jump_label_decorate_border_color = hex colors.base0D;
+              jump_label_decorate_fg_color = hex colors.base05;
+              jump_label_decorate_bg_color = hex colors.base01;
+              jump_label_decorate_focus_fg_color = hex colors.base00;
+              jump_label_decorate_focus_bg_color = hex colors.base0D;
+              jump_label_decorate_border_color = hex colors.base0D;
 
-          group_bar_decorate_fg_color = hex colors.base05;
-          group_bar_decorate_bg_color = hex colors.base01;
-          group_bar_decorate_focus_fg_color = hex colors.base00;
-          group_bar_decorate_focus_bg_color = hex colors.base0D;
-          group_bar_decorate_border_color = hex colors.base0D;
-        };
-    })
-    ({ fonts }: {
-      wayland.windowManager.mango.settings = {
-        jump_label_decorate_font_desc = "${fonts.sansSerif.name} Bold 16";
-        group_bar_decorate_font_desc = "${fonts.sansSerif.name} Bold 16";
-      };
-    })
-  ];
+              group_bar_decorate_fg_color = hex colors.base05;
+              group_bar_decorate_bg_color = hex colors.base01;
+              group_bar_decorate_focus_fg_color = hex colors.base00;
+              group_bar_decorate_focus_bg_color = hex colors.base0D;
+              group_bar_decorate_border_color = hex colors.base0D;
+            };
+        })
+        ({ fonts }: {
+          wayland.windowManager.mango.settings = {
+            jump_label_decorate_font_desc = "${fonts.sansSerif.name} Bold 16";
+            group_bar_decorate_font_desc = "${fonts.sansSerif.name} Bold 16";
+          };
+        })
+      ];
 }

--- a/modules/mango/hm.nix
+++ b/modules/mango/hm.nix
@@ -1,0 +1,42 @@
+{ mkTarget, ... }:
+mkTarget {
+  config = [
+    ({ colors }: {
+      wayland.windowManager.mango.settings =
+        let
+          hex = color: "0x${color}ff";
+        in
+        {
+          rootcolor = hex colors.base00;
+          bordercolor = hex colors.base03;
+          dropcolor = "0x${colors.base00}55";
+          splitcolor = hex colors.base0D;
+          focuscolor = hex colors.base0D;
+          urgentcolor = hex colors.base08;
+
+          maximizescreencolor = hex colors.base0B;
+          scratchpadcolor = hex colors.base0C;
+          globalcolor = hex colors.base0E;
+          overlaycolor = hex colors.base0C;
+
+          jump_label_decorate_fg_color = hex colors.base05;
+          jump_label_decorate_bg_color = hex colors.base01;
+          jump_label_decorate_focus_fg_color = hex colors.base00;
+          jump_label_decorate_focus_bg_color = hex colors.base0D;
+          jump_label_decorate_border_color = hex colors.base0D;
+
+          group_bar_decorate_fg_color = hex colors.base05;
+          group_bar_decorate_bg_color = hex colors.base01;
+          group_bar_decorate_focus_fg_color = hex colors.base00;
+          group_bar_decorate_focus_bg_color = hex colors.base0D;
+          group_bar_decorate_border_color = hex colors.base0D;
+        };
+    })
+    ({ fonts }: {
+      wayland.windowManager.mango.settings = {
+        jump_label_decorate_font_desc = "${fonts.sansSerif.name} Bold 16";
+        group_bar_decorate_font_desc = "${fonts.sansSerif.name} Bold 16";
+      };
+    })
+  ];
+}

--- a/modules/mango/meta.nix
+++ b/modules/mango/meta.nix
@@ -2,4 +2,14 @@
   name = "Mango";
   homepage = "https://github.com/mangowm/mango";
   maintainers = [ lib.maintainers.darkguibrine ];
+
+  description = ''
+    Themes window borders, window state colors, overview jump mode, and the
+    monocle tab bar, plus their fonts.
+
+    This module requires the upstream Mango Home Manager module from the
+    `github:mangowm/mango` flake input, since it sets
+    `wayland.windowManager.mango.settings`, which is only available there and
+    not in nixpkgs.
+  '';
 }

--- a/modules/mango/meta.nix
+++ b/modules/mango/meta.nix
@@ -1,0 +1,5 @@
+{ lib, ... }: {
+  name = "Mango";
+  homepage = "https://github.com/mangowm/mango";
+  maintainers = [ lib.maintainers.darkguibrine ];
+}

--- a/stylix/maintainers.nix
+++ b/stylix/maintainers.nix
@@ -43,6 +43,12 @@
     github = "cswimr";
     githubId = 102361830;
   };
+  darkguibrine = {
+    email = "darkgui@protonmail.com";
+    name = "Guilherme Hermando";
+    github = "DarkGuibrine";
+    githubId = 112888817;
+  };
   gideonwolfe = {
     email = "wolfegideon@gmail.com";
     name = "Gideon Wolfe";


### PR DESCRIPTION
## Init Mango module

Adds a Home Manager module to theme [Mango](https://github.com/mangowm/mango), a dwl-based Wayland compositor.

### What it themes

- Window borders: `rootcolor`, `bordercolor`, `focuscolor`, `urgentcolor`, `splitcolor`, `dropcolor`
- Window state colors: maximized, scratchpad, global, overlay
- Overview jump mode and monocle tab bar decorations (fg/bg/focus/border)
- Fonts for the jump mode and tab bar decorations

Colors follow the [Stylix style guide](https://nix-community.github.io/stylix/styling.html) and use Mango's `0xRRGGBBAA` hex format. The module targets Home Manager via `wayland.windowManager.mango.settings`.

**Note:** this module requires the upstream Mango Home Manager module from the `github:mangowm/mango` flake input, since `wayland.windowManager.mango.settings` is only available there and not in nixpkgs.

**LLM disclosure:** This change was created with assistance from opencode, an LLM-based CLI tool. The contributor reviewed, formatted, and verified all changes locally before submitting.

---

- [x] I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [x] I have disclosed the scope of involved LLM tools, if any
- [x] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [x] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [x] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [ ] Each commit in this PR is [suitable for backport](https://nix-community.github.io/stylix/backport_policy.html)
