### PR TITLE
zed: support transparent background

### DIFF
--- a/modules/zed/hm.nix
+++ b/modules/zed/hm.nix
@@ -1,4 +1,9 @@
-{ mkTarget, ... }:
+{
+  lib,
+  config,
+  mkTarget,
+  ...
+}:
 mkTarget {
   config = [
     ({ fonts }: {
@@ -11,14 +16,53 @@ mkTarget {
         };
       };
     })
-    ({ colors, inputs }: {
-      programs.zed-editor = {
-        userSettings.theme = "Base16 ${colors.scheme-name}";
-        themes.stylix = colors {
-          templateRepo = inputs.tinted-zed;
-          target = "base16";
+    (
+      {
+        inputs,
+        colors,
+        opacity,
+      }:
+      {
+        programs.zed-editor = {
+          userSettings = {
+            theme = "Base16 ${colors.scheme-name}";
+            "experimental.theme_overrides" =
+              with colors;
+              let
+                mkOpacityHexColor =
+                  color:
+                  let
+                    hex = builtins.substring 2 (-1) (
+                      config.lib.stylix.mkOpacityHexColor color opacity.desktop
+                    );
+                  in
+                  lib.toLower "${builtins.substring 2 (-1) hex}${builtins.substring 0 2 hex}";
+              in
+              if (opacity.desktop != 1.0) then
+                {
+                  "background" = "#${mkOpacityHexColor base00}";
+                  "surface.background" = "#${mkOpacityHexColor base00}";
+                  "title_bar.background" = "#${mkOpacityHexColor base00}";
+                  "title_bar.inactive.background" = "#00000000";
+                  "editor.background" = "#00000000";
+                  "editor.gutter.background" = "#00000000";
+                  "panel.background" = "#00000000";
+                  "toolbar.background" = "#00000000";
+                  "tab_bar.background" = "#00000000";
+                  "tab.active_background" = "#00000000";
+                  "tab.inactive_background" = "#00000000";
+                  "terminal.background" = "#00000000";
+
+                }
+              else
+                { };
+          };
+          themes.stylix = colors {
+            templateRepo = inputs.tinted-zed;
+            target = "base16";
+          };
         };
-      };
-    })
+      }
+    )
   ];
 }


### PR DESCRIPTION
Apply Stylix desktop opacity to Zed's theme overrides so the editor background follows the configured desktop transparency. Make the editor surfaces transparent while retaining the themed base background and title bar when desktop opacity is enabled.

---

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [x] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [x] <!-- MANDATORY --> I have disclosed the scope of involved LLM tools, if any
- [x] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [x] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [x] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [x] Each commit in this PR is [suitable for backport](https://nix-community.github.io/stylix/backport_policy.html)
