### PR TITLE
editorconfig: restore UTF-8 validation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,6 +6,7 @@ end_of_line = lf
 indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
+charset = utf-8
 
 [*.{diff,patch}]
 end_of_line = unset


### PR DESCRIPTION
Version 3.6.1 fixed +xml MIME detection. Restore the global charset = utf-8 setting removed by #2035.

Closes: #2058
Link: https://github.com/editorconfig-checker/editorconfig-checker/commit/ebaf1b91



<!-- Describe your PR above, following Stylix commit conventions. -->

---


- [x] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [x] <!-- MANDATORY --> I have disclosed the scope of involved LLM tools, if any
- [x] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [x] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [x] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [x] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [x] Each commit in this PR is [suitable for backport](https://nix-community.github.io/stylix/backport_policy.html)
