### PR TITLE
flake: build the palette generator for the build platform

### DIFF
--- a/flake/modules.nix
+++ b/flake/modules.nix
@@ -11,7 +11,7 @@
               stylix = {
                 inherit inputs;
                 paletteGenerator =
-                  self.packages.${pkgs.stdenv.hostPlatform.system}.palette-generator;
+                  self.packages.${pkgs.stdenv.buildPlatform.system}.palette-generator;
                 base16 = inputs.base16.lib args;
                 homeManagerIntegration.module = self.homeModules.stylix;
               };
@@ -31,7 +31,7 @@
               stylix = {
                 inherit inputs;
                 paletteGenerator =
-                  self.packages.${pkgs.stdenv.hostPlatform.system}.palette-generator;
+                  self.packages.${pkgs.stdenv.buildPlatform.system}.palette-generator;
                 base16 = inputs.base16.lib args;
               };
             }
@@ -50,7 +50,7 @@
               stylix = {
                 inherit inputs;
                 paletteGenerator =
-                  self.packages.${pkgs.stdenv.hostPlatform.system}.palette-generator;
+                  self.packages.${pkgs.stdenv.buildPlatform.system}.palette-generator;
                 base16 = inputs.base16.lib args;
                 homeManagerIntegration.module = self.homeModules.stylix;
               };
@@ -69,7 +69,7 @@
             {
               stylix = {
                 paletteGenerator =
-                  self.packages.${pkgs.stdenv.hostPlatform.system}.palette-generator;
+                  self.packages.${pkgs.stdenv.buildPlatform.system}.palette-generator;
                 base16 = inputs.base16.lib args;
                 homeManagerIntegration.module = self.homeModules.stylix;
               };


### PR DESCRIPTION
The palette generator is consumed through `nativeBuildInputs`, which by definition holds build-platform dependencies, but it is indexed by `hostPlatform`. Native builds cannot see the difference, since the two platforms are identical there. Cross builds instead hand the builder an executable built for the target, and evaluation fails as soon as the palette is imported:

```
palette-generator: cannot execute binary file: Exec format error
```

`paletteGenerator` is `internal` and `readOnly`, so downstream configurations cannot override it to work around this.

The Home Manager, nix-darwin and nix-on-droid modules index the generator the same way, so all four are corrected together.

### How this showed up

Cross-compiling an aarch64 SD image (`nixpkgs.buildPlatform = "x86_64-linux"`) for an Agilex 5 SoC FPGA board, on a stock x86_64 GitHub Actions runner. It only reproduces on a builder that *cannot* run the target's binaries — a machine with binfmt and `extra-platforms = aarch64-linux` configured will happily execute the aarch64 generator and never notice, which is presumably why this has gone unseen.

### Testing

With this branch pinned in a downstream flake, the cross configuration's `stylix.paletteGenerator` resolves to an `x86_64-linux` derivation, where it previously resolved to `aarch64-linux`.

Native builds are unaffected by construction: where `buildPlatform == hostPlatform` the expression is identical to before, and store paths do not change.

I have not run the testbeds as this is very much a "if it builds it works"-situation

---

- [x] I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [x] I have disclosed the scope of involved LLM tools, if any
  - Disclosure, per the mandatory checkbox above — edit or drop as you see fit: the diagnosis, patch and commit message were produced by Claude (Claude Code) during a debugging session, and reviewed before submission.
- [x] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [x] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [x] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [x] Each commit in this PR is [suitable for backport](https://nix-community.github.io/stylix/backport_policy.html)
