### PR TITLE
zen-browser: fix selection colors after Firefox 154

### DIFF
--- a/modules/zen-browser/hm.nix
+++ b/modules/zen-browser/hm.nix
@@ -68,6 +68,8 @@ mkTarget {
         lib.genAttrs cfg.profileNames (_: {
           settings = {
             "toolkit.legacyUserProfileCustomizations.stylesheets" = true;
+            "ui.highlight" = "#${colors.base0D}";
+            "ui.highlighttext" = "#${colors.base00}";
           };
 
           userChrome = import ./userChrome.nix {

--- a/modules/zen-browser/userChrome.nix
+++ b/modules/zen-browser/userChrome.nix
@@ -64,11 +64,6 @@
     color: #${base0D-hex} !important;
   }
 
-  #urlbar-input::selection {
-    background-color: #${base0D-hex} !important;
-    color: #${base00-hex} !important;
-  }
-
   #zenEditBookmarkPanelFaviconContainer {
     background: #${base00-hex} !important;
   }

--- a/modules/zen-browser/userContent.nix
+++ b/modules/zen-browser/userContent.nix
@@ -157,7 +157,7 @@
   }
 
   ::selection {
-    background-color: #${base02-hex} !important;
-    color: #${base05-hex} !important;
+    background-color: #${base0D-hex} !important;
+    color: #${base00-hex} !important;
   }
 ''


### PR DESCRIPTION
The text selection theming introduced in #2184 and the urlbar text selection highlight no longer works with Firefox 154 after https://github.com/mozilla-firefox/firefox/commit/fe629a3d61c58f36cdc028d9ca695105c5b75b32. It now ignores `::selection` from user stylesheets, and instead falls back to `ui.highlight` and `ui.highlighttext` preferences.

This PR sets those `ui.highlight` and `ui.highlighttext` preferences to `base0D` and `base00`.
- These match the colors previously used for URL bar text selection
- #2184 used `base02` and `base05` for webpage selection. After Firefox 154 we can no longer keep webpage selection colors separate from the browser UI selection, and (personally) this new accent pair has better contrast in most cases.
- The existing `::selection` rule is still needed because it overrides selection color defined by websites, but changed it to use  `base0D` and `base00` for consistency.
- Removed the URL bar selection rule which is not needed anymore

<table>
<tr>
 <td>Existing style before 154
 <td>Existing style after 154
 <td>This PR after 154
<tr>
 <td><img width="300" alt="image" src="https://github.com/user-attachments/assets/77467772-f6d8-4ffe-8414-f41651ae095c" />
 <td><img width="300" alt="image" src="https://github.com/user-attachments/assets/3334dc1a-28fa-4c74-829d-79b94c11b65e" />
 <td><img width="300" alt="image" src="https://github.com/user-attachments/assets/db22f1ea-8918-48da-9f58-e914d1199747" />
</table>

Note: I did not update the testbed's `zen-browser` flake because it requires `ffmpeg_9` which is not in the pinned nixpkgs version. 

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [x] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [x] <!-- MANDATORY --> I have disclosed the scope of involved LLM tools, if any
- [x] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [x] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [x] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [x] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [x] Each commit in this PR is [suitable for backport](https://nix-community.github.io/stylix/backport_policy.html)
