### PR TITLE
jankyborders: support hm

### DIFF
--- a/modules/jankyborders/hm.nix
+++ b/modules/jankyborders/hm.nix
@@ -1,0 +1,19 @@
+{
+  mkTarget,
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+mkTarget {
+  config = { colors, opacity }: {
+    services.jankyborders.settings =
+      let
+        mkOpacityHexColor = lib.flip config.lib.stylix.mkOpacityHexColor opacity.desktop;
+      in
+      lib.mkIf pkgs.stdenv.hostPlatform.isDarwin {
+        active_color = mkOpacityHexColor colors.base0D;
+        inactive_color = mkOpacityHexColor colors.base03;
+      };
+  };
+}


### PR DESCRIPTION


<!-- Describe your PR above, following Stylix commit conventions. -->

Adds home-manager support for jankyborders.
https://search.nixos.org/options?channel=26.05&query=jankyborders&source=home_manager&type=options#show=home-manager-option%253Aservices.jankyborders.settings

---

<!--
Unless otherwise specified, the following checkboxes are not mandatory, but
drastically accelerate the reviewing and merging process of this PR.
-->
- [x] <!-- MANDATORY --> I certify that I have the right to submit this contribution under the [MIT license](https://github.com/nix-community/stylix/blob/master/LICENSE)
- [x] <!-- MANDATORY --> I have disclosed the scope of involved LLM tools, if any
- [x] Commit messages adhere to [Stylix commit conventions](https://nix-community.github.io/stylix/commit_convention.html)
- [x] Theming changes adhere to the [Stylix style guide](https://nix-community.github.io/stylix/styling.html)
- [x] Changes have been [tested locally](https://nix-community.github.io/stylix/modules.html#development-setup) (Tested via override-input of https://github.com/eveeifyeve/stylix/tree/combined-pr-testing)
- [ ] Changes have been [tested in testbeds](https://nix-community.github.io/stylix/testbeds.html)
- [x] Each commit in this PR is [suitable for backport](https://nix-community.github.io/stylix/backport_policy.html)
